### PR TITLE
Added required fields in supplier invoices form

### DIFF
--- a/account_invoice_som/__terp__.py
+++ b/account_invoice_som/__terp__.py
@@ -8,12 +8,14 @@
     "category": "GISCEMaster",
     "depends":[
         "account_invoice_base",
+        "account_payment_extension",
         "poweremail",
     ],
     "init_xml": [],
     "demo_xml": [],
     "update_xml":[
-        "account_invoice_som_report.xml"
+        "account_invoice_som_report.xml",
+        "account_invoice_view.xml"
     ],
     "active": False,
     "installable": True

--- a/account_invoice_som/account_invoice_view.xml
+++ b/account_invoice_som/account_invoice_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="invoice_supplier_form2">
+            <field name="name">account.invoice.form</field>
+            <field name="model">account.invoice</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="account_payment_extension.invoice_supplier_form2"/>
+            <field name="arch" type="xml">
+                <field name="payment_type" position="replace">
+                    <field name="payment_type" on_change="onchange_payment_type(payment_type, partner_id)" select="2" required="1"/>
+                </field>
+                <field name="origin" position="replace">
+                     <field name="origin" select="2" required="1"/>
+                </field>
+                <field name="origin_date_invoice" position="replace">
+                    <field name="origin_date_invoice" select="2" required="1"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objetivos

- Set `payment_type`, `origin` and `origin_date_invoice` as required fields in supplier account invoices form.

![image](https://user-images.githubusercontent.com/12842454/125975080-fe19bc48-760d-407b-9084-ce53e8df104f.png)

## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
    - `account_invoice_som`
- [ ] Migración de datos
    - especificar que módulos y versión

