### PR TITLE
Afegir límit correus lot per enviar i poder eliminar els correus de la bústia

### DIFF
--- a/som_infoenergia/som_enviament_massiu.py
+++ b/som_infoenergia/som_enviament_massiu.py
@@ -141,6 +141,14 @@ class SomEnviamentMassiu(osv.osv):
                     self.add_info_line(cursor, uid, _id, "Correu enviat", context)
         return True
 
+    def poweremail_unlink_callback(self, cursor, uid, ids, vals, context=None):
+        """Hook que cridarà el poweremail quan s'esborra un email
+        d'un enviament.
+        """
+        for _id in ids:
+            self.write(cursor, uid, _id, {'estat':'obert'})
+            self.add_info_line(cursor, uid, _id, "Correu eliminat de la bústia", context)
+        return True
 
     _columns = {
         'polissa_id': fields.many2one('giscedata.polissa', _('Contracte'),
@@ -168,7 +176,7 @@ class SomEnviamentMassiu(osv.osv):
             ondelete='restrict',
             select=True),
         'mail_id': fields.many2one(
-            'poweremail.mailbox', 'Mail'
+            'poweremail.mailbox', 'Mail', ondelete='set null'
         ),
         'data_enviament':  fields.date(_("Data enviament"), allow_none=True),
         'info': fields.text(_(u'Informació Adicional'),

--- a/som_infoenergia/som_infoenergia_data.xml
+++ b/som_infoenergia/som_infoenergia_data.xml
@@ -302,6 +302,34 @@
     </html>
         ]]></field>
         </record>
+        <record model="poweremail.templates" id="correu_titular_pagador_diferents">
+            <field name="name">Correu Titular i Pagador diferents</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'som.enviament.massiu')]"/>
+            <field eval="0" name="save_to_drafts"/>
+            <field name="model_int_name">som.enviament.massiu</field>
+            <field eval="0" name="use_filter"/>
+            <field name="def_to">${object.polissa_id.titular.address[0].email},${object.polissa_id.pagador.address[0].email}</field>
+            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field name="def_cc"></field>
+            <field eval="0" name="auto_email"/>
+            <field eval="0" name="use_sign"/>
+            <field name="def_subject">Dades titular i fiscals</field>
+            <field name="template_language">mako</field>
+	    <field name="enforce_from_account" model="poweremail.core_accounts" search="[('email_id','=', 'modifica@somenergia.coop')]" />
+            <field eval="0" name="send_on_create"/>
+            <field name="lang">${object.polissa_id.titular.lang}</field>
+            <field eval="0" name="send_on_write"/>
+            <field name="def_body_text">
+    <![CDATA[
+    <!doctype html>
+    <html>
+    <head></head>
+    <body>
+    Avís pagador i titular diferents
+    </body>
+    </html>
+        ]]></field>
+        </record>
     </data>
     <data noupdate="1">
         <record model="res.config" id="infoenergia_send_tasks_max_procs">

--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -297,6 +297,15 @@ class SomInfoenergiaEnviament(osv.osv):
                     self.add_info_line(cursor, uid, _id, "Correu enviat", context)
         return True
 
+    def poweremail_unlink_callback(self, cursor, uid, ids, vals, context=None):
+        """Hook que cridarà el poweremail quan s'esborra un email
+        d'un enviament.
+        """
+        for _id in ids:
+            self.write(cursor, uid, _id, {'estat':'obert'})
+            self.add_info_line(cursor, uid, _id, "Correu eliminat de la bústia", context)
+        return True
+
     def resend_email(self, cursor, uid, id, context=None):
         md_obj = self.pool.get('ir.model.data')
         view_id = md_obj.get_object_reference(
@@ -357,7 +366,7 @@ class SomInfoenergiaEnviament(osv.osv):
             ondelete='restrict',
             select=True),
         'mail_id': fields.many2one(
-            'poweremail.mailbox', 'Mail'
+            'poweremail.mailbox', 'Mail', ondelete='set null'
         ),
         'tipus_informe_lot': fields.related('lot_enviament', 'tipus_informe',
             type='char',

--- a/som_infoenergia/wizard/wizard_send_reports_view.xml
+++ b/som_infoenergia/wizard/wizard_send_reports_view.xml
@@ -13,10 +13,12 @@
                         <label string="S'enviaran els reports pendents del lot (el procés es farà en segon pla)." colspan="4" />
                         <label string="" colspan="4"/>
                         <field name="allow_reenviar" widget="boolean"/>
+                        <field name="n_max_mails"/>
                         <group attrs="{'invisible': [('is_test', '=', False)]}" colspan="4" >
                             <separator string="Enviament de test" colspan="4"/>
                             <field name="email_to" colspan="4" width="500"/>
                             <field name="email_subject" colspan="4" width="500"/>
+                            <label string="Els correus s'enviaran exactament amb aquest assumpte (sense traduir)" colspan="4" />
                         </group>
                     </group>
                     <group colspan="6" attrs="{'invisible': [('state', '=', 'finished')]}">
@@ -30,7 +32,7 @@
             </field>
         </record>
         <record model="ir.actions.act_window" id="action_wizard_send_report_lot">
-            <field name="name">Enviament reports Infoenergia del lot</field>
+            <field name="name">Enviament correus del lot</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">wizard.infoenergia.send.reports</field>
             <field name="view_type">form</field>
@@ -41,7 +43,7 @@
         </record>
         <record id="values_infoenergia_send_report_lot_form" model="ir.values">
             <field name="object" eval="1"/>
-            <field name="name">Envia reports Infoenergia del lot</field>
+            <field name="name">Envia correus del lot</field>
             <field name="key2">client_action_multi</field>
             <field name="key">action</field>
             <field name="model">som.infoenergia.lot.enviament</field>

--- a/som_infoenergia/wizard/wizard_send_reports_view.xml
+++ b/som_infoenergia/wizard/wizard_send_reports_view.xml
@@ -53,7 +53,7 @@
             <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_send_report_lot'))"/>
         </record>
         <record model="ir.actions.act_window" id="action_wizard_send_reports">
-            <field name="name">Enviament report Infoenergia</field>
+            <field name="name">Enviament correu</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">wizard.infoenergia.send.reports</field>
             <field name="view_type">form</field>
@@ -64,7 +64,7 @@
         </record>
         <record id="values_infoenergia_send_report_form" model="ir.values">
             <field name="object" eval="1"/>
-            <field name="name">Enviament report Infoenergia</field>
+            <field name="name">Enviament correu</field>
             <field name="key2">client_action_multi</field>
             <field name="key">action</field>
             <field name="model">som.infoenergia.enviament</field>

--- a/som_infoenergia/wizard/wizard_send_reports_view.xml
+++ b/som_infoenergia/wizard/wizard_send_reports_view.xml
@@ -9,11 +9,14 @@
                 <form string="Envia reports Infoenergia">
                     <field name="state" invisible="1"/>
                     <field name="is_test" invisible="1"/>
+                    <field name="is_from_lot" invisible="1"/>
                     <group attrs="{'invisible': [('state', '!=', 'init')]}" colspan="4">
                         <label string="S'enviaran els reports pendents del lot (el procés es farà en segon pla)." colspan="4" />
                         <label string="" colspan="4"/>
                         <field name="allow_reenviar" widget="boolean"/>
-                        <field name="n_max_mails"/>
+                        <group attrs="{'invisible': [('is_from_lot', '=', False)]}" colspan="2" >
+                            <field name="n_max_mails"/>
+                        </group>
                         <group attrs="{'invisible': [('is_test', '=', False)]}" colspan="4" >
                             <separator string="Enviament de test" colspan="4"/>
                             <field name="email_to" colspan="4" width="500"/>


### PR DESCRIPTION
## Objectiu
- Poder assignar un màxim de correus que s'enviaran
- Canviar nom del wizard
- Afegir una plantilla per mort al pagador
- Setejar ondelete='set null' per poder eliminar correus associats als enviaments.
- Implementar el poweremail_unlink_callback per marcar com a Obert els enviaments si s'esborra el correu.

## Targeta on es demana o Incidència 
https://trello.com/c/y4eKLFSs/5228-0-0-p16-deadline-script-i-enviament-de-correus-mort-al-pagador-3464-contractes

## Comportament antic
- S'enviaven sempre tots els correus
- El wizard tenia un nom que generava confusió
- No es podien eliminar els correus.

## Comportament nou
- Es pot assignar un màxim de correus que s'enviaran.
- Es poden eliminar els correus de la bústia del poweremail.

## Comprovacions

- [X] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
