### PR TITLE
Added `baixa` state and  `found_in_search` field

### DIFF
--- a/som_infoenergia/README.md
+++ b/som_infoenergia/README.md
@@ -32,7 +32,8 @@ There are seven possible states:
 * Obert: desanonymized PDF report attatched and ready to send.
 * Encuat: sending on poweremail queue.
 * Enviat: sending sended.
-* Cancel·lat: when the polissa is not active, doesn't allow to recieve this kind of emails or manual action. The email won't be sent.
+* Cancel·lat: when the polissa doesn't allow to recieve this kind of emails or manual action. The email won't be sent.
+* Baixa: when the polissa is not active. The email won't be sent.
 * Error: an error occurred.
 
 ### som.enviament.massiu
@@ -48,7 +49,7 @@ There are four possible states:
 ### Partners
 *  Add action "Add partner to Batch email" (aka "Afegir partners a Lot d'Enviament Massiu"). It creates **som.infoenergia.enviament** objects based on the selected partners.
 ### GiscedataPolissa
-*  Add action "Add contract to Batch email" (aka "Afegir polisses a Lot d'Enviament Massiu"). It creates **som.infoenergia.enviament** or **som.infoenergia.enviament** objects based on the selected contracts and the type of the **Lot**.
+*  Add action "Add contract to Batch email" (aka "Afegir polisses a Lot d'Enviament Massiu"). It creates **som.infoenergia.enviament** or **som.infoenergia.enviament** objects based on the selected contracts and the type of the **Lot**. For **som.infoenergia.enviament** objects, it sets the field *found_in_search* to True.
 
 
 ## Dependencies

--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -46,18 +46,8 @@ ESTAT_ENVIAT = [
     ('error', 'Error'),
     ('encuat', 'Encuat per enviar'),
     ('enviat', 'Enviat'),
-    ('cancellat', 'Cancel·lat')
-]
-
-QUALITAT = [
-    ('tou', 'TOU'),
-    ('cch', 'CCH')
-]
-
-ANTIGUITAT = [
-    ('1r', 'Primer any'),
-    ('2n', 'Segon any'),
-    ('3r', 'Tercer any'),
+    ('cancellat', 'Cancel·lat'),
+    ('baixa', 'Baixa'),
 ]
 
 
@@ -246,7 +236,7 @@ class SomInfoenergiaEnviament(osv.osv):
             return
         if not polissa.active or polissa.data_baixa:
             message = u"La pòlissa està inactiva o té data de baixa"
-            enviament.write({'estat': 'cancellat'})
+            enviament.write({'estat': 'baixa'})
             self.add_info_line(cursor, uid, _id, message, context)
             return
 
@@ -369,8 +359,7 @@ class SomInfoenergiaEnviament(osv.osv):
             type='char',
             string=_('Tipus d\'informe lot'),
             readonly=True),
-        'antiguitat': fields.selection(ANTIGUITAT, _('Any de l\'informe'), size=256, allow_none=True),
-        'qualitat': fields.selection(QUALITAT, _('Qualitat de les dades'), size=256, allow_none=True),
+        'found_in_search': fields.boolean(_("La pòlissa relacionada estava present a alguna cerca")),
         'data_enviament':  fields.date(_("Data enviament"), allow_none=True),
         'data_informe':  fields.date(_("Data de l'informe"), allow_none=True),
         'pdf_filename': fields.char(_('Nom fitxer PDF'), size=256),
@@ -382,6 +371,7 @@ class SomInfoenergiaEnviament(osv.osv):
 
     _defaults = {
         'estat': lambda *a: 'esborrany',
+        'found_in_search': lambda *a: False,
     }
 
 SomInfoenergiaEnviament()

--- a/som_infoenergia/som_infoenergia_view.xml
+++ b/som_infoenergia/som_infoenergia_view.xml
@@ -17,6 +17,7 @@
                     <separator string="Dades enviament" colspan="4"/>
                     <group colspan="2" col="3">
                         <field name='estat' select="1"/>
+                        <field name='found_in_search' select="1" readonly="1"/>
                         <field name='lot_enviament' select="1" readonly="1"/>
                         <field name='data_informe' select="1"  readonly="1"/>
                         <field name='data_enviament' select="1" readonly="1"/>
@@ -80,16 +81,27 @@
                         <field name='info' readonly="1"/>
                     </group>
                     <separator string="Quantitats" colspan="4"/>
-                    <group colspan="2" col="3">
-                        <field name='total_preesborrany' select="2"/>
+
+                    <group>
+                        <field name='total_preesborrany' select="2" colspan="4"/>
                         <field name='total_esborrany' select="2"/>
+                        <field name='total_esborrany_in_search' select="2" string="(esborrany) presents en alguna cerca"/>
                         <field name='total_oberts' select="1"/>
+                        <field name='total_oberts_in_search' select="2" string="(oberts) presents en alguna cerca"/>
                         <field name='total_encuats' select="1"/>
+                        <field name='total_encuats_in_search' select="2" string="(encuats) presents en alguna cerca"/>
                         <field name='total_enviats' select="1"/>
+                        <field name='total_enviats_in_search' select="2" string="(enviats) presents en alguna cerca"/>
                         <field name='total_cancelats' select="1"/>
+                        <field name='total_cancelats_in_search' select="2" string="(cancel·lats) presents en alguna cerca"/>
+                        <field name='total_baixa' select="2"/>
+                        <field name='total_baixa_in_search' select="2" string="(baixa) presents en alguna cerca"/>
                         <field name='total_errors' select="2"/>
-                        <field name='total_env_csv' select="2"/>
+                        <field name='total_errors_in_search' select="2" string="(errors) presents en alguna cerca"/>
                         <field name='total_enviaments' select="1"/>
+                        <field name='total_enviaments_in_search' select="2" string="(total) presents en alguna cerca"/>
+                        <field name='total_env_csv' select="2"/>
+                        <field name='total_env_csv_in_search' select="2" string="(en csv) presents en alguna cerca"/>
                     </group>
                     <separator string="Progrés" colspan="4"/>
                     <group colspan="2" col="3">

--- a/som_infoenergia/tests/som_infoenergia_demo.xml
+++ b/som_infoenergia/tests/som_infoenergia_demo.xml
@@ -67,6 +67,7 @@
         <record id="enviament_infoenergia_0003_obert" model="som.infoenergia.enviament">
             <field name="polissa_id" ref='giscedata_polissa.polissa_0002'/>
             <field name="estat">obert</field>
+            <field name="found_in_search">True</field>
             <field name="data_informe">2021-01-01</field>
             <field name="pdf_filename">00002.pdf</field>
             <field name="lot_enviament" ref="lot_enviament_0003"/>

--- a/som_infoenergia/tests/test_enviament.py
+++ b/som_infoenergia/tests/test_enviament.py
@@ -94,7 +94,7 @@ class EnviamentTests(testing.OOTestCase):
         enviament.send_single_report()
 
         self.assertEqual(
-            env_obj.read(cursor, uid, enviament_id, ['estat'])['estat'], 'cancellat'
+            env_obj.read(cursor, uid, enviament_id, ['estat'])['estat'], 'baixa'
             )
         mocked_send_mail.assert_not_called()
 
@@ -119,7 +119,7 @@ class EnviamentTests(testing.OOTestCase):
         enviament.send_single_report()
 
         self.assertEqual(
-            env_obj.read(cursor, uid, enviament_id, ['estat'])['estat'], 'cancellat'
+            env_obj.read(cursor, uid, enviament_id, ['estat'])['estat'], 'baixa'
             )
         mocked_send_mail.assert_not_called()
 


### PR DESCRIPTION
## Objectives

- New state `baixa` for non-active contracts
- New fields for couting contracts found in searches

## Old behaviour

- Using `cancelat` state for refering to non-active contracts.
- Nonexistent found in search field

## New behaviour

- New state `baixa` for non-active contracts
- Added `found_in_search` fields 

![image](https://user-images.githubusercontent.com/12842454/120004943-a6aa8900-bfd7-11eb-824c-9359f046ef63.png)

