### PR TITLE
Pagar factures des de la OV: adaptació del `facturacio.pay.invoice` per generar avísos

### DIFF
--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -8,6 +8,7 @@
     "category": "Master",
     "depends":[
         "giscedata_facturacio_comer_bono_social",
+        "giscedata_facturacio_impagat_comer",
         "account_invoice_pending",
         "giscedata_facturacio",
         "l10n_ES_cobros_ventanilla",

--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Procediments d'impagats específics de Som Energia",
-    "description": """Mòdul per a la gestió dels impagaments de contractes 
+    "description": """Mòdul per a la gestió dels impagaments de contractes
         especifics de SomEngergia""",
     "version": "0.1.2",
     "author": "Som Energia SCCL",
     "category": "Master",
     "depends":[
-        "giscedata_facturacio_impagat_comer",
         "account_invoice_pending",
         "giscedata_facturacio",
         "l10n_ES_cobros_ventanilla",
         "powersms",
+        "giscedata_facturacio_impagat_comer",
         "www_som",
         "poweremail"
    ],

--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -7,7 +7,6 @@
     "author": "Som Energia SCCL",
     "category": "Master",
     "depends":[
-        "giscedata_facturacio_comer_bono_social",
         "giscedata_facturacio_impagat_comer",
         "account_invoice_pending",
         "giscedata_facturacio",

--- a/som_account_invoice_pending/demo/som_account_invoice_pending_demo_data.xml
+++ b/som_account_invoice_pending/demo/som_account_invoice_pending_demo_data.xml
@@ -49,5 +49,13 @@
             <field name="process_id" ref="account_invoice_pending.default_pending_state_process"/>
             <field name="pending_days_type">natural</field>
         </record>
+        <!-- Other Account journal -->
+        <record model="account.journal" id="other_journal">
+            <field name="name">Other</field>
+            <field name="code">Other</field>
+            <field name="type">cash</field>
+            <field name="view_id" ref="account.account_journal_bank_view"/>
+            <field name="sequence_id" ref="account.sequence_journal"/>
+        </record>
     </data>
 </openerp>

--- a/som_account_invoice_pending/requirements.txt
+++ b/som_account_invoice_pending/requirements.txt
@@ -1,3 +1,4 @@
 consolemsg==0.3.3
 yamlns==0.7
 ine_tugesto_somenergia==1.0.0.1
+xlsxwriter==2.0.0

--- a/som_account_invoice_pending/som_account_invoice_pending_data.xml
+++ b/som_account_invoice_pending/som_account_invoice_pending_data.xml
@@ -584,5 +584,50 @@ import_factura = object.residual
 ]]>
             </field>
         </record>
+
+        <record model="poweremail.templates" id="tpv_pay_alert_template_som">
+            <field name="name">Gestió de cobraments - Avís Factura pagada per TPV</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'giscedata.facturacio.factura')]"/>
+            <field eval="0" name="save_to_drafts"/>
+            <field name="model_int_name">giscedata.facturacio.factura</field>
+            <field name="def_to">cobraments@somenergia.coop</field>
+            <field eval="0" name="auto_email"/>
+            <field eval="0" name="single_email"/>
+            <field eval="0" name="use_sign"/>
+            <field name="def_subject">Avís Factura pagada per TPV</field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create"/>
+            <field name="lang"/>
+            <field eval="0" name="send_on_write"/>
+            <field name="def_bcc"></field>
+            <field name="def_cc"></field>
+            <field name="enforce_from_account" model="poweremail.core_accounts" search="[('name','=', 'Gestió de Cobraments')]"/>
+            <field name="def_body_text"><![CDATA[<!doctype html>
+                <html>
+                <head></head>
+                <body>
+                Este correo ha estado generado automáticamente.
+                </body>
+                </html>
+                ]]></field>
+        </record>
+    </data>
+
+    <data noupdate="1">
+        <record model="res.config" id="pay_alert_pending_states_som" forcecreate="1">
+            <field name="name">pay_alert_pending_states_som</field>
+            <field name="value">[]</field>
+            <field name="description">Estats pendents on volem rebre avís en rebre un pagament per TPV.\n(ids d'estats pendents) Ex: [3,12,33]</field>
+        </record>
+        <!-- Account journal for TPV payments -->
+        <record model="account.journal" id="tpv_journal">
+            <field name="name">TPV</field>
+            <field name="code">TPV</field>
+            <field name="type">cash</field>
+            <field name="view_id" ref="account.account_journal_bank_view"/>
+            <field name="sequence_id" ref="account.sequence_journal"/>
+            <!--field name="default_debit_account_id" model="account.account" search="[('type','=','cash')]"/-->
+            <!--field name="default_credit_account_id" model="account.account" search="[('type','=','cash')]"/-->
+        </record>
     </data>
 </openerp>

--- a/som_account_invoice_pending/tests/__init__.py
+++ b/som_account_invoice_pending/tests/__init__.py
@@ -2,3 +2,4 @@ from .update_pending_states_tests import *
 from .wizard_returned_invoices_export_tests import *
 from .wizard_unlink_sms_pending_history_tests import *
 from .wizard_tugesto_invoices_export_tests import *
+from .wizard_pay_invoice_tests import *

--- a/som_account_invoice_pending/tests/update_pending_states_tests.py
+++ b/som_account_invoice_pending/tests/update_pending_states_tests.py
@@ -274,23 +274,6 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
         inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
         self.assertEqual(inv_data.pending_state.id, self.annexIII_first_sent)
 
-    @mock.patch('som_account_invoice_pending.update_pending_states.UpdatePendingStates.send_email')
-    def test__update_unpaid_invoice_waiting_annexIII_first_email_unsend(self, mock_function):
-        cursor = self.txn.cursor
-        uid = self.txn.user
-        self._load_data_unpaid_invoices(cursor, uid, [self.waiting_annexIII_first])
-
-        mock_function.return_value = -1
-
-        pending_obj = self.pool.get('update.pending.states')
-        fact_obj = self.pool.get('giscedata.facturacio.factura')
-        inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
-        self.assertEqual(inv_data.pending_state.id, self.waiting_annexIII_first)
-
-        pending_obj.update_waiting_for_annexIII_first(cursor, uid)
-        inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
-        self.assertEqual(inv_data.pending_state.id, self.waiting_annexIII_first)
-
     def test__update_unpaid_invoice_waiting_for_annexIII_second_no_update(self):
         cursor = self.txn.cursor
         uid = self.txn.user
@@ -318,29 +301,6 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
 
         inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
         self.assertEqual(inv_data.pending_state.id, self.annexIII_second_sent)
-
-    @mock.patch('som_account_invoice_pending.update_pending_states.UpdatePendingStates.send_email')
-    def test__update_unpaid_invoice_waiting_annexIII_second_email_unsend(self, mock_function):
-        cursor = self.txn.cursor
-        uid = self.txn.user
-        self._load_data_unpaid_invoices(cursor, uid, [self.waiting_annexIII_second])
-
-        pending_obj = self.pool.get('update.pending.states')
-        fact_obj = self.pool.get('giscedata.facturacio.factura')
-        inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
-        self.assertEqual(inv_data.pending_state.id, self.waiting_annexIII_second)
-        mock_function.return_value = -1
-
-        pending_obj.update_waiting_for_annexIII_second(cursor, uid)
-
-        params = {
-            'email_from': self.account_id,
-            'template_id': self.annex3_template_id,
-        }
-        mock_function.assert_called_once_with(cursor, uid, self.invoice_1_id, params)
-
-        inv_data = fact_obj.browse(cursor, uid, self.invoice_1_id)
-        self.assertEqual(inv_data.pending_state.id, self.waiting_annexIII_second)
 
     @mock.patch('som_account_invoice_pending.update_pending_states.UpdatePendingStates.send_email')
     @mock.patch('som_account_invoice_pending.update_pending_states.UpdatePendingStates.send_sms')

--- a/som_account_invoice_pending/tests/wizard_pay_invoice_tests.py
+++ b/som_account_invoice_pending/tests/wizard_pay_invoice_tests.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+from datetime import date, timedelta
+import mock
+from mock import Mock
+from osv.osv import except_osv
+from giscedata_facturacio.wizard import wizard_pay_invoice
+from som_account_invoice_pending.wizard import wizard_pay_invoice as som_wizard_pay_invoice
+
+
+class TestWizardPayInvoice(testing.OOTestCase):
+
+    def setUp(self):
+        self.pool = self.openerp.pool
+
+    def _load_data_unpaid_invoice(self, cursor, uid):
+        imd_obj = self.pool.get('ir.model.data')
+        self.inv_obj = self.pool.get('account.invoice')
+        self.fact_obj = self.pool.get('giscedata.facturacio.factura')
+        self.pay_inv_obj = self.pool.get('facturacio.pay.invoice')
+        self.cfg_obj = self.pool.get('res.config')
+
+        self.waiting_48h_def = imd_obj.get_object_reference(
+            cursor, uid, 'som_account_invoice_pending', 'default_pendent_notificacio_tall_imminent_pending_state'
+        )[1]
+        self.tall_def = imd_obj.get_object_reference(
+            cursor, uid, 'som_account_invoice_pending', 'default_tall_pending_state'
+        )[1]
+
+        self.fact_id = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_facturacio', 'factura_0001'
+        )[1]
+
+        self.tpv_journal_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_account_invoice_pending', 'tpv_journal'
+        )[1]
+
+        self.other_journal_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_account_invoice_pending', 'other_journal'
+        )[1]
+
+        self.account_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_account_invoice_pending', 'cobraments_mail_account'
+        )[1]
+
+    @mock.patch.object(wizard_pay_invoice.WizardPayInvoice, 'action_pay_and_reconcile')
+    @mock.patch.object(som_wizard_pay_invoice.WizardPayInvoice, 'action_mail_avis_cobraments_async')
+    def test__action_pay_and_reconcile__other_journal__not_notified(self, mocked_action_mail_avis_cobraments_async, mocked_pay_and_rec):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            self._load_data_unpaid_invoice(cursor, uid)
+
+            ctx = { 'active_id': self.fact_id, 
+                    'active_ids': [self.fact_id] }
+
+            today = date.today().strftime('%Y%m%d')
+            vals = { 'comment': 'Pagament efectuat des de la OV. {}'.format(today),
+                     'journal_id': self.other_journal_id }
+
+            pay_invoice_wizard = self.pay_inv_obj.create(cursor, uid, vals, context=ctx)
+            wiz_id = pay_invoice_wizard
+            self.pay_inv_obj.action_pay_and_reconcile(cursor, uid, wiz_id, context=ctx)
+
+            mocked_pay_and_rec.assert_called_once()
+            mocked_action_mail_avis_cobraments_async.assert_not_called()
+
+    @mock.patch.object(wizard_pay_invoice.WizardPayInvoice, 'action_pay_and_reconcile')
+    @mock.patch.object(som_wizard_pay_invoice.WizardPayInvoice, 'action_mail_avis_cobraments_async')
+    def test__action_pay_and_reconcile__other_journal_other_ps__not_notified(self, mocked_action_mail_avis_cobraments_async, mocked_pay_and_rec):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            self._load_data_unpaid_invoice(cursor, uid)
+            self.fact_obj.set_pending(cursor, uid, [self.fact_id], self.waiting_48h_def)
+            self.cfg_obj.set(cursor, uid, 'pay_alert_pending_states_som', "[{}]".format(self.tall_def))
+
+            ctx = { 'active_id': self.fact_id, 
+                    'active_ids': [self.fact_id] }
+
+            today = date.today().strftime('%Y%m%d')
+            vals = { 'comment': 'Pagament efectuat des de la OV. {}'.format(today),
+                     'journal_id': self.other_journal_id }
+
+            pay_invoice_wizard = self.pay_inv_obj.create(cursor, uid, vals, context=ctx)
+            wiz_id = pay_invoice_wizard
+            self.pay_inv_obj.action_pay_and_reconcile(cursor, uid, wiz_id, context=ctx)
+
+            mocked_pay_and_rec.assert_called_once()
+            mocked_action_mail_avis_cobraments_async.assert_not_called()
+
+    @mock.patch.object(wizard_pay_invoice.WizardPayInvoice, 'action_pay_and_reconcile')
+    @mock.patch.object(som_wizard_pay_invoice.WizardPayInvoice, 'action_mail_avis_cobraments_async')
+    def test__action_pay_and_reconcile__other_journal_tall_ps__not_notified(self, mocked_action_mail_avis_cobraments_async, mocked_pay_and_rec):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            self._load_data_unpaid_invoice(cursor, uid)
+            self.fact_obj.set_pending(cursor, uid, [self.fact_id], self.tall_def)
+            self.cfg_obj.set(cursor, uid, 'pay_alert_pending_states_som', "[{}]".format(self.tall_def))
+
+            ctx = { 'active_id': self.fact_id, 
+                    'active_ids': [self.fact_id] }
+
+            today = date.today().strftime('%Y%m%d')
+            vals = { 'comment': 'Pagament efectuat des de la OV. {}'.format(today),
+                     'journal_id': self.other_journal_id }
+
+            pay_invoice_wizard = self.pay_inv_obj.create(cursor, uid, vals, context=ctx)
+            wiz_id = pay_invoice_wizard
+            self.pay_inv_obj.action_pay_and_reconcile(cursor, uid, wiz_id, context=ctx)
+
+            mocked_pay_and_rec.assert_called_once()
+            mocked_action_mail_avis_cobraments_async.assert_not_called()
+
+    @mock.patch.object(wizard_pay_invoice.WizardPayInvoice, 'action_pay_and_reconcile')
+    @mock.patch.object(som_wizard_pay_invoice.WizardPayInvoice, 'action_mail_avis_cobraments_async')
+    def test__action_pay_and_reconcile__tpv_journal_other_ps__not_notified(self, mocked_action_mail_avis_cobraments_async, mocked_pay_and_rec):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            self._load_data_unpaid_invoice(cursor, uid)
+            self.fact_obj.set_pending(cursor, uid, [self.fact_id], self.waiting_48h_def)
+            self.cfg_obj.set(cursor, uid, 'pay_alert_pending_states_som', "[{}]".format(self.tall_def))
+
+            ctx = { 'active_id': self.fact_id, 
+                    'active_ids': [self.fact_id] }
+
+            today = date.today().strftime('%Y%m%d')
+            vals = { 'comment': 'Pagament efectuat des de la OV. {}'.format(today),
+                     'journal_id': self.tpv_journal_id }
+
+            pay_invoice_wizard = self.pay_inv_obj.create(cursor, uid, vals, context=ctx)
+            wiz_id = pay_invoice_wizard
+            self.pay_inv_obj.action_pay_and_reconcile(cursor, uid, wiz_id, context=ctx)
+
+            mocked_pay_and_rec.assert_called_once()
+            mocked_action_mail_avis_cobraments_async.assert_not_called()
+
+    @mock.patch.object(wizard_pay_invoice.WizardPayInvoice, 'action_pay_and_reconcile')
+    @mock.patch.object(som_wizard_pay_invoice.WizardPayInvoice, 'action_mail_avis_cobraments_async')
+    def test__action_pay_and_reconcile__tpv_journal_tall_ps__notified(self, mocked_action_mail_avis_cobraments_async, mocked_pay_and_rec):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            self._load_data_unpaid_invoice(cursor, uid)
+
+            self.fact_obj.set_pending(cursor, uid, [self.fact_id], self.tall_def)
+            self.cfg_obj.set(cursor, uid, 'pay_alert_pending_states_som', "[{}]".format(self.tall_def))
+
+            ctx = { 'active_id': self.fact_id, 
+                    'active_ids': [self.fact_id] }
+
+            today = date.today().strftime('%Y%m%d')
+            vals = { 'comment': 'Pagament efectuat des de la OV. {}'.format(today),
+                     'journal_id': self.tpv_journal_id }
+
+            pay_invoice_wizard = self.pay_inv_obj.create(cursor, uid, vals, context=ctx)
+            wiz_id = pay_invoice_wizard
+            self.pay_inv_obj.action_pay_and_reconcile(cursor, uid, wiz_id, context=ctx)
+
+            mocked_pay_and_rec.assert_called_once()
+            mocked_action_mail_avis_cobraments_async.assert_called()
+
+    @mock.patch.object(wizard_pay_invoice.WizardPayInvoice, 'action_pay_and_reconcile')
+    @mock.patch.object(som_wizard_pay_invoice.WizardPayInvoice, 'action_mail_avis_cobraments_async')
+    def test__action_mail_avis_cobraments__ok(self, mocked_action_mail_avis_cobraments_async, mocked_pay_and_rec):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            self._load_data_unpaid_invoice(cursor, uid)
+
+            self.fact_obj.set_pending(cursor, uid, [self.fact_id], self.tall_def)
+            self.cfg_obj.set(cursor, uid, 'pay_alert_pending_states_som', "[{}]".format(self.tall_def))
+
+            ctx = { 'active_id': self.fact_id, 
+                    'active_ids': [self.fact_id] }
+
+            today = date.today().strftime('%Y%m%d')
+            vals = { 'comment': 'Pagament efectuat des de la OV. {}'.format(today),
+                     'journal_id': self.tpv_journal_id }
+
+            pay_invoice_wizard = self.pay_inv_obj.create(cursor, uid, vals, context=ctx)
+            wiz_id = pay_invoice_wizard
+            self.pay_inv_obj.action_pay_and_reconcile(cursor, uid, wiz_id, context=ctx)
+
+            mocked_pay_and_rec.assert_called_once()
+            mocked_action_mail_avis_cobraments_async.assert_called()

--- a/som_account_invoice_pending/wizard/__init__.py
+++ b/som_account_invoice_pending/wizard/__init__.py
@@ -1,3 +1,4 @@
 import wizard_returned_invoices_export
 import wizard_unlink_sms_pending_history
 import wizard_tugesto_invoices_export
+import wizard_pay_invoice

--- a/som_account_invoice_pending/wizard/wizard_pay_invoice.py
+++ b/som_account_invoice_pending/wizard/wizard_pay_invoice.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from osv import osv
+from tools.translate import _
+from ast import literal_eval
+from oorq.decorators import job
+from tools import config
+
+class WizardPayInvoice(osv.osv_memory):
+
+    _name = "facturacio.pay.invoice"
+    _inherit = "facturacio.pay.invoice"
+
+    def action_pay_and_reconcile(self, cursor, uid, ids, context=None):
+        """Enviament d'un avís en donar per pagades factures amb un estat pendent concret
+        """
+        if not context:
+            context = {}
+
+        if isinstance(ids, list) or isinstance(ids, tuple):
+            ids = ids[0]
+
+        ir_md_obj = self.pool.get('ir.model.data')
+        fact_obj = self.pool.get('giscedata.facturacio.factura')
+        fact_id = context.get('active_id', False)
+        factura = fact_obj.browse(cursor, uid, fact_id)
+        tpv_journal = ir_md_obj.get_object_reference(cursor, uid,
+                      'som_account_invoice_pending', 'tpv_journal')[1]
+        wiz = self.browse(cursor, uid, ids)
+
+        cfg_obj = self.pool.get('res.config')
+        pay_alert_conf = cfg_obj.get(cursor, uid, 'pay_alert_pending_states_som', '[]')
+
+        if factura.pending_state.id in literal_eval(pay_alert_conf) and wiz.journal_id.id == tpv_journal:
+            self.mail_avis_cobraments(cursor, uid, ids, [fact_id], context)
+
+        super(WizardPayInvoice, self).action_pay_and_reconcile(cursor, uid, ids, context)
+
+        wiz = self.browse(cursor, uid, ids)
+        old_comment = factura.comment if factura.comment else ''
+        new_comment = wiz.comment or '' + "\n"
+        fact_obj.write(cursor, uid, fact_id, {'comment': new_comment + old_comment })
+
+    def mail_avis_cobraments(self, cursor, uid, ids, fact_ids, context=None):
+        """Enviament individual
+        """
+        ir_mod_dat = self.pool.get('ir.model.data')
+
+        tmpl = ir_mod_dat._get_obj(cursor, uid,
+                                   'som_account_invoice_pending',
+                                   'tpv_pay_alert_template_som')
+        ctx = context.copy()
+
+        ctx.update({
+            'state': 'single',
+            'priority': '0',
+            'from': tmpl.enforce_from_account.id,
+            'template_id': tmpl.id,
+            'src_model': 'giscedata.facturacio.factura',
+            'type': 'out_invoice'
+        })
+
+        for fact_id in fact_ids:
+            ctx.update({
+                'src_rec_ids': [fact_id],
+                'active_ids': [fact_id],
+            })
+            self.action_mail_avis_cobraments_async(cursor, uid, ids, ctx)
+
+    def action_mail_avis_cobraments(self, cursor, uid, ids, context=None):
+        email_wizard_obj = self.pool.get('poweremail.send.wizard')
+
+        wiz_vals = {
+                    'state': context['state'],
+                    'priority': context['priority'],
+                    'from': context['from'],
+        }
+        pe_wiz = email_wizard_obj.create(cursor, uid, wiz_vals,
+                                         context=context)
+        return email_wizard_obj.send_mail(cursor, uid, [pe_wiz], context=context)
+
+    @job(queue=config.get('poweremail_render_queue', 'poweremail'))
+    def action_mail_avis_cobraments_async(self, cursor, uid, id, context=None):
+        self.action_mail_avis_cobraments(cursor, uid, id, context)
+
+WizardPayInvoice()


### PR DESCRIPTION
## Objectiu
 - Fer les modificacions addients al l'ERP per enllaçar el desenvolupament fer a la OV per pagar factures pendents.

## Targeta on es demana o Incidència 
 -  https://trello.com/c/GSVDDFRZ/5018-0-0-p37-ep212-pagar-factures-ov-requereix-atenci%C3%B3-posada-en-producci%C3%B3

## Comportament antic

Inexistent

## Comportament nou

 - S'exten el comportament de l'assistent `facturacio.pay.invoice` per tal d'enviar un correu a la bústia de cobraments si es compleix que:
   -  La factura prové d'un estat pendent que aparegui a la llista definida a la variable de config `pay_alert_pending_states_som`.
   -  El diari pel qual s'està intentant pagar la factura és el de pagament TPV  `'som_account_invoice_pending', 'tpv_journal'`
   -  A més afegim un comentari a la factura on queda reflexat que ha estat pagat a través de la OV.

## Comprovacions

- [X] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
  - `som_account_invoice_pending` 
- [ ] Script de migració
- [ ] Modifica traduccions
