### PR TITLE
Remove conditions for m102 from xml

### DIFF
--- a/som_switching/giscedata_switching_notification_data.xml
+++ b/som_switching/giscedata_switching_notification_data.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0"?>
 <openerp>
     <data>
-        <!--m1-02-->
-        <record model="giscedata.switching.notificacio.config" id="sw_not_m1_02_rebuig_57">
-            <field name="proces_id" ref="giscedata_switching.sw_proces_m1"/>
-            <field name="step_id" ref="giscedata_switching.sw_step_m1_02"/>
-            <field name="description">Activa les notificacions per els passos de rebuig M1-02 motiu 57 amb canvis tècnics però sense canvis en l'autoconsum</field>
-            <field name="conditions">[('01', 'sollicitudadm', '!=', 'S'),('02', 'rebuig', '==', True),('02', 'rebuig_ids[0].motiu_rebuig.name', '==', '57'),('01', 'tipus_autoconsum', '!=', 'sw_id.polissa_ref_id.autoconsumo')]</field>
-        </record>
-        <record model="giscedata.switching.notificacio.config" id="sw_not_m1_02_rebuig">
-            <field name="proces_id" ref="giscedata_switching.sw_proces_m1"/>
-            <field name="step_id" ref="giscedata_switching.sw_step_m1_02"/>
-            <field name="description">Activa les notificacions per els passos de rebuig M1-02 amb canvis tècnics per a tots els motius excepte el 57</field>
-            <field name="conditions">[('01', 'sollicitudadm', '!=', 'S'),('02', 'rebuig', '==', True),('02', 'rebuig_ids[0].motiu_rebuig.name', '!=', '57')]</field>
-        </record>
-        <record model="giscedata.switching.notificacio.config" id="giscedata_switching.sw_not_m1_altres_02">
-            <field name="conditions">[('01', 'sollicitudadm', '!=', 'S'),('02', 'rebuig', '==', False)]</field>
-        </record>
         <!--b1-07-->
         <record model="giscedata.switching.notificacio.config" id="giscedata_switching.sw_not_b107">
             <field name="conditions">[('01', 'motiu', '==', '01')]</field>


### PR DESCRIPTION
S'han eliminat les noves condicions que s'havien creat per filtrar les notificacions dels rebutjos M102 motiu 57 segons si hi havia canvi d'autoconsum o no (de moment no és possible implementar-ho). Es deixa com abans i s'enviaran tots els rebutjos segons les condicions ja configurades anteriorment.