### PR TITLE
Wizard de fraccionament via extralines agafant el  `residual` en lloc del `amount_total`

### DIFF
--- a/giscedata_facturacio_som/wizard/wizard_fraccionar_via_extralines.py
+++ b/giscedata_facturacio_som/wizard/wizard_fraccionar_via_extralines.py
@@ -30,10 +30,8 @@ class WizardFraccionarViaExtralines(osv.osv_memory):
             try:
                 factura_teo = TransactionExecute(cursor.dbname, uid, 'giscedata.facturacio.factura')
                 factura = factura_o.browse(cursor, uid, info['id'])
-                if factura.residual != factura.amount_total:
-                    raise Exception("La factura té un pagament parcial")
                 ntermes = wiz.ntermes-1
-                amount = (factura.amount_total / wiz.ntermes) * ntermes
+                amount = (factura.residual / wiz.ntermes) * ntermes
                 factura_teo.fraccionar_via_extralines(
                     info['id'], ntermes, wiz.data_inici,
                     data_final, journal_id=wiz.journal_id.id,


### PR DESCRIPTION
## Objectiu

 - Permetre el fraccionament sobre una factura amb un pagament parcial existent
 
## Targeta on es demana o Incidència 

 - https://trello.com/c/aR5vk8rQ/3621-0-1-p16-millores-fraccionament-extralines

## Comportament antic

- L'assistent funciona pel fraccionament del `total_amount` de la factura

## Comportament nou

- L'assistent funciona pel fraccionament del `residual` de la factura

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
