### PR TITLE
Afegida variable `res.config` per ometre comprovació de factures en esborrany

### DIFF
--- a/giscedata_facturacio_som/__terp__.py
+++ b/giscedata_facturacio_som/__terp__.py
@@ -13,7 +13,8 @@
     "demo_xml": [],
     "update_xml":[
         "wizard/wizard_fraccionar_via_extralines_view.xml",
-        "wizard/wizard_model_list_from_file_data.xml"
+        "wizard/wizard_model_list_from_file_data.xml",
+        "giscedata_facturacio_data.xml",
     ],
     "active": False,
     "installable": True

--- a/giscedata_facturacio_som/giscedata_facturacio_data.xml
+++ b/giscedata_facturacio_som/giscedata_facturacio_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record model="res.config" id="dismiss_draft_inv_f1_payment" forcecreate="1">
+            <field name="name">dismiss_draft_inv_f1_payment</field>
+            <field name="value">1</field>
+            <field name="description">Permet evitar la comprovació de si hi ha factures en esborrany a una remesa d'F1. Si es deixa a 0, es fa la validació.</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu

 - Ometre comprovació de factures en esborrany mitjançant una variable de configuració
 - Requereix de https://github.com/gisce/erp/pull/14648

## Targeta on es demana o Incidència 
 
- https://secure.helpscout.net/conversation/1921269908/12579214?folderId=3101096

## Comportament antic

 - Des la versió 107.5 s'impedeix el pagament de la remesa si existeix alguna factura en esborrany
 
## Comportament nou

- Amb la variable a 1, s'omet la comprovació

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
    - `giscedata_facturacio_som` 
- [ ] Script de migració
- [ ] Modifica traduccions
