### PR TITLE
Canviar el camp teoric_maximum_consume_GC a la pestanya Facturació

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_validation.py
+++ b/som_facturacio_comer/giscedata_facturacio_validation.py
@@ -74,7 +74,7 @@ class GiscedataFacturacioValidationValidator(osv.osv):
             fact_obj = self.pool.get('giscedata.facturacio.factura')
 
             pol_obj = self.pool.get('giscedata.polissa')
-            teoric_maximum_consume_GC = pol_obj.read(cursor, uid, fact.polissa_id.id, ['teoric_maximum_consume_GC'])['teoric_maximum_consume_GC']
+            teoric_maximum_consume_gc = pol_obj.read(cursor, uid, fact.polissa_id.id, ['teoric_maximum_consume_gc'])['teoric_maximum_consume_gc']
 
             n_months = parameters['n_months']
             min_periods = parameters.get('min_periods', False)
@@ -95,7 +95,7 @@ class GiscedataFacturacioValidationValidator(osv.osv):
             if number_of_invoices > 0:
                 max_consume = max(parameter_by_date.values())
 
-            if (not max_consume or number_of_invoices < n_months) and (not teoric_maximum_consume_GC or teoric_maximum_consume_GC == 0):
+            if (not max_consume or number_of_invoices < n_months) and (not teoric_maximum_consume_gc or teoric_maximum_consume_gc == 0):
                 return {
                     'invoice_consume': fact.energia_kwh,
                 }
@@ -138,13 +138,13 @@ class GiscedataFacturacioValidationValidator(osv.osv):
                 max_consume = max(parameter_by_date.values())
 
             pol_obj = self.pool.get('giscedata.polissa')
-            teoric_maximum_consume_GC = pol_obj.read(cursor, uid, fact.polissa_id.id, ['teoric_maximum_consume_GC'])['teoric_maximum_consume_GC']
+            teoric_maximum_consume_gc = pol_obj.read(cursor, uid, fact.polissa_id.id, ['teoric_maximum_consume_gc'])['teoric_maximum_consume_gc']
 
             if not max_consume or number_of_invoices < n_months:
                 max_consume = False
 
-            if not max_consume and teoric_maximum_consume_GC and teoric_maximum_consume_GC > 0:
-                max_consume = teoric_maximum_consume_GC
+            if not max_consume and teoric_maximum_consume_gc and teoric_maximum_consume_gc > 0:
+                max_consume = teoric_maximum_consume_gc
 
             if max_consume:
                 percentage_margin = parameters['overuse_percentage']
@@ -156,7 +156,7 @@ class GiscedataFacturacioValidationValidator(osv.osv):
                         'percentage': percentage_margin,
                         'maximum_consume': max_consume,
                         'n_months': n_months,
-                        'maximum_teoric_consume_GC': teoric_maximum_consume_GC if teoric_maximum_consume_GC else 0,
+                        'maximum_teoric_consume_GC': teoric_maximum_consume_gc if teoric_maximum_consume_gc else 0,
                     }
 
         return None

--- a/som_facturacio_comer/giscedata_polissa.py
+++ b/som_facturacio_comer/giscedata_polissa.py
@@ -14,7 +14,7 @@ class GiscedataPolissa(osv.osv):
         'teoric_maximum_consume_GC': fields.float(
             digits=(8,2),
             string='Teoric maximum consume Grans Contractes',
-            help=u"Maximum consum teoric d'un contracte d'autoconsum associat a una validació.")
+            help=u"Màxim consum mensual teòric d'un contracte amb categoria Gran Consum associat a la validació SF03.")
     }
 
 GiscedataPolissa()

--- a/som_facturacio_comer/giscedata_polissa.py
+++ b/som_facturacio_comer/giscedata_polissa.py
@@ -5,13 +5,13 @@ from osv.osv import except_osv
 import datetime
 
 class GiscedataPolissa(osv.osv):
-    """Pòlissa per afegir el camp teoric_maximum_consume_GC.
+    """Pòlissa per afegir el camp teoric_maximum_consume_gc.
     """
     _name = 'giscedata.polissa'
     _inherit = 'giscedata.polissa'
 
     _columns = {
-        'teoric_maximum_consume_GC': fields.float(
+        'teoric_maximum_consume_gc': fields.float(
             digits=(8,2),
             string='Teoric maximum consume Grans Contractes',
             help=u"Màxim consum mensual teòric d'un contracte amb categoria Gran Consum associat a la validació SF03.")
@@ -25,7 +25,7 @@ class GiscedataPolissaModcontractual(osv.osv):
     _inherit = 'giscedata.polissa.modcontractual'
 
     _columns = {
-        'teoric_maximum_consume_GC': fields.float(digits=(8,2), string='Teoric maximum consume Grans Contractes')
+        'teoric_maximum_consume_gc': fields.float(digits=(8,2), string='Teoric maximum consume Grans Contractes')
     }
 
 

--- a/som_facturacio_comer/giscedata_polissa_view.xml
+++ b/som_facturacio_comer/giscedata_polissa_view.xml
@@ -10,7 +10,7 @@
             <field name="arch" type="xml">
                 <field name="deposit" position="after">
                     <group col="2" colspan="2">
-                        <field name="teoric_maximum_consume_GC" string="Teoric maximum consume GC" select="2" widget="char"/>
+                        <field name="teoric_maximum_consume_gc" string="Teoric maximum consume GC" select="2" widget="char"/>
                     </group>
                 </field>
             </field>

--- a/som_facturacio_comer/giscedata_polissa_view.xml
+++ b/som_facturacio_comer/giscedata_polissa_view.xml
@@ -8,9 +8,9 @@
 			<field name="priority">110</field>
             <field name="inherit_id" ref="giscedata_polissa.view_polisses_form"/>
             <field name="arch" type="xml">
-                <field name="cnae" position="after">
-                    <group col="4" colspan="4">
-                        <field name="teoric_maximum_consume_GC" string="Teoric maximum consume GC" select="2"/>
+                <field name="deposit" position="after">
+                    <group col="2" colspan="2">
+                        <field name="teoric_maximum_consume_GC" string="Teoric maximum consume GC" select="2" widget="char"/>
                     </group>
                 </field>
             </field>

--- a/som_facturacio_comer/giscedata_polissa_view.xml
+++ b/som_facturacio_comer/giscedata_polissa_view.xml
@@ -10,7 +10,7 @@
             <field name="arch" type="xml">
                 <field name="deposit" position="after">
                     <group col="2" colspan="2">
-                        <field name="teoric_maximum_consume_gc" string="Teoric maximum consume GC" select="2" widget="char"/>
+                        <field name="teoric_maximum_consume_gc" string="Teoric maximum consume GC" select="2"/>
                     </group>
                 </field>
             </field>

--- a/som_facturacio_comer/tests/tests_facturacio_warnings.py
+++ b/som_facturacio_comer/tests/tests_facturacio_warnings.py
@@ -152,7 +152,7 @@ class TestsFacturesValidation(testing.OOTestCase):
 
         pol = polissa_obj.browse(cursor, uid, polissa_id)
         pol.send_signal(['modcontractual'])
-        polissa_obj.write(cursor, uid, polissa_id, {'teoric_maximum_consume_GC': teoric_max})
+        polissa_obj.write(cursor, uid, polissa_id, {'teoric_maximum_consume_gc': teoric_max})
         wz_crear_mc_obj = pool.get('giscedata.polissa.crear.contracte')
 
         ctx = {'active_id': polissa_id}


### PR DESCRIPTION
## Objectiu
- Canviar el camp teoric_maximum_consume_GC a la pestanya Facturació
- Evitar el scroll de un camp númeric mostrant-lo com a char

## Targeta on es demana o Incidència 

https://trello.com/c/01PrRZI2/4910-0-4-p44-modif-camp-teoric-maximum-consume-per-categoria-gran-contracte

## Comportament antic
 El camp es trobava en la part del formulari comuna a pòlissa i es mostrava amb un scroll.

## Comportament nou
El camp s'ha canviat de lloc i es mostra com a un char evitant el scroll del númeric

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [X] Actualitzar mòdul
- som_facturacio_comer
- [ ] Script de migració
- [ ] Modifica traduccions
