### PR TITLE
Update wizard_send_reports.py

### DIFF
--- a/som_infoenergia/wizard/wizard_send_reports.py
+++ b/som_infoenergia/wizard/wizard_send_reports.py
@@ -47,6 +47,9 @@ class WizardSendReports(osv.osv_memory):
         env_obj = self.pool.get(context.get('from_model'))
 
         ctx = {'allow_reenviar': wiz.allow_reenviar}
+        allowed_states = ['obert']
+        if wiz.allow_reenviar:
+            allowed_states.append('enviat')
         if wiz.is_test:
             if not wiz.email_to:
                 raise osv.except_osv(_(u'ERROR'), "Cal indicar l'email destinatari de l'enviament")
@@ -64,7 +67,7 @@ class WizardSendReports(osv.osv_memory):
                 env_obj = self.pool.get('som.enviament.massiu')
             else:
                 raise osv.except_osv(_(u'ERROR'), "Tipus de lot desconegut")
-            env_ids = env_obj.search(cursor, uid, [('lot_enviament', '=', lot_id)])
+            env_ids = env_obj.search(cursor, uid, [('lot_enviament', '=', lot_id), ('estat','in', allowed_states)])
         elif context.get('from_model') in ['som.infoenergia.enviament', 'som.enviament.massiu']:
             env_ids = context.get('active_ids', [])
 


### PR DESCRIPTION
## Objectiu

Fer que el `send_reports` vaig més ràpid quan s'envien en vàries tongades.

## Targeta on es demana o Incidència 


## Comportament antic

El `send_reports` intenta tornar a enviar tots els enviaments del lot

## Comportament nou

Només intenta enviar els enviaments en estat `obert` o també els `enviats` quan a l'assistent es marca l'opció de reenviar els correus ja enviats.

## Comprovacions

[] Hi ha testos
[] Reiniciar serveis
[] Actualitzar mòdul
[] Script de migració
[] Modifica traduccions
