### PR TITLE
Genera Enviaments del CSV de Beedata amb el fitxer temporal

### DIFF
--- a/som_infoenergia/som_infoenergia_lot.py
+++ b/som_infoenergia/som_infoenergia_lot.py
@@ -85,11 +85,8 @@ class SomInfoenergiaLotEnviament(osv.osv):
             os.unlink(filepath)
         return attachment_id
 
-    def create_enviaments_from_attached_csv(self, cursor, uid, ids, attach_id, context=None):
-
-            attachment_obj = self.pool.get('ir.attachment')
-            attach_data = attachment_obj.read(cursor,uid, attach_id, ['datas'])['datas']
-            csv_file = StringIO(base64.b64decode(attach_data))
+    def create_enviaments_from_csv_file(self, cursor, uid, ids, filename, context=None):
+        with open(filename, 'rb') as csv_file:
             headers = [
                 h.lower()
                 for h in csv.reader(csv_file, delimiter=';', quotechar='"').next()
@@ -237,8 +234,8 @@ class SomInfoenergiaLotEnviament(osv.osv):
             scp = SCPClient(ssh.get_transport())
             scp.get(csv_path_file, output_filepath)
 
-            attachment_id = self._attach_csv(cursor, uid, ids, output_filepath)
-            lot.create_enviaments_from_attached_csv(attachment_id, context)
+            self._attach_csv(cursor, uid, ids, output_filepath)
+            lot.create_enviaments_from_csv_file(output_filepath, context)
 
             self.add_info_line(cursor, uid, ids, 'CSV descarregat correctament')
         except Exception as e:

--- a/som_infoenergia/tests/test_lot_enviament.py
+++ b/som_infoenergia/tests/test_lot_enviament.py
@@ -35,7 +35,7 @@ class LotEnviamentTests(testing.OOTestCase):
         return results
 
     @mock.patch('som_infoenergia.som_infoenergia_lot.SomInfoenergiaLotEnviament.create_enviaments_from_csv')
-    def test_create_enviaments_from_attached_csv(self, mocked_create_enviaments_from_csv):
+    def test_create_enviaments_from_csv_file(self, mocked_create_enviaments_from_csv):
         imd_obj = self.openerp.pool.get('ir.model.data')
         lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
         env_obj = self.openerp.pool.get('som.infoenergia.enviament')
@@ -53,9 +53,7 @@ class LotEnviamentTests(testing.OOTestCase):
         rel_path = 'T1_2020_minimal.csv'
         abs_file_path = os.path.join(script_dir, rel_path)
 
-        attach_id = self._attach_csv(cursor, uid, lot_enviament_id, abs_file_path)
-
-        lot_enviament.create_enviaments_from_attached_csv(attach_id, {})
+        lot_enviament.create_enviaments_from_csv_file(abs_file_path, {})
 
         mocked_create_enviaments_from_csv.assert_called_with(cursor, uid, [lot_enviament_id], [{'report': '0001.pdf','text': 'First;Text', 'contractid': '0001'}],{})
 
@@ -305,7 +303,7 @@ class LotEnviamentTests(testing.OOTestCase):
         lot_enviament = lot_env_obj.browse(cursor, uid, lot_enviament_id)
         cancellats_pre = lot_enviament.total_cancelats
 
-        lot_enviament.cancel_enviaments_from_polissa_names(['0001','0002'], {'reason': 'Test cancel from polissa list'})
+        lot_enviament.cancel_enviaments_from_polissa_names(['0001C','0002'], {'reason': 'Test cancel from polissa list'})
 
         lot_enviament = lot_env_obj.browse(cursor, uid, lot_enviament_id)
         cancellats_post = lot_enviament.total_cancelats
@@ -325,7 +323,7 @@ class LotEnviamentTests(testing.OOTestCase):
         lot_enviament = lot_env_obj.browse(cursor, uid, lot_enviament_id)
         cancellats_pre = lot_enviament.total_cancelats
 
-        lot_enviament.cancel_enviaments_from_polissa_names(['0001','0002'], {'reason': 'Test cancel from polissa list'})
+        lot_enviament.cancel_enviaments_from_polissa_names(['0001C','0002'], {'reason': 'Test cancel from polissa list'})
 
         lot_enviament = lot_env_obj.browse(cursor, uid, lot_enviament_id)
         cancellats_post = lot_enviament.total_cancelats


### PR DESCRIPTION
## Objectiu

Fer que el csv que baixem de Beedata es llegeixi des de la carpeta temporal del servidor, i no des del clúster de Mongo on l'hem penjat. Ens hem trobat que a vegades no s'havia replicat el fitxer als nodes de lectura quan l'anàvem a llegir.

## Incidència 
https://secure.helpscout.net/conversation/1730313942/10482085?folderId=3063409

## Comportament antic

Primer penjava el fitxer i després el llegia per crear els "Enviaments"

## Comportament nou

Baixa el fitxer, el penja a Mongo, però per crear els enviaments, llegeix el fitxer baixat prèviament.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
