### PR TITLE
Afegida cerca exacta per origen

### DIFF
--- a/account_invoice_som/account_invoice_data.xml
+++ b/account_invoice_som/account_invoice_data.xml
@@ -6,5 +6,10 @@
             <field name="value">0</field>
             <field name="description">Cerca el número de factura exacte si no se li posa un caracter '%'.</field>
         </record>
+        <record id="invoice_origin_cerca_exacte" model="res.config">
+            <field name="name">invoice_origin_cerca_exacte</field>
+            <field name="value">0</field>
+            <field name="description">Cerca l'origen de factura i de F1's (invoice_number_text) exacte si no se li posa un caracter '%'.</field>
+        </record>
     </data>
 </openerp>

--- a/account_invoice_som/tests/__init__.py
+++ b/account_invoice_som/tests/__init__.py
@@ -9,6 +9,9 @@ class TestAccountInvoiceSom(testing.OOTestCaseWithCursor):
     def setUp(self):
         self.ai_obj = self.openerp.pool.get('account.invoice')
         super(TestAccountInvoiceSom, self).setUp()
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', '=', False)], limit=2)
+        self.ai_obj.write(self.cursor, self.uid, ai_ids[0], {'origin': 'sample_origin1'})
+        self.ai_obj.write(self.cursor, self.uid, ai_ids[1], {'origin': 'sample_origin2'})
 
     def set_account_invoice_number_cerca_exacte(self, cursor, uid, value):
         res_obj = self.openerp.pool.get('res.config')
@@ -18,41 +21,89 @@ class TestAccountInvoiceSom(testing.OOTestCaseWithCursor):
     def test_search_withPercentage_active(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE%')])
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE%')])
 
-        self.assertGreater(len(gff_ids), 1)
+        self.assertGreater(len(ai_ids), 1)
 
     def test_search_exactExist_active(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE210001')])
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE210001')])
 
-        self.assertEqual(len(gff_ids), 1)
+        self.assertEqual(len(ai_ids), 1)
 
     def test_search_exactNotExist_active(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '1')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE')])
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE')])
 
-        self.assertEqual(len(gff_ids), 0)
+        self.assertEqual(len(ai_ids), 0)
 
     def test_search_withPercentage_disabled(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE%')])
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE%')])
 
-        self.assertGreater(len(gff_ids), 1)
+        self.assertGreater(len(ai_ids), 1)
 
     def test_search_exactExist_disabled(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE210001')])
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE210001')])
 
-        self.assertEqual(len(gff_ids), 1)
+        self.assertEqual(len(ai_ids), 1)
 
     def test_search_exactNotExist_disabled(self):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
-        gff_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE')])
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('number', 'ilike', 'FE')])
 
-        self.assertGreater(len(gff_ids), 1)
+        self.assertGreater(len(ai_ids), 1)
+
+#####
+
+    def set_invoice_origin_cerca_exacte(self, cursor, uid, value):
+        res_obj = self.openerp.pool.get('res.config')
+        cache.clean_caches_for_db(cursor.dbname)
+        res_obj.set(cursor, uid, 'invoice_origin_cerca_exacte', value)
+
+    def test_search_withPercentage_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '1')
+
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin%')])
+        self.assertGreater(len(ai_ids), 1)
+
+    def test_search_exactExist_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '1')
+
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin1')])
+
+        self.assertEqual(len(ai_ids), 1)
+
+    def test_search_exactNotExist_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '1')
+
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin')])
+
+        self.assertEqual(len(ai_ids), 0)
+
+    def test_search_withPercentage_disabled(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '0')
+
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin%')])
+
+        self.assertGreater(len(ai_ids), 1)
+
+    def test_search_exactExist_disabled(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '0')
+
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin1')])
+
+        self.assertEqual(len(ai_ids), 1)
+
+    def test_search_exactNotExist_disabled(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '0')
+
+        ai_ids = self.ai_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin')])
+
+        self.assertGreater(len(ai_ids), 1)

--- a/giscedata_facturacio_som/giscedata_facturacio.py
+++ b/giscedata_facturacio_som/giscedata_facturacio.py
@@ -8,7 +8,7 @@ class GiscedataFacturacio(osv.osv):
 
 
     @cache(timeout=5 * 60)
-    def exact_search(self, cursor, uid, context=None):
+    def exact_number_search(self, cursor, uid, context=None):
         if context is None:
             context = {}
         exact = int(self.pool.get('res.config').get(
@@ -16,15 +16,29 @@ class GiscedataFacturacio(osv.osv):
         )
         return exact
 
+    @cache(timeout=5 * 60)
+    def exact_origin_search(self, cursor, uid, context=None):
+        if context is None:
+            context = {}
+        exact = int(self.pool.get('res.config').get(
+            cursor, uid, 'invoice_origin_cerca_exacte', '0')
+        )
+        return exact
+
     def search(self, cr, user, args, offset=0, limit=None, order=None, context=None, count=False):
         """Funció per fer cerques per number exacte, enlloc d'amb 'ilike'.
         """
-        exact = self.exact_search(cr, user, context=context)
-        if exact:
+        exact_number = self.exact_number_search(cr, user, context=context)
+        exact_origin = self.exact_origin_search(cr, user, context=context)
+        if exact_number or exact_origin:
             for idx, arg in enumerate(args):
                 if len(arg) == 3:
                     field, operator, match = arg
-                    if field == 'number' and isinstance(match,(unicode,str)):
+                    if exact_number and field == 'number' and isinstance(match,(unicode,str)):
+                        if not '%' in match:
+                            operator = '='
+                        args[idx] = (field, operator, match)
+                    if exact_origin and field == 'origin' and isinstance(match,(unicode,str)):
                         if not '%' in match:
                             operator = '='
                         args[idx] = (field, operator, match)

--- a/giscedata_facturacio_som/tests/__init__.py
+++ b/giscedata_facturacio_som/tests/__init__.py
@@ -9,6 +9,9 @@ class TestGiscedataFacturacioSom(testing.OOTestCaseWithCursor):
     def setUp(self):
         self.gff_obj = self.openerp.pool.get('giscedata.facturacio.factura')
         super(TestGiscedataFacturacioSom, self).setUp()
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', '=', False)], limit=2)
+        self.gff_obj.write(self.cursor, self.uid, gff_ids[0], {'origin': 'sample_origin1'})
+        self.gff_obj.write(self.cursor, self.uid, gff_ids[1], {'origin': 'sample_origin2'})
 
     def set_account_invoice_number_cerca_exacte(self, cursor, uid, value):
         res_obj = self.openerp.pool.get('res.config')
@@ -54,5 +57,52 @@ class TestGiscedataFacturacioSom(testing.OOTestCaseWithCursor):
         self.set_account_invoice_number_cerca_exacte(self.cursor, self.uid, '0')
 
         gff_ids = self.gff_obj.search(self.cursor, self.uid, [('number', 'ilike', '00')])
+
+        self.assertGreater(len(gff_ids), 1)
+
+
+    def set_invoice_origin_cerca_exacte(self, cursor, uid, value):
+        res_obj = self.openerp.pool.get('res.config')
+        cache.clean_caches_for_db(cursor.dbname)
+        res_obj.set(cursor, uid, 'invoice_origin_cerca_exacte', value)
+
+    def test_search_withPercentage_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin%')])
+        self.assertGreater(len(gff_ids), 1)
+
+    def test_search_exactExist_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin1')])
+
+        self.assertEqual(len(gff_ids), 1)
+
+    def test_search_exactNotExist_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '1')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin')])
+
+        self.assertEqual(len(gff_ids), 0)
+
+    def test_search_withPercentage_disabled(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin%')])
+
+        self.assertGreater(len(gff_ids), 1)
+
+    def test_search_exactExist_disabled(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin1')])
+
+        self.assertEqual(len(gff_ids), 1)
+
+    def test_search_exactNotExist_disabled(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, '0')
+
+        gff_ids = self.gff_obj.search(self.cursor, self.uid, [('origin', 'ilike', 'sample_origin')])
 
         self.assertGreater(len(gff_ids), 1)


### PR DESCRIPTION
## Objectiu
(D'igual forma que a https://github.com/Som-Energia/openerp_som_addons/pull/71)
 - Fer les cerques de factura per origen més ràpides.

## Targeta on es demana o Incidència 
 - https://trello.com/c/lJS1YwGD/4704-add-cerca-exacta-per-origen-de-factures-i-f1ns

## Comportament antic

 - Les cerques per origen es consultaven a la base de dades amb `ilike`

## Comportament nou

 - El camp de cerca de "origen" del llistat de factures, fa cerques exactes. Per fer cerques per ilike cal posar un %.

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
	- `account_invoice_som`
- [ ] Script de migració
- [ ] Modifica traduccions
