### PR TITLE
Noves llistes de preus indexades

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -111,7 +111,7 @@ def is_6XTD(pol):
     return pol.tarifa.codi_ocsum in ('020', '021', '022', '023', '025')
 
 def is_indexed(fact):
-    return fact.llista_preu.name == 'Indexada'
+    return 'Indexada' in fact.llista_preu.name
 
 def val(object):
     try:


### PR DESCRIPTION
## Objectiu
Detectar com a indexades les indexades de Canàries i Balears

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1933708774/12648381?folderId=3904968

## Comportament antic
Només es detectava com a indexades les factures de les indexades de península.

## Comportament nou
Es detecten les indexades de canàries i balears

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
