### PR TITLE
Assistent per la impressió de factures en paper

### DIFF
--- a/som_factures_paper/__init__.py
+++ b/som_factures_paper/__init__.py
@@ -1,0 +1,1 @@
+import wizard

--- a/som_factures_paper/__terp__.py
+++ b/som_factures_paper/__terp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Mòdul per crear un assitent per ajudar a la impresuió de factures en paper",
+    "description": """
+    """,
+    "version": "0-dev",
+    "author": "SomEnergia",
+    "category": "SomEnergia",
+    "depends":[
+        "base",
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml":[
+        "som_factures_paper.xml",
+        "wizard/wizard_paper_invoice_som.xml",
+        "security/ir.model.access.csv",
+    ],
+    "active": False,
+    "installable": True
+}

--- a/som_factures_paper/security/ir.model.access.csv
+++ b/som_factures_paper/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_wizard_paper_invoice_som_rcwd","wizard.paper.invoice_som","model_wizard_paper_invoice_som","base.group_user",1,1,1,1

--- a/som_factures_paper/som_factures_paper.xml
+++ b/som_factures_paper/som_factures_paper.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+    </data>
+</openerp>

--- a/som_factures_paper/wizard/__init__.py
+++ b/som_factures_paper/wizard/__init__.py
@@ -1,0 +1,1 @@
+import wizard_paper_invoice_som

--- a/som_factures_paper/wizard/wizard_paper_invoice_som.py
+++ b/som_factures_paper/wizard/wizard_paper_invoice_som.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+from c2c_webkit_report import webkit_report
+from report import report_sxw
+from tools import config
+import tempfile
+from datetime import date, datetime
+from yamlns import namespace as ns
+
+STATES = [
+    ('init', 'Estat Inicial'),
+    ('finished', 'Estat Final')
+]
+
+class WizardPaperInvoiceSom(osv.osv_memory):
+    _name = 'wizard.paper.invoice.som'
+
+    _columns = {
+        #Header
+        'state': fields.selection(STATES, _(u'Estat del wizard de imprimir report')),
+    }
+
+    _defaults = {
+        'state': 'init'
+    }
+
+WizardPaperInvoiceSom()

--- a/som_factures_paper/wizard/wizard_paper_invoice_som.py
+++ b/som_factures_paper/wizard/wizard_paper_invoice_som.py
@@ -139,13 +139,10 @@ class WizardPaperInvoiceSom(osv.osv_memory):
             'info': wiz.info + "\n" + info,
         })
 
-    """
-    @job(queue=config.get('invoice_render_queue', 'invoice_render'),
+    @job(queue=config.get('som_factures_paper_render_queue', 'poweremail_render'),
          result_ttl=24 * 3600)
-    """
-    @job(queue="import_xml", result_ttl=24 * 3600)
     def render_to_file(self, cursor, uid, fids, report, dirname, file_name, context=None):
-        """Return a tuple of status (0: OK, 1: Failed) and the invoice path.
+        """Return a tuple of status (True: OK, False: Failed) and the invoice path.
         """
         if context is None:
             context = {}

--- a/som_factures_paper/wizard/wizard_paper_invoice_som.py
+++ b/som_factures_paper/wizard/wizard_paper_invoice_som.py
@@ -1,28 +1,142 @@
 # -*- coding: utf-8 -*-
 from osv import osv, fields
 from tools.translate import _
-from c2c_webkit_report import webkit_report
-from report import report_sxw
-from tools import config
+from datetime import datetime
+import json
+import netsvc
 import tempfile
-from datetime import date, datetime
-from yamlns import namespace as ns
+import os
+import tools
+from cStringIO import StringIO
+from zipfile import PyZipFile, ZIP_DEFLATED
+import base64
+
 
 STATES = [
     ('init', 'Estat Inicial'),
-    ('finished', 'Estat Final')
+    ('info', 'Informació de factures impresses'),
+    ('done', 'Estat Final'),
 ]
+
 
 class WizardPaperInvoiceSom(osv.osv_memory):
     _name = 'wizard.paper.invoice.som'
 
     _columns = {
-        #Header
         'state': fields.selection(STATES, _(u'Estat del wizard de imprimir report')),
+        'date_from': fields.date('Data desde'),
+        'date_to': fields.date('Data fins'),
+        'info': fields.text('Informació', readonly=True),
+        'invoice_ids': fields.text('Factures'),
+        'file': fields.binary('Fitxer generat'),
+        'file_name': fields.text('Nom del fitxer'),
     }
 
     _defaults = {
-        'state': 'init'
+        'state': lambda *a: 'init',
+        'file_name': lambda *a: 'factures.zip',
+        'date_to': lambda *a: datetime.today().strftime("%Y-%m-%d")
     }
+
+    def search_invoices(self, cursor, uid, ids, context=None):
+        if not context:
+            context = {}
+
+        pol_obj = self.pool.get('giscedata.polissa')
+        fact_obj = self.pool.get('giscedata.facturacio.factura')
+
+        wiz = self.browse(cursor, uid, ids[0], context=context)
+
+        pol_ids = pol_obj.search(cursor, uid, [('enviament', '!=', 'email')], context=context)
+        fact_ids = []
+        for pol_id in pol_ids:
+            p_f_ids = fact_obj.search(cursor, uid, [
+                ('polissa_id', '=', pol_id),
+                ('date_invoice', '>=', wiz.date_from),
+                ('date_invoice', '<=', wiz.date_to),
+                ('state', 'in', ('open', 'paid')),
+                ('type', 'in', ('out_refund', 'out_invoice')),
+                ], context=context)
+            fact_ids.extend(p_f_ids)
+
+        fact_datas = fact_obj.read(cursor, uid, fact_ids, ['number'])
+        fact_names = ', '.join([f['number'] for f in fact_datas])
+        wiz.write({
+            'state': 'info',
+            'invoice_ids': json.dumps(fact_ids),
+            'info': "Trobades {} polisses amb enviament postal.\nEs generanan {} pdf's de les seguents factures:\n{}".format(
+                len(pol_ids),
+                len(fact_ids),
+                fact_names),
+        })
+
+    def generate_invoices(self, cursor, uid, ids, context=None):
+        if not context:
+            context = {}
+
+        fact_obj = self.pool.get('giscedata.facturacio.factura')
+
+        wiz = self.browse(cursor, uid, ids[0], context=context)
+        fact_ids = json.loads(wiz.invoice_ids)
+        report = 'report.giscedata.facturacio.factura'
+        tmp_dir = tempfile.mkdtemp()
+
+        for fact_id in fact_ids:
+            fact = fact_obj.browse(cursor, uid, fact_id, context=context)
+            file_name = "{}-{}.pdf".format(fact.polissa_id.direccio_notificacio.name, fact.number)
+            self.render_to_file(cursor, uid, [fact_id], report, tmp_dir, file_name, context)
+
+        wiz.write({
+            'state': 'done',
+            'file': self.get_zip_from_directory(tmp_dir, True),
+        })
+
+    def render_to_file(self, cursor, uid, fids, report, dirname, file_name, context=None):
+        """Return a tuple of status (0: OK, 1: Failed) and the invoice path.
+        """
+        if context is None:
+            context = {}
+        try:
+            report = netsvc.service_exist(report)
+            values = {
+                'model': 'giscedata.facturacio.factura',
+                'id': fids,
+                'report_type': 'pdf'
+            }
+            content = report.create(cursor, uid, fids, values, context)[0]
+            # Escriure report a "fitxer"
+            fitxer_name = '{}/{}'.format(dirname, file_name)
+            with open(fitxer_name, 'wb') as f:
+                f.write(content)
+            return 0, fitxer_name
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            sentry = self.pool.get('sentry.setup')
+            if sentry is not None:
+                sentry.client.captureException()
+            return 1, fids
+
+    def get_zip_from_directory(self, directory, b64enc=True):
+
+        def _zippy(archive, path):
+            path = os.path.abspath(path)
+            base = os.path.basename(path)
+            for f in tools.osutil.listdir(path, True):
+                archive.write(os.path.join(path, f), os.path.join(base, f))
+
+        archname = StringIO()
+        archive = PyZipFile(archname, "w", ZIP_DEFLATED)
+        archive.writepy(directory)
+        _zippy(archive, directory)
+        archive.close()
+        val = archname.getvalue()
+        archname.close()
+
+        if b64enc:
+            val = base64.encodestring(val)
+
+        return val
+
 
 WizardPaperInvoiceSom()

--- a/som_factures_paper/wizard/wizard_paper_invoice_som.xml
+++ b/som_factures_paper/wizard/wizard_paper_invoice_som.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_paper_invoice_som_form" model="ir.ui.view">
+            <field name="name">wizard.paper.invoice.som.form</field>
+            <field name="model">wizard.paper.invoice.som</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="assitent d'impressio" col="2">
+                    <field name="state" invisible="1"/>
+                    <button type="object" string="Generar" name="generate_report" icon="gtk-ok"/>
+                </form>
+            </field>
+        </record>
+        <record id="action_paper_invoice_som" model="ir.actions.act_window">
+            <field name="name">Wizard impressio factures en paper</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.paper.invoice.som</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="domain">[]</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="view_paper_invoice_som_form"/>
+        </record>
+        <record id="wizard_paper_invoice_som" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Imprimir factures en paper</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">wizard.paper.invoice.som</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_paper_invoice_som'))"/>
+        </record>
+        <menuitem action="action_paper_invoice_som" id="wizard_paper_invoice_som" name="Factures en paper Som" parent="giscedata_polissa.menu_principal" sequence="10"/>
+    </data>
+</openerp>

--- a/som_factures_paper/wizard/wizard_paper_invoice_som.xml
+++ b/som_factures_paper/wizard/wizard_paper_invoice_som.xml
@@ -19,6 +19,10 @@
                     <group colspan="4" col="4" attrs="{'invisible':[('state', '!=', 'info')]}">
                         <button type="object" string="Imprimir factures" name="generate_invoices" icon="gtk-ok" />
                     </group>
+                    <group colspan="4" col="4" attrs="{'invisible': [('state', '!=', 'working')]}">
+                        <field name="progress" widget="progressbar" colspan="3"/>
+                          <button type="object" name="read" string="Actualitzar" icon="gtk-refresh"/>
+                    </group>
                     <group colspan="4" col="4" attrs="{'invisible':[('state', '!=', 'done')]}">
                         <field name="file_name" readonly="1" invisible="1" />
                         <field name="file" readonly="1" filename="file_name" />

--- a/som_factures_paper/wizard/wizard_paper_invoice_som.xml
+++ b/som_factures_paper/wizard/wizard_paper_invoice_som.xml
@@ -8,7 +8,21 @@
             <field name="arch" type="xml">
                 <form string="assitent d'impressio" col="2">
                     <field name="state" invisible="1"/>
-                    <button type="object" string="Generar" name="generate_report" icon="gtk-ok"/>
+                    <group string="Dates" colspan="3" col="4" attrs="{'readonly' : [('state', '!=', 'init')]}" >
+                        <field name="date_from" select="1"/>
+                        <field name="date_to" select="1"/>
+                    </group>
+                    <field name="info" nolabel="1" colspan="4" readonly="1" width="700" height="120"/>
+                    <group colspan="4" col="4" attrs="{'invisible':[('state', '!=', 'init')]}">
+                        <button type="object" string="Cercar factures" name="search_invoices" icon="gtk-ok" />
+                    </group>
+                    <group colspan="4" col="4" attrs="{'invisible':[('state', '!=', 'info')]}">
+                        <button type="object" string="Imprimir factures" name="generate_invoices" icon="gtk-ok" />
+                    </group>
+                    <group colspan="4" col="4" attrs="{'invisible':[('state', '!=', 'done')]}">
+                        <field name="file_name" readonly="1" invisible="1" />
+                        <field name="file" readonly="1" filename="file_name" />
+                    </group>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
## Objectius

- Es necessita gestionar el volum creixent de factures en paper. Cal crear un wizard que en faciliti la tasca de cercar i generar els pdf implicats en la facturació per contractes que han de notificar la factura físicament en paper i no només per e-mail.

## Comportament antic

- Treball manual minuciós i amb força propens a l'error

## Comportament nou

- wizard

## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
     - som_factures_paper
- [ ] Migración de datos

## Checklist

- [x] Test code
- [ ] Documentation (link to [PowERP docs](https://github.com/gisce/powerp-docs) repo)
- [ ] Si se modifica alguna vista poner una captura indicando qué se modifica
- [ ] Si se modifica un report adjuntar el report
- [ ] Migration data
