### PR TITLE
Controlar cas quan no hi ha prou lectures cch en genear lectures a 7 dies

### DIFF
--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -130,7 +130,7 @@ class GiscedataPolissaCalculada(osv.osv):
             data_seguent_lect = add_days(data_ultima_lect, 7)
             start_date = add_days(data_ultima_lect, 1)
 
-            cups_text = pol_data['cups'][1]
+            cups_text = pol_data['cups'][1][:20]
             tg_ids = tg_val_o.get_curve(cursor, uid, cups_text, data_ultima_lect, data_seguent_lect)
             if not tg_ids:
                 msgs.append(

--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -130,16 +130,6 @@ class GiscedataPolissaCalculada(osv.osv):
             data_seguent_lect = add_days(data_ultima_lect, 7)
             start_date = add_days(data_ultima_lect, 1)
 
-            cups_text = pol_data['cups'][1][:20]
-            tg_ids = tg_val_o.get_curve(cursor, uid, cups_text, data_ultima_lect, data_seguent_lect)
-            if not tg_ids:
-                msgs.append(
-                    u"La pòlissa {} amb data última lectura {} sense corbes en la data {}".format(
-                        pol_name,
-                        data_ultima_lect,
-                        data_seguent_lect)
-                )
-                continue
             vals = {
                 'measure_origin': lc_origin,
                 'insert_reactive': False,
@@ -157,7 +147,7 @@ class GiscedataPolissaCalculada(osv.osv):
                 wiz_measures_curve_o.load_measures(cursor, uid, [wiz_id], context=ctx)
             except Exception as e:
                 if isinstance(e, osv.orm.except_orm):
-                    msgs.append(u"La pòlissa {} no pot generar lectures per falta de corva.".format(pol_name))
+                    msgs.append(u"La pòlissa {} no pot generar lectures per falta de corba.".format(pol_name))
                 else:
                     msgs.append(u"La pòlissa {} no pot generar lectures per error inesperat de wizard {}.".format(pol_name,str(e)))
                 continue

--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from osv import osv, fields
+from osv import osv, orm
 import re
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
@@ -153,8 +153,15 @@ class GiscedataPolissaCalculada(osv.osv):
                 'active_ids': [mtr_id], 'active_id': mtr_id
             }
             wiz_id = wiz_measures_curve_o.create(cursor, uid, vals, context=ctx)
+            try:
+                wiz_measures_curve_o.load_measures(cursor, uid, [wiz_id], context=ctx)
+            except Exception as e:
+                if isinstance(e, osv.orm.except_orm):
+                    msgs.append(u"La pòlissa {} no pot generar lectures per falta de corva.".format(pol_name))
+                else:
+                    msgs.append(u"La pòlissa {} no pot generar lectures per error inesperat de wizard {}.".format(pol_name,str(e)))
+                continue
 
-            wiz_measures_curve_o.load_measures(cursor, uid, [wiz_id], context=ctx)
             wiz_measures_curve_o.create_measures(cursor, uid, [wiz_id], context=ctx)
             msgs.append(u"La polissa {} té lectures creades en data {}".format(pol_name, data_seguent_lect))
         self.retrocedir_lot(cursor, uid, ids, context=context)

--- a/som_facturacio_calculada/tests/__init__.py
+++ b/som_facturacio_calculada/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from test_polissa_lectures_calculades import *

--- a/som_facturacio_calculada/tests/test_polissa_lectures_calculades.py
+++ b/som_facturacio_calculada/tests/test_polissa_lectures_calculades.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 from destral import testing
 from destral.transaction import Transaction
-
 from expects import *
 import osv
-
 from .. import giscedata_polissa
-
 import mock
 
 class PolissaLecturesCalculadesTest(testing.OOTestCase):
@@ -33,15 +30,17 @@ class PolissaLecturesCalculadesTest(testing.OOTestCase):
             self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
         )[1]
 
+        check_conditions_values = [(False,u'no té categoria'),(False,u'no es 2.0TD')]
         def check_conditions_lectures_calculades(cursor, uid, polissa_id, context={}):
-            return (False,u'no té categoria')
+            return check_conditions_values.pop()
         mock_check_conditions_lectures_calculades.side_effect = check_conditions_lectures_calculades
         mock_retrocedir_lot.return_value = None
 
-        result = pol_obj.crear_lectures_calculades(self.cursor, self.uid, [polissa_id], {})
+        result = pol_obj.crear_lectures_calculades(self.cursor, self.uid, [polissa_id, polissa_id], {})
 
-        self.assertEqual(result[0], u'La pòlissa 0001C no compleix les condicions per que no té categoria')
-        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], u'La pòlissa 0001C no compleix les condicions per que no es 2.0TD')
+        self.assertEqual(result[1], u'La pòlissa 0001C no compleix les condicions per que no té categoria')
+        self.assertEqual(len(result), 2)
 
 
     @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "retrocedir_lot")
@@ -54,9 +53,7 @@ class PolissaLecturesCalculadesTest(testing.OOTestCase):
             self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
         )[1]
 
-        def check_conditions_lectures_calculades(cursor, uid, polissa_id, context={}):
-            return (True,u'Ok')
-        mock_check_conditions_lectures_calculades.side_effect = check_conditions_lectures_calculades
+        mock_check_conditions_lectures_calculades.return_value = (True,u'Ok')
         mock_retrocedir_lot.return_value = None
 
         pol_obj.write(self.cursor, self.uid, polissa_id, {'data_ultima_lectura': None})
@@ -77,9 +74,7 @@ class PolissaLecturesCalculadesTest(testing.OOTestCase):
             self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
         )[1]
 
-        def check_conditions_lectures_calculades(cursor, uid, polissa_id, context={}):
-            return (True,u'Ok')
-        mock_check_conditions_lectures_calculades.side_effect = check_conditions_lectures_calculades
+        mock_check_conditions_lectures_calculades.return_value = (True,u'Ok')
         mock_retrocedir_lot.return_value = None
 
         pol_obj.write(self.cursor, self.uid, polissa_id, {'data_ultima_lectura': '2022-03-01', 'data_ultima_lectura_f1':  '2022-03-02' })

--- a/som_facturacio_calculada/tests/test_polissa_lectures_calculades.py
+++ b/som_facturacio_calculada/tests/test_polissa_lectures_calculades.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+
+from expects import *
+import osv
+
+from .. import giscedata_polissa
+
+import mock
+
+class PolissaLecturesCalculadesTest(testing.OOTestCase):
+
+    def model(self, model_name):
+        return self.openerp.pool.get(model_name)
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+    def tearDown(self):
+        self.txn.stop()
+
+    @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "retrocedir_lot")
+    @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "check_conditions_lectures_calculades")
+    def test_crear_lectures_calculades__sense_lectures(self, mock_check_conditions_lectures_calculades, mock_retrocedir_lot):
+        
+        imd_obj = self.model('ir.model.data')
+        pol_obj = self.model('giscedata.polissa')
+        polissa_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
+        )[1]
+
+        def check_conditions_lectures_calculades(cursor, uid, polissa_id, context={}):
+            return (False,u'no té categoria')
+        mock_check_conditions_lectures_calculades.side_effect = check_conditions_lectures_calculades
+        mock_retrocedir_lot.return_value = None
+
+        result = pol_obj.crear_lectures_calculades(self.cursor, self.uid, [polissa_id], {})
+
+        self.assertEqual(result[0], u'La pòlissa 0001C no compleix les condicions per que no té categoria')
+        self.assertEqual(len(result), 1)
+
+
+    @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "retrocedir_lot")
+    @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "check_conditions_lectures_calculades")
+    def test_crear_lectures_calculades__sense_data_ultima_lectura(self, mock_check_conditions_lectures_calculades, mock_retrocedir_lot):
+        
+        imd_obj = self.model('ir.model.data')
+        pol_obj = self.model('giscedata.polissa')
+        polissa_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
+        )[1]
+
+        def check_conditions_lectures_calculades(cursor, uid, polissa_id, context={}):
+            return (True,u'Ok')
+        mock_check_conditions_lectures_calculades.side_effect = check_conditions_lectures_calculades
+        mock_retrocedir_lot.return_value = None
+
+        pol_obj.write(self.cursor, self.uid, polissa_id, {'data_ultima_lectura': None})
+
+        result = pol_obj.crear_lectures_calculades(self.cursor, self.uid, [polissa_id], {})
+
+        self.assertEqual(result[0], u'La pòlissa 0001C sense data ultima lectura')
+        self.assertEqual(len(result), 1)
+
+
+    @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "retrocedir_lot")
+    @mock.patch.object(giscedata_polissa.GiscedataPolissaCalculada, "check_conditions_lectures_calculades")
+    def test_crear_lectures_calculades__data_fi_menor_inicial(self, mock_check_conditions_lectures_calculades, mock_retrocedir_lot):
+        
+        imd_obj = self.model('ir.model.data')
+        pol_obj = self.model('giscedata.polissa')
+        polissa_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
+        )[1]
+
+        def check_conditions_lectures_calculades(cursor, uid, polissa_id, context={}):
+            return (True,u'Ok')
+        mock_check_conditions_lectures_calculades.side_effect = check_conditions_lectures_calculades
+        mock_retrocedir_lot.return_value = None
+
+        pol_obj.write(self.cursor, self.uid, polissa_id, {'data_ultima_lectura': '2022-03-01', 'data_ultima_lectura_f1':  '2022-03-02' })
+
+        result = pol_obj.crear_lectures_calculades(self.cursor, self.uid, [polissa_id], {})
+
+        self.assertEqual(result[0], u'La pòlissa 0001C té lectura F1 amb data {} i data última factura {}.'.format('2022-03-02','2022-03-01'))
+        self.assertEqual(len(result), 1)


### PR DESCRIPTION
## Objectiu

Controlar el cas en que no hi ha prou lectures cch per a generar lectures calculades a 7 dies per que continui funcionant correctament.

## Targeta on es demana o Incidència 

https://trello.com/c/vpCyz1Aa/4924-0-8-p3-prova-pilot-facturaci%C3%B3-setmanal

## Comportament antic

Saltava excepció no controlada i finalitzava l'execució del assistent.

## Comportament nou

Es controla l'excepció

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
