### PR TITLE
FIX: Evitar propagació de totes les active_ids en cada un dels jobs

### DIFF
--- a/som_infoenergia/wizard/wizard_create_enviaments_from_object.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_object.py
@@ -19,7 +19,7 @@ class WizardCreateEnviamentsFromObject(osv.osv_memory):
 
         pol_ids = context.get('active_ids',[])
         wiz.write({'state': "finished"})
-
+        del context['active_ids']
         lot_obj.create_enviaments_from_object_list(cursor, uid, lot_id, pol_ids, context)
 
 

--- a/som_infoenergia/wizard/wizard_download_pdf.py
+++ b/som_infoenergia/wizard/wizard_download_pdf.py
@@ -33,6 +33,7 @@ class WizardDownloadPdf(osv.osv_memory):
             env_ids = context.get('active_ids', [])
         context.update({'force_download_pdf': wiz.force_download_pdf})
         wiz.write({'state': "finished"})
+        del context['active_ids']
         for env_id in env_ids:
             env = env_obj.browse(cursor, uid, env_id)
             env.download_pdf(context)


### PR DESCRIPTION
## Objectiu
Evitar propagació de totes les active_ids en cada un dels jobs

## Targeta on es demana o Incidència 


## Comportament antic
Cada un dels jobs rebia el llistat de totes les active_ids que tenia el wizard

## Comportament nou
No es propaguen totes les active_ids

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
