### PR TITLE
Add extra_info when CSV is loaded in Lot Enviament

### DIFF
--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -190,6 +190,10 @@ class SomInfoenergiaEnviament(osv.osv):
                 cursor, uid, _id, context
             )
             job_ids.append(j.id)
+
+        if not job_ids:
+            return False
+
         create_jobs_group(
             cursor.dbname, uid, _('Enviament Infoenergia Lot {} - {} enviaments').format(
                 lot_name, len(ids)

--- a/som_infoenergia/som_infoenergia_lot.py
+++ b/som_infoenergia/som_infoenergia_lot.py
@@ -114,7 +114,11 @@ class SomInfoenergiaLotEnviament(osv.osv):
 
             job = self.create_single_enviament_from_object_async(cursor, uid, ids, obj_id, context=contexte)
             job_ids.append(job.id)
-            # Create a jobs_group to see the status of the operation
+
+        if not job_ids:
+            return False
+
+        # Create a jobs_group to see the status of the operation
         create_jobs_group(
             cursor.dbname, uid,
             _('Crear Enviaments al lot {0} a partir de {1} {2}.').format(lot_info['name'], len(job_ids), context['from_model']),

--- a/som_infoenergia/som_infoenergia_lot.py
+++ b/som_infoenergia/som_infoenergia_lot.py
@@ -105,12 +105,12 @@ class SomInfoenergiaLotEnviament(osv.osv):
         context['tipus'] = lot_info['tipus']
         job_ids = []
 
+        contexte = context.copy()
         for obj_id in object_ids:
             if context.get('extra_text', False):
-                env_obj = self.pool.get('som.enviament.massiu')
-                env_data = env_obj.read(cursor, uid, obj_id, ['name'])
-                contexte = context
-                contexte['extra_text'] = context['extra_text'][env_data['name']]
+                pol_obj = self.pool.get('giscedata.polissa')
+                pol_data = pol_obj.read(cursor, uid, obj_id, ['name'])
+                contexte['extra_text'] = context['extra_text'][pol_data['name']]
 
             job = self.create_single_enviament_from_object_async(cursor, uid, ids, obj_id, context=contexte)
             job_ids.append(job.id)

--- a/som_infoenergia/tests/EiE_extra_info.csv
+++ b/som_infoenergia/tests/EiE_extra_info.csv
@@ -1,0 +1,2 @@
+polissa; codi_oferta;consum_anual;marge;import_garantia
+0001; OFERTA1; 1400; 1;1000

--- a/som_infoenergia/tests/test_wizards.py
+++ b/som_infoenergia/tests/test_wizards.py
@@ -462,3 +462,76 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
              '0003': {'k': '213', 'extra_info': 'Info 2'}}})
         wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
         self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")
+
+    @mock.patch('som_infoenergia.som_infoenergia_lot.SomInfoenergiaLotEnviament.create_enviaments_from_object_list')
+    def test_create_enviaments_from_csv__massive_extra_info_without_header(self, mock_create):
+        wiz_obj = self.openerp.pool.get('wizard.create.enviaments.from.csv')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+        env_obj = self.openerp.pool.get('som.enviament.massiu')
+        lot_enviament_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_infoenergia', 'lot_enviament_0002'
+        )[1]
+        pol_id_2 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0002'
+        )[1]
+        pol_id_3 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0003'
+        )[1]
+        pol_name_2 = pol_obj.read(self.cursor, self.uid, pol_id_2, ['name'])['name']
+        pol_name_3 = pol_obj.read(self.cursor, self.uid, pol_id_3, ['name'])['name']
+        csv_content = "{},Info 1,234\n{},Info 2,213".format(pol_name_2, pol_name_3)
+        encoded_csv = base64.b64encode(csv_content)
+        vals = {
+            'csv_file': encoded_csv,
+        }
+
+        ctx = {
+            'active_id': lot_enviament_id, 'active_ids': [lot_enviament_id],
+        }
+        wiz_id = wiz_obj.create(self.cursor, self.uid, vals, context=ctx)
+
+        wiz_obj.create_from_file(self.cursor, self.uid, [wiz_id], context=ctx)
+
+        mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3],
+            {'from_model': 'polissa_id'})
+        wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
+        self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")
+
+    @mock.patch('som_infoenergia.som_infoenergia_lot.SomInfoenergiaLotEnviament.create_enviaments_from_object_list')
+    def test_create_enviaments_from_csv__massive_extra_info_with_semicolon(self, mock_create):
+        wiz_obj = self.openerp.pool.get('wizard.create.enviaments.from.csv')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+        env_obj = self.openerp.pool.get('som.enviament.massiu')
+        lot_enviament_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_infoenergia', 'lot_enviament_0002'
+        )[1]
+        pol_id_2 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0002'
+        )[1]
+        pol_id_3 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0003'
+        )[1]
+        pol_name_2 = pol_obj.read(self.cursor, self.uid, pol_id_2, ['name'])['name']
+        pol_name_3 = pol_obj.read(self.cursor, self.uid, pol_id_3, ['name'])['name']
+        csv_content = "polissa;extra_info;k\n{};Info 1;234\n{};Info 2;213".format(pol_name_2, pol_name_3)
+        encoded_csv = base64.b64encode(csv_content)
+        vals = {
+            'csv_file': encoded_csv,
+        }
+
+        ctx = {
+            'active_id': lot_enviament_id, 'active_ids': [lot_enviament_id],
+        }
+        wiz_id = wiz_obj.create(self.cursor, self.uid, vals, context=ctx)
+
+        wiz_obj.create_from_file(self.cursor, self.uid, [wiz_id], context=ctx)
+
+        mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3],
+            {'from_model': 'polissa_id', 'extra_text': {'0002': {'k': '234', 'extra_info': 'Info 1'},
+             '0003': {'k': '213', 'extra_info': 'Info 2'}}})
+        wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
+        self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")

--- a/som_infoenergia/tests/test_wizards.py
+++ b/som_infoenergia/tests/test_wizards.py
@@ -385,3 +385,41 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
         mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3], {'from_model': 'polissa_id'})
         wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
         self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")
+
+
+
+    @mock.patch('som_infoenergia.som_infoenergia_lot.SomInfoenergiaLotEnviament.create_enviaments_from_object_list')
+    def test_create_enviaments_from_csv__massive_extra_info(self, mock_create):
+        wiz_obj = self.openerp.pool.get('wizard.create.enviaments.from.csv')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+        env_obj = self.openerp.pool.get('som.enviament.massiu')
+        lot_enviament_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_infoenergia', 'lot_enviament_0002'
+        )[1]
+        pol_id_2 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0002'
+        )[1]
+        pol_id_3 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0003'
+        )[1]
+        pol_name_2 = pol_obj.read(self.cursor, self.uid, pol_id_2, ['name'])['name']
+        pol_name_3 = pol_obj.read(self.cursor, self.uid, pol_id_3, ['name'])['name']
+        csv_content = "polissa,extra_info,k\n{},Info 1,234\n{},Info 2,213".format(pol_name_2, pol_name_3)
+        encoded_csv = base64.b64encode(csv_content)
+        vals = {
+            'csv_file': encoded_csv,
+        }
+
+        ctx = {
+            'active_id': lot_enviament_id, 'active_ids': [lot_enviament_id],
+        }
+
+        wiz_id = wiz_obj.create(self.cursor, self.uid, vals, context=ctx)
+        #import pudb;pu.db
+        wiz_obj.create_from_file(self.cursor, self.uid, [wiz_id], context=ctx)
+
+        mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3], {'from_model': 'polissa_id', 'extra_text': {'0002': {'k': '234', 'extra_info': 'Info 1'}, '0003': {'k': '213', 'extra_info': 'Info 2'}}})
+        wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
+        self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")

--- a/som_infoenergia/tests/test_wizards.py
+++ b/som_infoenergia/tests/test_wizards.py
@@ -415,11 +415,50 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
         ctx = {
             'active_id': lot_enviament_id, 'active_ids': [lot_enviament_id],
         }
-
         wiz_id = wiz_obj.create(self.cursor, self.uid, vals, context=ctx)
-        #import pudb;pu.db
+
         wiz_obj.create_from_file(self.cursor, self.uid, [wiz_id], context=ctx)
 
-        mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3], {'from_model': 'polissa_id', 'extra_text': {'0002': {'k': '234', 'extra_info': 'Info 1'}, '0003': {'k': '213', 'extra_info': 'Info 2'}}})
+        mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3],
+            {'from_model': 'polissa_id', 'extra_text': {'0002': {'k': '234', 'extra_info': 'Info 1'},
+             '0003': {'k': '213', 'extra_info': 'Info 2'}}})
+        wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
+        self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")
+
+
+    @mock.patch('som_infoenergia.som_infoenergia_lot.SomInfoenergiaLotEnviament.create_enviaments_from_object_list')
+    def test_create_enviaments_from_csv__massive_extra_info(self, mock_create):
+        wiz_obj = self.openerp.pool.get('wizard.create.enviaments.from.csv')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+        env_obj = self.openerp.pool.get('som.enviament.massiu')
+        lot_enviament_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_infoenergia', 'lot_enviament_0002'
+        )[1]
+        pol_id_2 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0002'
+        )[1]
+        pol_id_3 = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0003'
+        )[1]
+        pol_name_2 = pol_obj.read(self.cursor, self.uid, pol_id_2, ['name'])['name']
+        pol_name_3 = pol_obj.read(self.cursor, self.uid, pol_id_3, ['name'])['name']
+        csv_content = "polissa,extra_info,k\n{},Info 1,234\n{},Info 2,213".format(pol_name_2, pol_name_3)
+        encoded_csv = base64.b64encode(csv_content)
+        vals = {
+            'csv_file': encoded_csv,
+        }
+
+        ctx = {
+            'active_id': lot_enviament_id, 'active_ids': [lot_enviament_id],
+        }
+        wiz_id = wiz_obj.create(self.cursor, self.uid, vals, context=ctx)
+
+        wiz_obj.create_from_file(self.cursor, self.uid, [wiz_id], context=ctx)
+
+        mock_create.assert_called_with(self.cursor, self.uid, lot_enviament_id, [pol_id_2, pol_id_3],
+            {'from_model': 'polissa_id', 'extra_text': {'0002': {'k': '234', 'extra_info': 'Info 1'},
+             '0003': {'k': '213', 'extra_info': 'Info 2'}}})
         wiz_info = wiz_obj.read(self.cursor, self.uid, [wiz_id], ['info'])[0]['info']
         self.assertEqual(wiz_info, "Es crearan els enviaments de 2 pòlisses en segon pla")

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
@@ -15,10 +15,10 @@ STATES = [
 class WizardCancelFromCSV(osv.osv_memory):
     _name = 'wizard.create.enviaments.from.csv'
     _columns = {
-        'name': fields.char('Filename', size=256),
-        'csv_file': fields.binary('CSV File', required=True, help=_(u"Número de pòlissa de les pòlisses de les quals se'n vol crear un enviament")),
+        'name': fields.char(_(u'Nom del fitxer'), size=256),
+        'csv_file': fields.binary(_(u'Fitxer CSV'), required=True, help=_(u"Número de pòlissa de les pòlisses de les quals se'n vol crear un enviament")),
         'state': fields.selection(STATES, _(u'Estat del wizard de crear enviaments des de CSV')),
-        'info': fields.text(_('Informació'), help=_(u"Només es creen enviaments de pòlisses Activa=Si"), size=256, readonly=True),
+        'info': fields.text(_(u'Informació'), help=_(u"Només es creen enviaments de pòlisses Activa=Si"), size=256, readonly=True),
     }
     _defaults = {
         'state': 'init',
@@ -36,29 +36,36 @@ class WizardCancelFromCSV(osv.osv_memory):
         linies= list(reader)
         n_linies = len(linies)
         start = 0
+        header = []
         if n_linies>0 and not linies[0][0].isdigit():
-            header = linies[0]
+            if ';' in linies[0][0]:
+                header = linies[0][0].split(';')
+            else:
+                header = linies[0]
             start=1
 
         pol_list= []
         result = {}
         for line in linies[start:]:
+            if ';' in line[0]:
+                line = line[0].split(';')
+            pol_list.append(line[0])
+            if not header:
+                continue
             i = 1
             result_extra_info = {}
             for column in line[1:]:
-                result_extra_info[header[i]] = column #TODO header without value
+                result_extra_info[header[i]] = column
                 i += 1
             if result_extra_info:
                 result[line[0]] = result_extra_info
-            pol_list.append(line[0])
         if result:
             vals['extra_text'] =  result
-            #pol_list = [pol for pol in result.keys()]
 
         lot_id = context.get('active_id', [])
         pol_ids = pol_obj.search(cursor, uid, [('name','in', pol_list)])
         lot_obj.create_enviaments_from_object_list(cursor, uid, lot_id, pol_ids, vals)
-        msg = "Es crearan els enviaments de {} pòlisses en segon pla".format(len(pol_ids))
+        msg = _(u"Es crearan els enviaments de {} pòlisses en segon pla".format(len(pol_ids)))
         wiz.write({'state': "finished", 'info': msg})
         return True
 

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv_view.xml
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv_view.xml
@@ -10,13 +10,14 @@
                     <field name="state" invisible="1"/>
                     <group attrs="{'invisible': [('state', '!=', 'init')]}">
                         <label string="Crear enviaments de les pòlisses indicades al CSV" colspan="4"/>
-                        <label string="Format del CSV: a la primera columna hi ha d'haver els números dels contractes, sense capçalera. Un contracte a cada fila." colspan="4"/>
+                        <label string="Format del CSV: a la primera columna hi ha d'haver els números dels contractes, un contracte a cada fila. Les següents columnes que hi hagi, les guardarà en un diccionari de dades al camp 'Informació Extra'" colspan="4"/>
                         <field name="csv_file" colspan="4" filename="name" string="Arxiu CSV"/>
-                        <button name="create_from_file" type="object" string="Crear enviaments" icon="gtk-ok"/>
+                            <button special="cancel" string="Sortir" icon="gtk-cancel"/>
+                            <button name="create_from_file" type="object" string="Crear enviaments" icon="gtk-execute"/>
                     </group>
                     <group attrs="{'invisible': [('state', '!=', 'finished')]}">
-                        <field name="info" colspan="4"/>
-                        <button special="cancel" string="Sortir" icon="gtk-ok"/>
+                            <field name="info" colspan="4"/>
+                            <button special="cancel" string="Sortir" icon="gtk-ok"/>
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
## Objectiu

Poder carregar un CSV que et crei n enviaments per número de pólissa (a la primera columna del CSV) i que la resta de columnes les posi en un diccionari al camp "Informació adicional" per a que puguin fer-se servir des dels correus electrònics.

## Targeta on es demana o Incidència 

[Targeta](https://trello.com/c/q4IcHjkx/4791-0-8-p3-ep213-carregar-csv-a-enviament-infoenergia-i-enviament-massiu-i-guardi-diccionari-de-dades)


## Comportament antic

Només es creaven els n enviaments a partir del número de pòlissa.

## Comportament nou

S'afegeix aquest diccionari de dades
## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
