### PR TITLE
Add wizard filter ag invoices

### DIFF
--- a/account_invoice_som/wizard/wizard_payment_order_add_invoices.py
+++ b/account_invoice_som/wizard/wizard_payment_order_add_invoices.py
@@ -49,6 +49,9 @@ class WizardPaymentOrderAddInvoices(osv.osv_memory):
         for field in search_params_relation.keys():
             if getattr(wiz, field):
                 search_params += (search_params_relation[field])
+        if not wiz.allow_grouped:
+            search_params += [('group_move_id', '=', False)]
+
         res_ids = inv_obj.search(cursor, uid, search_params + [('payment_order_id','=',False)])
         values = {
             'len_result': 'La cerca ha trobat {} resultats'.format(len(res_ids)),
@@ -120,6 +123,8 @@ class WizardPaymentOrderAddInvoices(osv.osv_memory):
         'invoice_type': fields.selection([(False, '')]+ INVOICE_TYPES, _('Tipus')),
         'fiscal_position': fields.many2one('account.fiscal.position', 'Posició Fiscal'),
         'payment_type': fields.many2one('payment.type', 'Tipus de pagament'),
+        'allow_grouped': fields.boolean('Permetre agrupacions',
+            help='Activar aquesta opció admet factures agrupades')
     }
 
     _defaults = {
@@ -129,7 +134,8 @@ class WizardPaymentOrderAddInvoices(osv.osv_memory):
         'init_date': lambda *a: time.strftime('%Y-%m-%d'),
         'end_date': lambda *a: time.strftime('%Y-%m-%d'),
         'invoice_type': 'out_invoice',
-        'len_result': lambda *a: ''
+        'len_result': lambda *a: '',
+        'allow_grouped': False
     }
 
 WizardPaymentOrderAddInvoices()

--- a/account_invoice_som/wizard/wizard_payment_order_add_invoices_view.xml
+++ b/account_invoice_som/wizard/wizard_payment_order_add_invoices_view.xml
@@ -25,6 +25,7 @@
                         <field name="payment_type" />
                         <field name="invoice_state" />
                         <field name="invoice_type" />
+                        <field name="allow_grouped" />
                     </group>
                     <group colspan="6" attrs="{'invisible': [('state', '!=', 'init')]}">
                         <button special="cancel" string="Cancelar" icon="gtk-cancel"/>


### PR DESCRIPTION
## Objectiu
- Afegir filtre per evitar factures agrupades (amb `group_move_id` )

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1853205738/11943381?folderId=3063374

## Comportament antic
S'estaven afegint factures que tenien moviments agrupats

## Comportament nou
 - Afegit el checkbox "Permetre agrupacions" per evitar aquestes factures
![image](https://user-images.githubusercontent.com/12842454/164266970-96faed18-e2f5-484f-9610-2f462b164e69.png)

## Comprovacions

- [X] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
  - `account_invoice_som`
- [ ] Script de migració
- [ ] Modifica traduccions
