### PR TITLE
Overwrite _create_tmp_zip and _get_b64_zip_files methods

### DIFF
--- a/som_switching/tests/__init__.py
+++ b/som_switching/tests/__init__.py
@@ -6,3 +6,4 @@ from tests_activacions_b1 import *
 from tests_activacions_b2 import *
 from tests_wizard_comment_to_F1 import *
 from tests_wizard_switching_b1 import *
+from tests_wizard_import_atr_and_f1 import *

--- a/som_switching/tests/tests_wizard_import_atr_and_f1.py
+++ b/som_switching/tests/tests_wizard_import_atr_and_f1.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from destral import testing
+from destral.transaction import Transaction
+import mock
+from datetime import datetime
+
+class TestWizardImportAtrAndF1(testing.OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.pool = self.openerp.pool
+
+    def tearDown(self):
+        self.txn.stop()
+    
+    @mock.patch('__builtin__.open')
+    def test__import_F1__originalName(self, mock_open):        
+        wiz_o = self.pool.get('wizard.import.atr.and.f1')
+        wiz_content = {'filename': 'nomFitxer'}
+        wiz_id = wiz_o.create(self.cursor, self.uid, wiz_content)
+
+        zip_handler = wiz_o._create_tmp_zip(self.cursor, self.uid, [wiz_id], 'testDirectory', 'F1_')
+
+        mock_open.assert_called_with('testDirectory/nomFitxer', 'w+')
+
+    @mock.patch('giscedata_switching.wizard.wizard_import_atr_and_f1.datetime')
+    @mock.patch('__builtin__.open')
+    def test__import_ATR__nameChanged(self, mock_open, mock_datetime):
+        wiz_o = self.pool.get('wizard.import.atr.and.f1')
+        wiz_content = {'filename': ''}
+        wiz_id = wiz_o.create(self.cursor, self.uid, wiz_content)
+        
+        today = datetime.strftime(datetime.today(), '%Y%m%d')
+        mock_datetime.strftime.return_value = today
+
+        zip_handler = wiz_o._create_tmp_zip(self.cursor, self.uid, wiz_id, 'testDirectory', 'ATR_')
+
+        filename = 'testDirectory/ATR_' + today + '.zip'
+        mock_open.assert_called_with(filename, 'w+')

--- a/som_switching/wizard/__init__.py
+++ b/som_switching/wizard/__init__.py
@@ -8,3 +8,4 @@ import wizard_comment_to_F1
 import giscedata_switching_mod_con_wizard
 import wizard_create_atc_from_polissa
 import giscedata_switching_wizard_b1
+import wizard_import_atr_and_f1

--- a/som_switching/wizard/wizard_import_atr_and_f1.py
+++ b/som_switching/wizard/wizard_import_atr_and_f1.py
@@ -1,0 +1,47 @@
+import zipfile
+import glob
+
+from osv import osv
+
+class WizardImportAtrAndF1(osv.osv_memory):
+
+    _name = 'wizard.import.atr.and.f1'
+    _inherit = 'wizard.import.atr.and.f1'
+
+    def _create_tmp_zip(self, cursor, uid, ids, directory, prefix, context=None):
+        """
+        Creates a temporal zip file and returns it's **opened** handler.
+        :param prefix: prefix of the temporal zip name
+        """
+
+        if prefix == 'F1_':
+            wizard = self.browse(cursor, uid, ids[0])
+            tmp_zip = open('{temporal_folder}/{filename}'.format(
+                temporal_folder = directory, pref=prefix,
+                filename = wizard.filename),
+                'w+'
+            )
+            zip_handler = zipfile.ZipFile(tmp_zip, 'w')
+        else:
+            zip_handler = super(WizardImportAtrAndF1, self)._create_tmp_zip(
+                cursor, uid, ids, directory, prefix, context
+            )
+
+        return zip_handler
+
+    @staticmethod
+    def _get_b64_zip_files(zip_path, context=None):
+
+        _type = context['type']
+        if _type == 'F1':
+            zip_filename = glob.glob(
+                '{path}/*.zip.b64'.format(path=zip_path)
+            )[0]
+        else:
+            zip_filename = super(WizardImportAtrAndF1, self)._get_b64_zip_files(
+                zip_path, context
+            )
+        with open(zip_filename, 'r') as zip_handler:
+            return zip_filename, zip_handler.read()
+
+WizardImportAtrAndF1()

--- a/som_switching/wizard/wizard_import_atr_and_f1.py
+++ b/som_switching/wizard/wizard_import_atr_and_f1.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import zipfile
 import glob
 
@@ -17,7 +18,7 @@ class WizardImportAtrAndF1(osv.osv_memory):
         if prefix == 'F1_':
             wizard = self.browse(cursor, uid, ids[0])
             tmp_zip = open('{temporal_folder}/{filename}'.format(
-                temporal_folder = directory, pref=prefix,
+                temporal_folder = directory,
                 filename = wizard.filename),
                 'w+'
             )
@@ -26,7 +27,6 @@ class WizardImportAtrAndF1(osv.osv_memory):
             zip_handler = super(WizardImportAtrAndF1, self)._create_tmp_zip(
                 cursor, uid, ids, directory, prefix, context
             )
-
         return zip_handler
 
     @staticmethod

--- a/som_switching/wizard/wizard_import_atr_and_f1.py
+++ b/som_switching/wizard/wizard_import_atr_and_f1.py
@@ -38,9 +38,9 @@ class WizardImportAtrAndF1(osv.osv_memory):
                 '{path}/*.zip.b64'.format(path=zip_path)
             )[0]
         else:
-            zip_filename = super(WizardImportAtrAndF1, self)._get_b64_zip_files(
-                zip_path, context
-            )
+            zip_filename = glob.glob(
+                '{path}/{type}_*.zip.b64'.format(path=zip_path, type=_type)
+            )[0]
         with open(zip_filename, 'r') as zip_handler:
             return zip_filename, zip_handler.read()
 


### PR DESCRIPTION
## Objectiu
Que es mantingui el nom del fitxer original quan s'importan F1s amb el wizard_import_atr_and_f1

## Targeta on es demana o Incidència 
https://trello.com/c/DqBwJiEj/5183-0-0-p26-ep259conservar-el-nom-dels-paquets-df1ns-quan-importem-per-la-porta-atr

## Comportament antic
Quan s'importavan els fitxers F1 i ATR amb el wizard_import_atr_and_f1 el nom del fitxer original es canviava

## Comportament nou
Es mante el nom del fitxer original només en el cas del F1s. 

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
