### PR TITLE
Canviar el camp `agree_tipus` (deprecated) per `tipo_medida` al wizard add_contracts_lot

### DIFF
--- a/som_infoenergia/wizard/wizard_add_contracts_lot.py
+++ b/som_infoenergia/wizard/wizard_add_contracts_lot.py
@@ -34,7 +34,7 @@ class WizardAddContractsLot(osv.osv_memory):
             'comer_fare': [('llista_preu', 'ilike', '%{}%'.format(wiz.comer_fare))],
             'access_fare': [('tarifa', 'ilike', '%{}%'.format(wiz.access_fare))],
             'autoconsum': [('autoconsumo','!=','00'), ('autoconsumo', '!=', False)] if wiz.autoconsum == 'all' else [('autoconsumo', '=', wiz.autoconsum)],
-            'agree_tipus': [('agree_tipus', 'ilike', '%{}%'.format(wiz.agree_tipus))],
+            'tipo_medida': [('tipo_medida', 'ilike', '%{}%'.format(wiz.tipo_medida))],
             'category': [('category_id','!=',False), ('category_id.name','ilike', '%{}%'.format(wiz.category))],
         }
         for field in search_params_relation.keys():
@@ -56,7 +56,7 @@ class WizardAddContractsLot(osv.osv_memory):
         'access_fare': fields.char('Tarifa d\'accés', size=256),
         'comer_fare': fields.char('Tarifa comercialitzadora', size=256),
         'autoconsum': fields.selection([(False, ''), ('all','Qualsevol Autoconsum')]+TABLA_113, 'Tipus autoconsum'),
-        'agree_tipus': fields.char('Tipus Punt', size=256),
+        'tipo_medida': fields.char('Tipus Punt', size=256),
         'category': fields.char('Categoria', size=256),
         'len_result': fields.text('Resultat de la cerca', readonly=True),
     }

--- a/som_infoenergia/wizard/wizard_add_contracts_lot_view.xml
+++ b/som_infoenergia/wizard/wizard_add_contracts_lot_view.xml
@@ -17,7 +17,7 @@
                         <field name="access_fare" />
                         <field name="comer_fare" />
                         <field name="autoconsum" />
-                        <field name="agree_tipus" />
+                        <field name="tipo_medida" />
                         <field name="category" />
                     </group>
                     <group colspan="6" attrs="{'invisible': [('state', '=', 'finished')]}">


### PR DESCRIPTION
## Objectiu
Canviar el camp `agree_tipus` (deprecated) per `tipo_medida` al wizard add_contracts_lot

## Targeta on es demana o Incidència 


## Comportament antic
S'utilitzava el camp `agree_tipus`, que està deprecated.

## Comportament nou
Ja s'utilitza el `tipo_medida` 

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul:
     - `som_infoenergia`
- [ ] Script de migració
- [ ] Modifica traduccions
