### PR TITLE
Modificar camp de número de factura perquè facis cerques exactes

### DIFF
--- a/account_invoice_som/__init__.py
+++ b/account_invoice_som/__init__.py
@@ -1,1 +1,2 @@
 import report
+import account_invoice

--- a/account_invoice_som/__terp__.py
+++ b/account_invoice_som/__terp__.py
@@ -12,7 +12,9 @@
         "poweremail",
     ],
     "init_xml": [],
-    "demo_xml": [],
+    "demo_xml": [
+        "tests/account_invoice_demo.xml",
+    ],
     "update_xml":[
         "account_invoice_som_report.xml",
         "account_invoice_view.xml",

--- a/account_invoice_som/__terp__.py
+++ b/account_invoice_som/__terp__.py
@@ -15,7 +15,8 @@
     "demo_xml": [],
     "update_xml":[
         "account_invoice_som_report.xml",
-        "account_invoice_view.xml"
+        "account_invoice_view.xml",
+        "account_invoice_data.xml",
     ],
     "active": False,
     "installable": True

--- a/account_invoice_som/account_invoice.py
+++ b/account_invoice_som/account_invoice.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from osv import osv
+from tools import cache
+
+class AccountInvoice(osv.osv):
+
+    _name = 'account.invoice'
+    _inherit = 'account.invoice'
+
+    @cache(timeout=5 * 60)
+    def exact_search(self, cursor, uid, context=None):
+        if context is None:
+            context = {}
+        exact = int(self.pool.get('res.config').get(
+            cursor, uid, 'account_invoice_number_cerca_exacte', '0')
+        )
+        return exact
+
+    def search(self, cr, user, args, offset=0, limit=None, order=None, context=None, count=False):
+        """Funció per fer cerques per number exacte, enlloc d'amb 'ilike'.
+        """
+        import pudb;pu.db
+        exact = self.exact_search(cr, user, context=context)
+        for idx, arg in enumerate(args):
+            if len(arg) == 3:
+                field, operator, match = arg
+                if field == 'number' and isinstance(match,(unicode,str)):
+                    if exact and not '%' in match:
+                        operator = '='
+                    args[idx] = (field, operator, match)
+        return super(AccountInvoice, self).search(cr, user, args, offset, limit, order, context, count)
+
+    def _auto_init(self, cr, context={}):
+        result = super(AccountInvoice, self)._auto_init(cr, context)
+        cr.execute('SELECT indexname FROM pg_indexes WHERE indexname = \'account_invoice_number_index\'')
+        if not cr.fetchone():
+            cr.execute('CREATE INDEX account_invoice_number_index ON account_invoice(number)')
+        return result
+
+
+AccountInvoice()

--- a/account_invoice_som/account_invoice_data.xml
+++ b/account_invoice_som/account_invoice_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data noupdate="1">
+        <record id="account_invoice_number_cerca_exacte" model="res.config">
+            <field name="name">account_invoice_number_cerca_exacte</field>
+            <field name="value">0</field>
+            <field name="description">Cerca el número de factura exacte si no se li posa un caracter '%'.</field>
+        </record>
+    </data>
+</openerp>

--- a/account_invoice_som/tests/__init__.py
+++ b/account_invoice_som/tests/__init__.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from destral import testing
+from destral.transaction import Transaction
+from tools.misc import cache
+
+
+class TestAccountInvoiceSom(testing.OOTestCaseWithCursor):
+    def setUp(self):
+        self.ai_obj = self.openerp.pool.get('account.invoice')
+        super(TestAccountInvoiceSom, self).setUp()
+
+    def set_account_invoice_number_cerca_exacte(self, cursor, uid, value):
+        res_obj = self.openerp.pool.get('res.config')
+        cache.clean_caches_for_db(cursor.dbname)
+        res_obj.set(cursor, uid, 'account_invoice_number_cerca_exacte', value)
+
+    def test_search_withPercentage_active(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00%')])
+
+        self.assertGreater(len(gff_ids), 1)
+
+    def test_search_exactExist_active(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '0046/F')])
+
+        self.assertEqual(len(gff_ids), 1)
+
+    def test_search_exactNotExist_active(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+
+        self.assertEqual(len(gff_ids), 0)
+
+    def test_search_withPercentage_disabled(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00%')])
+
+        self.assertGreater(len(gff_ids), 1)
+
+    def test_search_exactExist_disabled(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '0046/F')])
+
+        self.assertEqual(len(gff_ids), 1)
+
+    def test_search_exactNotExist_disabled(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+
+        self.assertGreater(len(gff_ids), 1)

--- a/account_invoice_som/tests/__init__.py
+++ b/account_invoice_som/tests/__init__.py
@@ -18,41 +18,41 @@ class TestAccountInvoiceSom(testing.OOTestCaseWithCursor):
     def test_search_withPercentage_active(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00%')])
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE%')])
 
         self.assertGreater(len(gff_ids), 1)
 
     def test_search_exactExist_active(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '0046/F')])
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE210001')])
 
         self.assertEqual(len(gff_ids), 1)
 
     def test_search_exactNotExist_active(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE')])
 
         self.assertEqual(len(gff_ids), 0)
 
     def test_search_withPercentage_disabled(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00%')])
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE%')])
 
         self.assertGreater(len(gff_ids), 1)
 
     def test_search_exactExist_disabled(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '0046/F')])
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE210001')])
 
         self.assertEqual(len(gff_ids), 1)
 
     def test_search_exactNotExist_disabled(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE')])
 
         self.assertGreater(len(gff_ids), 1)

--- a/account_invoice_som/tests/account_invoice_demo.xml
+++ b/account_invoice_som/tests/account_invoice_demo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="invoice_fe210001" model="account.invoice">
+            <field name="number">FE210001</field>
+            <field name="type">out_invoice</field>
+            <!--<field name="state"></field>-->
+            <field name="date_invoice">2021-03-01</field>
+            <field name="partner_id" ref="base.res_partner_c2c"/>
+            <field name="address_invoice_id" ref="base.res_partner_address_c2c_1"/>
+            <field name="period_id" ref="account.period_1"/>
+            <field name="account_id" ref="account.a_recv"/>
+        </record>
+        <record id="invoice_fe0002" model="account.invoice">
+            <field name="number">FE210002</field>
+            <field name="type">out_invoice</field>
+            <!--<field name="state"></field>-->
+            <field name="date_invoice">2021-04-01</field>
+            <field name="partner_id" ref="base.res_partner_c2c"/>
+            <field name="address_invoice_id" ref="base.res_partner_address_c2c_1"/>
+            <field name="period_id" ref="account.period_1"/>
+            <field name="account_id" ref="account.a_recv"/>
+        </record>
+    </data>
+</openerp>

--- a/giscedata_facturacio_som/__init__.py
+++ b/giscedata_facturacio_som/__init__.py
@@ -1,0 +1,1 @@
+import giscedata_facturacio

--- a/giscedata_facturacio_som/__terp__.py
+++ b/giscedata_facturacio_som/__terp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Giscedata Facturació Factura (SomEnergia)",
+    "description": """Este módulo añade las siguientes funcionalidades:
+    * Extiende giscedata_facturacio""",
+    "version": "2.103.13",
+    "author": "SomEnergia",
+    "category": "GISCE extend",
+    "depends":[
+        "giscedata_facturacio",
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml":[],
+    "active": False,
+    "installable": True
+}

--- a/giscedata_facturacio_som/giscedata_facturacio.py
+++ b/giscedata_facturacio_som/giscedata_facturacio.py
@@ -2,10 +2,10 @@
 from osv import osv
 from tools import cache
 
-class AccountInvoice(osv.osv):
+class GiscedataFacturacio(osv.osv):
+    _name = 'giscedata.facturacio.factura'
+    _inherit = 'giscedata.facturacio.factura'
 
-    _name = 'account.invoice'
-    _inherit = 'account.invoice'
 
     @cache(timeout=5 * 60)
     def exact_search(self, cursor, uid, context=None):
@@ -25,17 +25,10 @@ class AccountInvoice(osv.osv):
                 if len(arg) == 3:
                     field, operator, match = arg
                     if field == 'number' and isinstance(match,(unicode,str)):
-                        if exact and not '%' in match:
+                        if not '%' in match:
                             operator = '='
                         args[idx] = (field, operator, match)
-        return super(AccountInvoice, self).search(cr, user, args, offset, limit, order, context, count)
-
-    def _auto_init(self, cr, context={}):
-        result = super(AccountInvoice, self)._auto_init(cr, context)
-        cr.execute('SELECT indexname FROM pg_indexes WHERE indexname = \'account_invoice_number_index\'')
-        if not cr.fetchone():
-            cr.execute('CREATE INDEX account_invoice_number_index ON account_invoice(number)')
-        return result
+        return super(GiscedataFacturacio, self).search(cr, user, args, offset, limit, order, context, count)
 
 
-AccountInvoice()
+GiscedataFacturacio()

--- a/giscedata_facturacio_som/tests/__init__.py
+++ b/giscedata_facturacio_som/tests/__init__.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from destral import testing
+from destral.transaction import Transaction
+from tools.misc import cache
+
+
+class TestGiscedataFacturacioSom(testing.OOTestCaseWithCursor):
+    def setUp(self):
+        self.gff_obj = self.openerp.pool.get('giscedata.facturacio.factura')
+        super(TestGiscedataFacturacioSom, self).setUp()
+
+    def set_account_invoice_number_cerca_exacte(self, cursor, uid, value):
+        res_obj = self.openerp.pool.get('res.config')
+        cache.clean_caches_for_db(cursor.dbname)
+        res_obj.set(cursor, uid, 'account_invoice_number_cerca_exacte', value)
+
+    def test_search_withPercentage_active(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '00%')])
+
+        self.assertGreater(len(gff_ids), 1)
+
+    def test_search_exactExist_active(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '0046/F')])
+
+        self.assertEqual(len(gff_ids), 1)
+
+    def test_search_exactNotExist_active(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+
+        self.assertEqual(len(gff_ids), 0)
+
+    def test_search_withPercentage_disabled(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '00%')])
+
+        self.assertGreater(len(gff_ids), 1)
+
+    def test_search_exactExist_disabled(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '0046/F')])
+
+        self.assertEqual(len(gff_ids), 1)
+
+    def test_search_exactNotExist_disabled(self):
+        self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+
+        self.assertGreater(len(gff_ids), 1)


### PR DESCRIPTION
## Objectiu

- Fer les cerques de factura per número de factura més ràpides.

## Comportamient antic

- Les cerques per número de factura es consultaven a la base de dades amb `ilike`

## Comportamient nou

-  El camp de cerca de "número de factura" del llistat de factures, fa cerques exactes. Per fer cerques per `ilike` cal posar un %.

## Afectacions / Migració de dades

- [x] Codi. Reinicar serveis
- [x] Actualizació mòduls:
    - som_polissa

## Variables de configuració

- `account_invoice_number_cerca_exacte`: Si esta activada, les cerques per factura són exactes. Sinó són sempre per `ilike`.

## Relacionat

## Checklist

- [ ] Test code
- [ ] Documentatió
- [ ] Si es modifica alguna vista posar una captura indicant que es modifica
- [ ] Si es modifica un report adjuntar el report
- [ ] Migració de dades
