### PR TITLE
Afegida prioritat 1 a `account.account.fast.tree`

### DIFF
--- a/account_account_som/account_view.xml
+++ b/account_account_som/account_view.xml
@@ -30,6 +30,7 @@
             <field name="name">account.account.fast.tree</field>
             <field name="model">account.account</field>
             <field name="type">tree</field>
+            <field name="priority">1</field>
             <field name="arch" type="xml">
                 <tree string="Account" toolbar="1" colors="blue:type=='view'">
                     <field name="code"/>


### PR DESCRIPTION
## Objectiu

 - Des del wizard de balanç de sumes i saldos, s'utilitza la vista de acount.account.tree` llegint tots els camps del llistats entre els quals es troba `balance`. Això alenteix molt el llistat.

## Targeta on es demana o Incidència 

 - Posant prioritat alta, fem que la vista rapida sigui la que utilitzi el wizard.

## Comportament antic


## Comportament nou


## Comprovacions

[] Hi ha testos
[X] Reiniciar serveis
[X] Actualitzar mòdul
 - `account_account_som`
[] Script de migració
[] Modifica traduccions
