### PR TITLE
ADD mapping from address city and Tugesto specific ID for each city

### DIFF
--- a/som_account_invoice_pending/requirements.txt
+++ b/som_account_invoice_pending/requirements.txt
@@ -1,2 +1,3 @@
 consolemsg==0.3.3
 yamlns==0.7
+ine_tugesto_somenergia==1.0.0.1

--- a/som_account_invoice_pending/wizard/wizard_tugesto_invoices_export.py
+++ b/som_account_invoice_pending/wizard/wizard_tugesto_invoices_export.py
@@ -6,6 +6,7 @@ import re
 from tqdm import tqdm
 import pandas as pd
 import json
+from ine_tugesto_somenergia import ine_maping_tugesto as imtug
 
 from osv import osv, fields
 from datetime import datetime, timedelta, date
@@ -83,10 +84,14 @@ class WizardExportTugestoInvoices(osv.osv_memory):
                 aux_addr = addr_objs[0] if addr_objs else partner.address[0]
 
             direccion = aux_addr.street or ''
-            provincia = aux_addr.id_municipi.state.code if aux_addr.id_municipi.state else ''
-            poblacion = aux_addr.id_municipi.ine if aux_addr.id_municipi else ''
+            provincia = aux_addr.id_poblacio.id_municipi.state.code if (aux_addr.id_poblacio and aux_addr.id_poblacio.id_municipi.state) else ''
+            poblacion_pais = aux_addr.id_poblacio.id_municipi.name if (aux_addr.id_poblacio and aux_addr.id_poblacio.id_municipi_id) else ''
+
+            # fem el mapeig per obtenir el ID específic de Tugesto per al municipi
+            aux_ine_code = aux_addr.id_poblacio.id_municipi.ine if (aux_addr.id_poblacio and aux_addr.id_poblacio.id_municipi_id and aux_addr.id_poblacio.id_municipi_id.ine) else None
+            poblacion = imtug.INEMapingTugesto().get_tugesto_id(poblacion_pais or 'unknown', provincia or None, aux_ine_code)
+            
             pais = 9 # Codi propi de Tugesto per a 'Espanya'
-            poblacion_pais =  aux_addr.id_municipi.name
             codigo_postal = aux_addr.zip or ''
             telefono = aux_addr.phone or ''
             movil = aux_addr.mobile or ''

--- a/som_account_invoice_pending/wizard/wizard_tugesto_invoices_export.py
+++ b/som_account_invoice_pending/wizard/wizard_tugesto_invoices_export.py
@@ -84,11 +84,11 @@ class WizardExportTugestoInvoices(osv.osv_memory):
                 aux_addr = addr_objs[0] if addr_objs else partner.address[0]
 
             direccion = aux_addr.street or ''
-            provincia = aux_addr.id_poblacio.id_municipi.state.code if (aux_addr.id_poblacio and aux_addr.id_poblacio.id_municipi.state) else ''
-            poblacion_pais = aux_addr.id_poblacio.id_municipi.name if (aux_addr.id_poblacio and aux_addr.id_poblacio.id_municipi_id) else ''
+            provincia = aux_addr.id_poblacio.municipi_id.state.code if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id.state) else ''
+            poblacion_pais = aux_addr.id_poblacio.id_municipi_id.name if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id) else ''
 
             # fem el mapeig per obtenir el ID específic de Tugesto per al municipi
-            aux_ine_code = aux_addr.id_poblacio.id_municipi.ine if (aux_addr.id_poblacio and aux_addr.id_poblacio.id_municipi_id and aux_addr.id_poblacio.id_municipi_id.ine) else None
+            aux_ine_code = aux_addr.id_poblacio.municipi_id.ine if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id and aux_addr.id_poblacio.municipi_id.ine) else None
             poblacion = imtug.INEMapingTugesto().get_tugesto_id(poblacion_pais or 'unknown', provincia or None, aux_ine_code)
             
             pais = 9 # Codi propi de Tugesto per a 'Espanya'

--- a/som_account_invoice_pending/wizard/wizard_tugesto_invoices_export.py
+++ b/som_account_invoice_pending/wizard/wizard_tugesto_invoices_export.py
@@ -85,7 +85,7 @@ class WizardExportTugestoInvoices(osv.osv_memory):
 
             direccion = aux_addr.street or ''
             provincia = aux_addr.id_poblacio.municipi_id.state.code if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id.state) else ''
-            poblacion_pais = aux_addr.id_poblacio.id_municipi_id.name if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id) else ''
+            poblacion_pais = aux_addr.id_poblacio.municipi_id.name if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id) else ''
 
             # fem el mapeig per obtenir el ID específic de Tugesto per al municipi
             aux_ine_code = aux_addr.id_poblacio.municipi_id.ine if (aux_addr.id_poblacio and aux_addr.id_poblacio.municipi_id and aux_addr.id_poblacio.municipi_id.ine) else None


### PR DESCRIPTION
## Objectiu
Poder obtenir el ID especific de Tugesto per a cada municipi cridant a un paquet de PyPy que hem creat que implementa una funcióper retornar aquest ID passant-li nom_ciutat (obligat), codi_provincia (opcional)i codi INE de la població (opcional).
Aquest ID és requerit per Tugesto en una de les columnes del llistat Excel que s'exporta.

## Targeta on es demana o Incidència 
https://trello.com/c/H35Yx6Ju/4930-0-3-p16-acci%C3%B3-extreure-excel-txt-per-carregar-expedients-a-tugesto

## Comportament antic
Usavem el codi INE però Tugesto ho va rebutjar

## Comportament nou
Usem el ID específic de Tugesto per als municipis

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis: al requirements.txt del mòdul hem afegit la càrrega del paquet: ine_tugesto_somenergia==1.0.0.1
- [X] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
