### PR TITLE
Single 48h sms per contract

### DIFF
--- a/som_account_invoice_pending/__init__.py
+++ b/som_account_invoice_pending/__init__.py
@@ -2,3 +2,4 @@ import update_pending_states
 import norma57
 import wizard
 import account_invoice_pending_history
+import som_account_invoice_pending_exceptions

--- a/som_account_invoice_pending/account_invoice_pending_history.py
+++ b/som_account_invoice_pending/account_invoice_pending_history.py
@@ -10,10 +10,16 @@ class AccountInvoicePendingHistory(osv.osv):
     _name = 'account.invoice.pending.history'
     _inherit = 'account.invoice.pending.history'
 
-    def historize(self, cursor, uid, ids, message=None):
+    def historize(self, cursor, uid, ids, message=''):
         """sets text to observations field"""
-        data = {'observations': message}
-        return self.write(cursor, uid, ids, data)
+        if not isinstance(ids, (tuple,list)):
+            ids = [ids]
+        for _id in ids:
+            old_observations = self.read(cursor, uid, _id, ['observations'])['observations']
+            old_observations = '\n{}'.format(old_observations) if old_observations else ''
+            data = {'observations': message + old_observations}
+            self.write(cursor, uid, _id, data)
+        return True
 
     _columns = {
         'powersms_id': fields.many2one(

--- a/som_account_invoice_pending/account_invoice_pending_history.py
+++ b/som_account_invoice_pending/account_invoice_pending_history.py
@@ -10,11 +10,17 @@ class AccountInvoicePendingHistory(osv.osv):
     _name = 'account.invoice.pending.history'
     _inherit = 'account.invoice.pending.history'
 
+    def historize(self, cursor, uid, ids, message=None):
+        """sets text to observations field"""
+        data = {'observations': message}
+        return self.write(cursor, uid, ids, data)
+
     _columns = {
         'powersms_id': fields.many2one(
             'powersms.smsbox', u'SMS', required=False
         ),
-        'powersms_sent_date': fields.date(u'SMS sent date', readonly=True)
+        'powersms_sent_date': fields.date(u'SMS sent date', readonly=True),
+        'observations': fields.char(u'Observacions', size=256)
     }
 
 AccountInvoicePendingHistory()
@@ -48,7 +54,6 @@ class GiscedataFacturacioFactura(osv.osv):
     def powersms_write_callback(self, cursor, uid, ids, vals, context=None):
         """Hook que cridarà el powersms quan es modifiqui un sms.
         """
-
         if context is None:
             context = {}
 

--- a/som_account_invoice_pending/account_invoice_pending_view.xml
+++ b/som_account_invoice_pending/account_invoice_pending_view.xml
@@ -9,6 +9,7 @@
             <field name="arch" type="xml" >
                 <field name="end_date" position="after">
                     <field name="powersms_sent_date"/>
+                    <field name="observations"/>
                 </field>
             </field>
         </record>

--- a/som_account_invoice_pending/som_account_invoice_pending_exceptions.py
+++ b/som_account_invoice_pending/som_account_invoice_pending_exceptions.py
@@ -50,6 +50,18 @@ class UpdateWaitingFor48hException(SomAccountInvoicePendingError):
     def __str__(self):
         return self.__repr__()
 
+class UpdateWaitingForAnnexIVException(SomAccountInvoicePendingError):
+
+    def __init__(self, msg):
+        super(SomAccountInvoicePendingError, self).__init__(msg)
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.__repr__()
+
 class UpdateWaitingCancelledContractsException(SomAccountInvoicePendingError):
 
     def __init__(self, msg):

--- a/som_account_invoice_pending/som_account_invoice_pending_exceptions.py
+++ b/som_account_invoice_pending/som_account_invoice_pending_exceptions.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+class SomAccountInvoicePendingError(Exception):
+    """Base class for other exceptions"""
+    def __init__(self, msg):
+        super(SomAccountInvoicePendingError, self).__init__(msg)
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class SMSException(SomAccountInvoicePendingError):
+    """Raised when there is any error within SMS send"""
+    def __init__(self, msg):
+        super(SMSException, self).__init__(msg)
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class MailException(SomAccountInvoicePendingError):
+    """Raised when there is any error within Email send"""
+    def __init__(self, msg):
+        super(MailException, self).__init__(msg)
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.__repr__()
+
+class UpdateWaitingFor48hException(SomAccountInvoicePendingError):
+
+    def __init__(self, msg):
+        super(SomAccountInvoicePendingError, self).__init__(msg)
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.__repr__()
+
+class UpdateWaitingCancelledContractsException(SomAccountInvoicePendingError):
+
+    def __init__(self, msg):
+        super(SomAccountInvoicePendingError, self).__init__(msg)
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.__repr__()

--- a/som_account_invoice_pending/tests/update_pending_states_tests.py
+++ b/som_account_invoice_pending/tests/update_pending_states_tests.py
@@ -473,7 +473,7 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
 
     @mock.patch('som_account_invoice_pending.update_pending_states.UpdatePendingStates.send_email')
     @mock.patch('som_account_invoice_pending.update_pending_states.UpdatePendingStates.send_sms')
-    def test__update_two_unpaid_invoice_waiting_for_48_same_contract(self, mock_sms, mock_mail):
+    def test__update_two_unpaid_invoice_waiting_for_48_same_contract_single_sms(self, mock_sms, mock_mail):
         cursor = self.txn.cursor
         uid = self.txn.user
         self._load_data_unpaid_invoices(cursor, uid, [self.waiting_48h_def, self.waiting_48h_def])
@@ -492,11 +492,11 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
         }
 
         mock_mail.assert_called_with(cursor, uid, self.invoice_1_id, params)
-        mock_sms.assert_called_with(cursor, uid, self.invoice_1_id,
+        mock_sms.assert_called_once_with(cursor, uid, ANY,
                                     self.sms_48h_template_id, self.waiting_48h_def, {})
 
         self.assertEqual(mock_mail.call_count, 2)
-        self.assertEqual(mock_sms.call_count, 2)
+        self.assertEqual(mock_sms.call_count, 1)
 
         inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
         self.assertEqual(inv_data.pending_state.id, self.sent_48h_def)
@@ -529,4 +529,4 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
             ('psms_from', 'like', 'Info'),
             ('psms_body_text', 'ilike', '%CORTE LUZ POR IMPAGO EN 48h%'),
         ])
-        self.assertEqual(len(sms_to_send), 2)
+        self.assertEqual(len(sms_to_send), 1)

--- a/som_account_invoice_pending/tests/wizard_unlink_sms_pending_history_tests.py
+++ b/som_account_invoice_pending/tests/wizard_unlink_sms_pending_history_tests.py
@@ -27,14 +27,10 @@ class TestWizardUnlinkSMSPendingHistory(testing.OOTestCase):
         address_id = rpa_obj.search(cursor, uid, [('partner_id','=', titular_id)])
         rpa_obj.write(cursor, uid, address_id, {'mobile':'600000000'})
 
-        account_obj = self.pool.get('poweremail.core_accounts')
-        self.account_id = account_obj.create(cursor, uid, {
-            'name': 'Gestió de Cobraments',
-            'email_id': 'test@example.com',
-            'company': 'yes',
-            'smtpport': 0,
-            'smtpserver': 'test'
-        })
+        self.account_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_account_invoice_pending', 'cobraments_mail_account'
+        )[1]
+
         invoice_id = self.fact_obj.read(cursor, uid, self.fact_id, ['invoice_id'])['invoice_id'][0]
         self.inv_obj.set_pending(cursor, uid, [invoice_id], waiting_48h_def)
 
@@ -44,6 +40,7 @@ class TestWizardUnlinkSMSPendingHistory(testing.OOTestCase):
             uid = txn.user
 
             wiz_obj = self.pool.get('wizard.unlink.sms.pending.history')
+
             self._load_data_unpaid_invoice(cursor, uid)
             pending_obj = self.pool.get('update.pending.states')
 

--- a/som_account_invoice_pending/update_pending_states.py
+++ b/som_account_invoice_pending/update_pending_states.py
@@ -276,6 +276,7 @@ class UpdatePendingStates(osv.osv_memory):
                     )
                 )
             else:
+                fact_obj.set_pending(cursor, uid, [factura_id], next_state)
                 if not related_invoice:
                     try:
                         self.send_sms(cursor, uid, factura_id, sms_48h_template_id, current_state_id, context)
@@ -285,7 +286,6 @@ class UpdatePendingStates(osv.osv_memory):
                     last_peding_id = max(fact_obj.read(cursor, uid, factura_id, ['pending_history_ids'])['pending_history_ids'])
                     last_pending = aiph_obj.browse(cursor, uid, last_peding_id)
                     last_pending.historize(message=u"Comunicació feta a través de la factura amb id:{}".format(related_invoice))
-                fact_obj.set_pending(cursor, uid, [factura_id], next_state)
                 logger.info(
                     'Sending 48h email for {factura_id} invoice with result: {ret_value}'.format(
                         factura_id=factura_id,
@@ -628,6 +628,7 @@ class UpdatePendingStates(osv.osv_memory):
                     )
                 )
             else:
+                fact_obj.set_pending(cursor, uid, [factura_id], next_state)
                 if not related_invoice:
                     try:
                         self.send_sms(cursor, uid, factura_id, sms_template_id, current_state_id, context)
@@ -637,7 +638,6 @@ class UpdatePendingStates(osv.osv_memory):
                     last_peding_id = max(fact_obj.read(cursor, uid, factura_id, ['pending_history_ids'])['pending_history_ids'])
                     last_pending = aiph_obj.browse(cursor, uid, last_peding_id)
                     last_pending.historize(message=u"Comunicació feta a través de la factura amb id:{}".format(related_invoice))
-                fact_obj.set_pending(cursor, uid, [factura_id], next_state)
                 logger.info(
                     'Sending Annex 4 email for {factura_id} invoice with result: {ret_value}'.format(
                         factura_id=factura_id,


### PR DESCRIPTION
* Added exception handling for 48h and annexIV functions.
* Added "Observations" field into `account.invoice.pending.history`.

![image](https://user-images.githubusercontent.com/12842454/121890436-a241d800-cd1a-11eb-8bc4-63bbcd5b1d57.png)

