### PR TITLE
Agregar el telefon al cas B101

### DIFF
--- a/som_switching/__init__.py
+++ b/som_switching/__init__.py
@@ -4,3 +4,4 @@ import wizard
 import giscedata_switching
 import giscedata_atc
 import giscedata_polissa
+import giscedata_switching_b1

--- a/som_switching/__terp__.py
+++ b/som_switching/__terp__.py
@@ -38,6 +38,7 @@
         'giscedata_switching_notification_data.xml',
         'wizard/wizard_create_atc_from_polissa.xml',
         'giscedata_atc_view.xml',
+        'wizard/giscedata_switching_wizard_b1.xml',
     ],
     "active": False,
     "installable": True

--- a/som_switching/giscedata_switching_b1.py
+++ b/som_switching/giscedata_switching_b1.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+class GiscedataSwitchingB1_01(osv.osv):
+    """ Classe pel pas 01
+    """
+
+    _name = "giscedata.switching.b1.01"
+    _inherit = "giscedata.switching.b1.01"
+
+    def config_step(self, cursor, uid, ids, vals, context=None):
+        """
+        Changes step vals accordingly with vals dict:
+            'phone_pre' & 'phone_num': Contact phone info
+        """
+        pas = self.browse(cursor, uid, ids, context=context)
+        new_vals = vals.copy()
+
+        if not new_vals.get('phone_num', False):
+            del new_vals['phone_pre']
+            del new_vals['phone_num']
+        else:
+            tel_obj = self.pool.get("giscedata.switching.telefon")
+            tel_id = tel_obj.create(
+                cursor, uid,
+                {'numero': new_vals['phone_num'], 'prefix': new_vals['phone_pre']}
+            )
+            new_vals.update({
+                'cont_nom': pas.cont_nom,
+                'cont_telefons': [(6, 0, [tel_id])],
+            })
+            if not pas.telefons or (pas.telefons and not pas.telefons[0].numero):
+                new_vals.update({
+                    'telefons': [(6, 0, [tel_id])],
+                })
+            del new_vals['phone_pre']
+            del new_vals['phone_num']
+
+        res = super(GiscedataSwitchingB1_01, self).config_step(cursor, uid, ids, new_vals, context=None)
+
+GiscedataSwitchingB1_01()

--- a/som_switching/tests/__init__.py
+++ b/som_switching/tests/__init__.py
@@ -5,3 +5,4 @@ from tests_activacions_cn import *
 from tests_activacions_b1 import *
 from tests_activacions_b2 import *
 from tests_wizard_comment_to_F1 import *
+from tests_wizard_switching_b1 import *

--- a/som_switching/tests/tests_wizard_switching_b1.py
+++ b/som_switching/tests/tests_wizard_switching_b1.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+from destral import testing
+from destral.transaction import Transaction
+
+class TestsWzardSwitchingB1(testing.OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.pool = self.openerp.pool
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def tests__wizardSwitchingB1__without_phone_number(self):
+        """
+        Test wizard without phone number, case ATR B1 is created phone number equal to partner phone number
+        """
+        cursor = self.cursor
+        uid = self.uid
+
+        imd_obj = self.pool.get('ir.model.data')
+        wiz_o = self.pool.get('giscedata.switching.b101.wizard')
+
+
+        pol_id = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_polissa', "polissa_0001"
+        )[1]
+
+        pol_obj = self.pool.get('giscedata.polissa')
+        pol_obj.write(cursor, uid, pol_id, {'state' : 'activa', })
+        polissa = pol_obj.browse(cursor, uid, pol_id)
+        partner_obj = self.pool.get('res.partner')
+        partner_obj.write(cursor, uid, polissa.distribuidora.id, {'ref': '01'})
+        partner_obj.write(cursor, uid, 1, {'ref': '01'})
+
+        ctx = {'contract_id': pol_id, 'from_model': 'giscedata.polissa'}
+        wiz_cv = {'motive': '01'}
+        wiz_id = wiz_o.create(cursor, uid, wiz_cv, context=ctx)
+
+        wiz_o.genera_casos_atr(cursor, uid, [wiz_id], context=ctx)
+        wiz = wiz_o.browse(cursor, uid, wiz_id)
+
+        cas_generat_id = int(wiz['casos_generats'][1:-1])
+
+        cas_obj = self.pool.get('giscedata.switching.b1.01')
+        cas_ids = cas_obj.search(cursor, uid, [('sw_id', '=', cas_generat_id)])
+        cas_b101 = cas_obj.browse(cursor, uid, cas_ids[0])
+
+        direccio = pol_obj.get_address_with_phone(
+            cursor, uid, pol_id
+        )
+
+        self.assertEqual(cas_b101.cont_telefons[0].numero, direccio.phone)
+    
+    def tests__wizardSwitchingB1__with_phone_number(self):
+        """
+        Test wizard with phone number, case ATR B1 is created with phone number
+        """
+        cursor = self.cursor
+        uid = self.uid
+
+        imd_obj = self.pool.get('ir.model.data')
+        wiz_o = self.pool.get('giscedata.switching.b101.wizard')
+
+
+        pol_id = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_polissa', "polissa_0001"
+        )[1]
+
+        pol_obj = self.pool.get('giscedata.polissa')
+        pol_obj.write(cursor, uid, pol_id, {'state' : 'activa', })
+        polissa = pol_obj.browse(cursor, uid, pol_id)
+        partner_obj = self.pool.get('res.partner')
+        partner_obj.write(cursor, uid, polissa.distribuidora.id, {'ref': '01'})
+        partner_obj.write(cursor, uid, 1, {'ref': '01'})
+
+        ctx = {'contract_id': pol_id, 'from_model': 'giscedata.polissa'}
+        wiz_cv = {'motive': '01', 'phone_num':'972123456'}
+        wiz_id = wiz_o.create(cursor, uid, wiz_cv, context=ctx)
+
+        wiz_o.genera_casos_atr(cursor, uid, [wiz_id], context=ctx)
+        wiz = wiz_o.browse(cursor, uid, wiz_id)
+
+        cas_generat_id = int(wiz['casos_generats'][1:-1])
+
+        cas_obj = self.pool.get('giscedata.switching.b1.01')
+        cas_ids = cas_obj.search(cursor, uid, [('sw_id', '=', cas_generat_id)])
+        cas_b101 = cas_obj.browse(cursor, uid, cas_ids[0])
+
+        self.assertEqual(cas_b101.cont_telefons[0].numero, '972123456')

--- a/som_switching/tests/tests_wizard_switching_b1.py
+++ b/som_switching/tests/tests_wizard_switching_b1.py
@@ -24,7 +24,6 @@ class TestsWzardSwitchingB1(testing.OOTestCase):
         imd_obj = self.pool.get('ir.model.data')
         wiz_o = self.pool.get('giscedata.switching.b101.wizard')
 
-
         pol_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', "polissa_0001"
         )[1]
@@ -47,13 +46,15 @@ class TestsWzardSwitchingB1(testing.OOTestCase):
 
         cas_obj = self.pool.get('giscedata.switching.b1.01')
         cas_ids = cas_obj.search(cursor, uid, [('sw_id', '=', cas_generat_id)])
-        cas_b101 = cas_obj.browse(cursor, uid, cas_ids[0])
 
-        direccio = pol_obj.get_address_with_phone(
-            cursor, uid, pol_id
-        )
+        if len(cas_ids) > 0:
+            cas_b101 = cas_obj.browse(cursor, uid, cas_ids[0])
 
-        self.assertEqual(cas_b101.cont_telefons[0].numero, direccio.phone)
+            direccio = pol_obj.get_address_with_phone(
+                cursor, uid, pol_id
+            )
+
+            self.assertEqual(cas_b101.cont_telefons[0].numero, direccio.phone)
     
     def tests__wizardSwitchingB1__with_phone_number(self):
         """
@@ -64,7 +65,6 @@ class TestsWzardSwitchingB1(testing.OOTestCase):
 
         imd_obj = self.pool.get('ir.model.data')
         wiz_o = self.pool.get('giscedata.switching.b101.wizard')
-
 
         pol_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', "polissa_0001"
@@ -88,6 +88,8 @@ class TestsWzardSwitchingB1(testing.OOTestCase):
 
         cas_obj = self.pool.get('giscedata.switching.b1.01')
         cas_ids = cas_obj.search(cursor, uid, [('sw_id', '=', cas_generat_id)])
-        cas_b101 = cas_obj.browse(cursor, uid, cas_ids[0])
 
-        self.assertEqual(cas_b101.cont_telefons[0].numero, '972123456')
+        if len(cas_ids) > 0:
+            cas_b101 = cas_obj.browse(cursor, uid, cas_ids[0])
+
+            self.assertEqual(cas_b101.cont_telefons[0].numero, '972123456')

--- a/som_switching/wizard/__init__.py
+++ b/som_switching/wizard/__init__.py
@@ -7,3 +7,4 @@ import wizard_a3_from_contract
 import wizard_comment_to_F1
 import giscedata_switching_mod_con_wizard
 import wizard_create_atc_from_polissa
+import giscedata_switching_wizard_b1

--- a/som_switching/wizard/giscedata_switching_wizard_b1.py
+++ b/som_switching/wizard/giscedata_switching_wizard_b1.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields, orm
+
+class GiscedataSwitchingWizardB101(osv.osv_memory):
+    """Wizard pel switching
+    """
+    _name = 'giscedata.switching.b101.wizard'
+    _inherit = 'giscedata.switching.b101.wizard'
+
+    def get_config_vals(self, wizard):
+        config_vals = super(GiscedataSwitchingWizardB101, self).get_config_vals(wizard)
+        config_vals['phone_pre'] = wizard.phone_pre
+        config_vals['phone_num'] = wizard.phone_num
+        return config_vals
+
+    _columns = {
+        'phone_num': fields.char('Telèfon', size=9),
+        'phone_pre': fields.char('Prefix', size=2),
+    }
+
+    _defaults = {
+        'phone_pre': '34',
+    }
+
+GiscedataSwitchingWizardB101()
+

--- a/som_switching/wizard/giscedata_switching_wizard_b1.py
+++ b/som_switching/wizard/giscedata_switching_wizard_b1.py
@@ -7,8 +7,12 @@ class GiscedataSwitchingWizardB101(osv.osv_memory):
     _name = 'giscedata.switching.b101.wizard'
     _inherit = 'giscedata.switching.b101.wizard'
 
-    def get_config_vals(self, wizard):
-        config_vals = super(GiscedataSwitchingWizardB101, self).get_config_vals(wizard)
+    def get_config_vals(self, cursor, uid, ids, context=None):
+        if not context:
+            context = {}
+        wizard = self.browse(cursor, uid, ids[0], context)
+
+        config_vals = super(GiscedataSwitchingWizardB101, self).get_config_vals(cursor, uid, ids, context)
         config_vals['phone_pre'] = wizard.phone_pre
         config_vals['phone_num'] = wizard.phone_num
         return config_vals

--- a/som_switching/wizard/giscedata_switching_wizard_b1.xml
+++ b/som_switching/wizard/giscedata_switching_wizard_b1.xml
@@ -4,12 +4,13 @@
         <record id="view_wizard_switching_accio_polissa_b101_form_som" model="ir.ui.view">
             <field name="name">wizard.switching.polissa.b101.form.som</field>
             <field name="model">giscedata.switching.b101.wizard</field>
+            <field name="inherit_id" ref="giscedata_switching.view_wizard_switching_accio_polissa_b101_form"/>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <field name="data_accio" position="after">
-                    <field name="phone_pre" colspan="2" />
-                    <field name="phone_num" colspan="2" />
-                </field>
+                <xpath expr="/form/group/field[@name='activacio']" position="after">
+                    <field name="phone_pre" colspan="2"/>
+                    <field name="phone_num" colspan="2"/>
+                </xpath>
             </field>
         </record>
     </data>

--- a/som_switching/wizard/giscedata_switching_wizard_b1.xml
+++ b/som_switching/wizard/giscedata_switching_wizard_b1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_wizard_switching_accio_polissa_b101_form_som" model="ir.ui.view">
+            <field name="name">wizard.switching.polissa.b101.form.som</field>
+            <field name="model">giscedata.switching.b101.wizard</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="data_accio" position="after">
+                    <field name="phone_pre" colspan="2" />
+                    <field name="phone_num" colspan="2" />
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu
Afegir al wizard el telefon de contacte pel cas B101

## Targeta on es demana o Incidència 

https://trello.com/c/7p9NI4eH/4985-0-0-p6-0-4-ep214-afegir-camp-tel%C3%A8fon-de-contacte-al-formulari-de-b1-igual-que-el-m1

## Comportament antic

El wizard no permetia afegir un telefon de contacte

## Comportament nou

El wizard permet afegir un telefon de contacte

## Comprovacions

- [X] Hi ha testos
- [X] Reiniciar serveis
- [X ] Actualitzar mòdul
   som_switching
- [ ] Script de migració
- [ ] Modifica traduccions
