### PR TITLE
Afegir la llista de preus (tarifa comercialitzadora) al PDF de les factures d'indexada

### DIFF
--- a/giscedata_facturacio_comer_som/__terp__.py
+++ b/giscedata_facturacio_comer_som/__terp__.py
@@ -10,6 +10,8 @@
         'c2c_webkit_report',
         "account_invoice_base",
         "giscedata_facturacio_comer",
+        "giscedata_sup_territorials_2013_tec271_comer",
+        "giscedata_facturacio_iese",
         "giscedata_polissa_comer",
         "som_polissa_soci",
         "jasper_reports",
@@ -17,6 +19,7 @@
     "init_xml": [],
     "demo_xml": [],
     "update_xml":[
+        "giscedata_facturacio_comer_som_demo.xml",
         "giscedata_facturacio_comer_data.xml",
         "giscedata_facturacio_comer_report.xml"
     ],

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_comer_som_demo.xml
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_comer_som_demo.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="factura_101SF" model="giscedata.facturacio.factura">
+            <field name="name">0018</field>
+            <field name="date_invoice">2021-08-01</field>
+            <field name="date_due">2021-08-08</field>
+            <field name="number">0101/F</field>
+            <field name="polissa_id" ref="giscedata_polissa.polissa_tarifa_018"/>
+            <field name="account_id"  search="[('code', '=', 430000)]" model="account.account"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="date_boe">2017-01-01</field>
+            <field name="reference_type">none</field>
+            <field name="journal_id" ref="giscedata_facturacio.facturacio_journal_energia"/>
+            <field name="cups_id" ref="giscedata_cups.cups_tarifa_018"/>
+            <field eval="1" name="facturacio"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="address_invoice_id" ref="base.res_partner_address_c2c_1"/>
+            <field name="potencia">6.0</field>
+            <field name="tarifa_acces_id" ref="giscedata_polissa.tarifa_20TD"/>
+            <field name="llista_preu" ref="giscedata_facturacio.pricelist_tarifas_electricidad"/>
+            <field name="partner_id" ref="base.res_partner_c2c"/>
+            <field name="data_inici">2021-07-01</field>
+            <field name="data_final">2021-07-31</field>
+            <field name="fiscal_position" ref="giscedata_facturacio.fp_nacional_2012"/>
+            <field name="payment_type" ref="l10n_ES_remesas.payment_type_recibodomiciliado0"/>
+        </record>
+                <record id="linia_factura_ene_P1_0045" model="giscedata.facturacio.factura.linia">
+            <field name="name">P1</field>
+            <field name="product_id" search="[('name', '=', 'P1'), ('categ_id', '=', ref('giscedata_polissa.categ_e_t20TD'))]" model="product.product"/>
+            <field name="account_id"  search="[('code', '=', 700000)]" model="account.account"/>
+            <field name="tipus">energia</field>
+            <field name="quantity" eval="2"/>
+            <field name="price_unit" eval="0.108728"/>
+            <field name="price_unit_multi" eval="0.108728"/>
+            <field name="uos_id" ref="giscedata_polissa.uom_eneg_elec"/>
+            <!--<field name="multi" eval="1"/>-->
+            <!--<field name="uom_multi_id"></field>-->
+            <field name="factura_id" ref="factura_101SF"/>
+            <!--<field name="invoice_line_id"></field>-->
+            <!--<field name="cosfi"></field>-->
+            <field name="data_desde">2021-07-01</field>
+            <field name="data_fins">2021-07-31</field>
+        </record>
+        <record id="linia_factura_ene_P2_0045" model="giscedata.facturacio.factura.linia">
+            <field name="name">P2</field>
+            <field name="product_id" search="[('name', '=', 'P2'), ('categ_id', '=', ref('giscedata_polissa.categ_e_t20TD'))]" model="product.product"/>
+            <field name="account_id"  search="[('code', '=', 700000)]" model="account.account"/>
+            <field name="tipus">energia</field>
+            <field name="quantity" eval="0"/>
+            <field name="price_unit" eval="0.108728"/>
+            <field name="price_unit_multi" eval="0.108728"/>
+            <!--<field name="multi" eval="1"/>-->
+            <!--<field name="uom_multi_id"></field>-->
+            <field name="factura_id" ref="factura_101SF"/>
+            <field name="uos_id" ref="giscedata_polissa.uom_eneg_elec"/>
+            <!--<field name="invoice_line_id"></field>-->
+            <!--<field name="cosfi"></field>-->
+            <field name="data_desde">2021-07-01</field>
+            <field name="data_fins">2021-07-31</field>
+        </record>
+        <record id="linia_factura_pot_P1_0045" model="giscedata.facturacio.factura.linia">
+            <field name="name">P1</field>
+            <field name="product_id" search="[('name', '=', 'P1'), ('categ_id', '=', ref('giscedata_polissa.categ_p_t20TD'))]" model="product.product"/>
+            <field name="account_id"  search="[('code', '=', 700000)]" model="account.account"/>
+            <field name="tipus">potencia</field>
+            <field name="quantity" eval="6.928"/>
+            <field name="price_unit" eval="6.340584"/>
+            <field name="price_unit_multi" eval="0.103944"/>
+            <!--<field name="multi" eval="1"/>-->
+            <field name="uos_id" ref="giscedata_facturacio.uom_pot_elec_dia_traspas"/>
+            <field name="factura_id" ref="factura_101SF"/>
+            <!--<field name="invoice_line_id"></field>-->
+            <!--<field name="cosfi"></field>-->
+            <field name="data_desde">2021-07-01</field>
+            <field name="data_fins">2021-07-31</field>
+        </record>
+        <record id="linia_factura_llog_0045" model="giscedata.facturacio.factura.linia">
+            <field name="name">P1</field>
+            <field name="product_id" eval="False"/>
+            <field name="account_id"  search="[('code', '=', 700000)]" model="account.account"/>
+            <field name="tipus">lloguer</field>
+            <field name="quantity" eval="60.0"/>
+            <field name="price_unit" eval="0.05"/>
+            <field name="price_unit_multi" eval="0.05"/>
+            <!--<field name="multi" eval="1"/>-->
+            <!--<field name="uom_multi_id"></field>-->
+            <field name="factura_id" ref="factura_101SF"/>
+            <!--<field name="invoice_line_id"></field>-->
+            <!--<field name="cosfi"></field>-->
+            <field name="data_desde">2021-07-01</field>
+            <field name="data_fins">2021-07-31</field>
+        </record>
+                <record id="lectura_energia_factura_101SF" model="giscedata.facturacio.lectures.energia">
+            <field name="name">P1</field>
+            <field name="comptador_id" ref="giscedata_lectures.comptador_0001"/>
+            <field name="factura_id" ref="factura_101SF"/>
+            <field name="tipus">activa</field>
+            <field name="magnitud">AE</field>
+            <field name="data_actual">2021-07-31</field>
+            <field name="lect_actual">21</field>
+            <field name="data_anterior">2021-06-30</field>
+            <field name="lect_anterior">19</field>
+            <field name="consum">2</field>
+            <field name="origen_id" ref="giscedata_lectures.origen10"/>
+            <field name="origen_anterior_id"  ref="giscedata_lectures.origen10"/>
+            <!--<field name="motiu_ajust"></field>-->
+            <!--<field name="ajust"></field>-->
+        </record>
+        <record id="lectura_potencia_factura_101SF" model="giscedata.facturacio.lectures.potencia">
+            <field name="name">P1</field>
+            <field name="comptador_id" ref="giscedata_lectures.comptador_0001"/>
+            <field name="factura_id" ref="factura_101SF"/>
+            <field name="pot_contract">6</field>
+        </record>
+    </data>
+</openerp>

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -821,6 +821,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 'cups': fact.cups_id.name,
                 'cups_direction': fact.cups_id.direccio,
                 'tariff': pol.tarifa.name,
+                'pricelist': pol.llista_preu.name,
+                'invoicing_mode': pol.mode_facturacio,
                 'remote_managed_meter': pol.tg in ['1','3'],
                 'power': pol.potencia,
                 'powers': sorted([ (potencia.periode_id.name, potencia.potencia) for potencia in pol.potencies_periode ], key=lambda l:l[0]),

--- a/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
@@ -53,9 +53,12 @@ autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_di
                         ${_(u"Facturació potència:")} <span style="font-weight: bold;">${_(u"Facturació per poténcia quarthorari")}</span> <br />
                     % else:
                         ${_(u"Facturació potència:")} <span style="font-weight: bold;">${_(u"Facturació per ICP")}</span> <br />
-                    % endif                    
+                    % endif
                     ${_(u"Peatge de transport i distribució:")} <span style="font-weight: bold;">${cd.tariff}</span> <br />
                     ${_(u"Segment tarifari:")} <span style="font-weight: bold;">${cd.segment_tariff}</span> <br />
+                    % if cd.invoicing_mode == 'index':
+                        ${_(u"Tarifa Comercialitzadora:")} ${cd.pricelist}  <br />
+                    % endif
                     ${_(u"CUPS:")} <span style="font-weight: bold;">${cd.cups}</span> <br />
                     ${_(u"Comptador telegestionat:")} <span style="font-weight: bold;">${cd.remote_managed_meter and _(u'Sí') or _(u'No')}</span> <br />
                 </p>


### PR DESCRIPTION
## Objectiu
Afegir la llista de preus (tarifa comercialitzadora) al PDF de les factures d'indexada

## Targeta on es demana o Incidència 
[Aquí](https://trello.com/c/X90JZjXP/5076-0-0-p43-afegir-el-camp-tarifa-comercialitzadora-al-pdf-de-la-factura)

## Comportament antic
No es mostrava

## Comportament nou
Es mostra

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul: `giscedata_facturacio_comer_som`
- [ ] Script de migració
- [ ] Modifica traduccions
