### PR TITLE
Afegir plantmeter a githubactions

### DIFF
--- a/.github/workflows/integration_config.yml
+++ b/.github/workflows/integration_config.yml
@@ -89,6 +89,7 @@ jobs:
           cd $ROOT_DIR_SRC/ooop
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
           pip install -e .
+          pip install somutils==1.7.2
           cd $ROOT_DIR_SRC/somenergia-generationkwh
           pip install -e . || "Not installing somenergia-generation Python package"
           cd $ROOT_DIR_SRC/plantmeter

--- a/.github/workflows/integration_config.yml
+++ b/.github/workflows/integration_config.yml
@@ -62,6 +62,7 @@ jobs:
           git clone --depth 1 git@github.com:Som-Energia/openerp_som_addons.git $ROOT_DIR_SRC/openerp_som_addons
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/gisce/erp.git -b developer $ROOT_DIR_SRC/erp
           git clone --depth 1 git@github.com:Som-Energia/somenergia-generationkwh.git $ROOT_DIR_SRC/somenergia-generationkwh
+          git clone --depth 1 https://github.com/Som-Energia/plantmeter.git $ROOT_DIR_SRC/plantmeter
           git clone --depth 1 git@github.com:gisce/oorq.git -b api_v5 $ROOT_DIR_SRC/oorq
           git clone --depth 1 git@github.com:gisce/spawn_oop.git $ROOT_DIR_SRC/spawn_oop
           git clone --depth 1 git@github.com:gisce/poweremail.git $ROOT_DIR_SRC/poweremail2
@@ -88,6 +89,10 @@ jobs:
           cd $ROOT_DIR_SRC/ooop
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
           pip install -e .
+          cd $ROOT_DIR_SRC/somenergia-generationkwh
+          pip install -e . || "Not installing somenergia-generation Python package"
+          cd $ROOT_DIR_SRC/plantmeter
+          pip install -e . || "Not installing plantmeter Python package"
           cd $ROOT_DIR_SRC
           pip install -r $ROOT_DIR_SRC/erp/requirements-dev.txt
           pip install -r $ROOT_DIR_SRC/erp/requirements.txt

--- a/.github/workflows/integration_config.yml
+++ b/.github/workflows/integration_config.yml
@@ -63,7 +63,6 @@ jobs:
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/gisce/erp.git -b developer $ROOT_DIR_SRC/erp
           git clone --depth 1 git@github.com:Som-Energia/somenergia-generationkwh.git $ROOT_DIR_SRC/somenergia-generationkwh
           git clone --depth 1 https://github.com/Som-Energia/plantmeter.git $ROOT_DIR_SRC/plantmeter
-          git clone --depth 1 https://github.com/Som-Energia/somenergia-utils.git $ROOT_DIR_SRC/somenergia-utils
           git clone --depth 1 git@github.com:gisce/oorq.git -b api_v5 $ROOT_DIR_SRC/oorq
           git clone --depth 1 git@github.com:gisce/spawn_oop.git $ROOT_DIR_SRC/spawn_oop
           git clone --depth 1 git@github.com:gisce/poweremail.git $ROOT_DIR_SRC/poweremail2
@@ -94,8 +93,6 @@ jobs:
           pip install -e . || "Not installing somenergia-generation Python package"
           cd $ROOT_DIR_SRC/plantmeter
           pip install -e . || "Not installing plantmeter Python package"
-          cd $ROOT_DIR_SRC/somenergia-utils
-          pip install -e . || "Not installing somenergia-utils Python package"
           cd $ROOT_DIR_SRC
           pip install -r $ROOT_DIR_SRC/erp/requirements-dev.txt
           pip install -r $ROOT_DIR_SRC/erp/requirements.txt

--- a/.github/workflows/integration_config.yml
+++ b/.github/workflows/integration_config.yml
@@ -63,6 +63,7 @@ jobs:
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/gisce/erp.git -b developer $ROOT_DIR_SRC/erp
           git clone --depth 1 git@github.com:Som-Energia/somenergia-generationkwh.git $ROOT_DIR_SRC/somenergia-generationkwh
           git clone --depth 1 https://github.com/Som-Energia/plantmeter.git $ROOT_DIR_SRC/plantmeter
+          git clone --depth 1 https://github.com/Som-Energia/somenergia-utils.git $ROOT_DIR_SRC/somenergia-utils
           git clone --depth 1 git@github.com:gisce/oorq.git -b api_v5 $ROOT_DIR_SRC/oorq
           git clone --depth 1 git@github.com:gisce/spawn_oop.git $ROOT_DIR_SRC/spawn_oop
           git clone --depth 1 git@github.com:gisce/poweremail.git $ROOT_DIR_SRC/poweremail2
@@ -93,6 +94,8 @@ jobs:
           pip install -e . || "Not installing somenergia-generation Python package"
           cd $ROOT_DIR_SRC/plantmeter
           pip install -e . || "Not installing plantmeter Python package"
+          cd $ROOT_DIR_SRC/somenergia-utils
+          pip install -e . || "Not installing somenergia-utils Python package"
           cd $ROOT_DIR_SRC
           pip install -r $ROOT_DIR_SRC/erp/requirements-dev.txt
           pip install -r $ROOT_DIR_SRC/erp/requirements.txt

--- a/som_facturacio_comer/tests/tests_wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_comer/tests/tests_wizard_refund_rectify_from_origin.py
@@ -221,3 +221,6 @@ class TestRefundRectifyFromOrigin(testing.OOTestCase):
             cursor, uid, wiz_id, fact_info['polissa_id'][0], fact_info['data_inici'], fact_info['data_final'], context=ctx
         )
         self.assertEqual(sorted(result[0]), sorted(f_cli_ids[:2]))
+
+    def test_dummy(self):
+        self.assertEqual(1,1)

--- a/som_facturacio_comer/tests/tests_wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_comer/tests/tests_wizard_refund_rectify_from_origin.py
@@ -221,6 +221,3 @@ class TestRefundRectifyFromOrigin(testing.OOTestCase):
             cursor, uid, wiz_id, fact_info['polissa_id'][0], fact_info['data_inici'], fact_info['data_final'], context=ctx
         )
         self.assertEqual(sorted(result[0]), sorted(f_cli_ids[:2]))
-
-    def test_dummy(self):
-        self.assertEqual(1,1)


### PR DESCRIPTION
## Objectiu
Afegir el repositori plantmeter a github actions. També instaŀlar-lo i instaŀlar el mòdul de gkwh

## Targeta on es demana o Incidència 


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
