### PR TITLE
Remove subfolder from file_name and unit tests added

### DIFF
--- a/som_switching/tests/tests_wizard_import_atr_and_f1.py
+++ b/som_switching/tests/tests_wizard_import_atr_and_f1.py
@@ -26,6 +26,16 @@ class TestWizardImportAtrAndF1(testing.OOTestCase):
 
         mock_open.assert_called_with('testDirectory/nomFitxer', 'w+')
 
+    @mock.patch('__builtin__.open')
+    def test__import_F1_subfolder__originalName(self, mock_open):
+        wiz_o = self.pool.get('wizard.import.atr.and.f1')
+        wiz_content = {'filename': '25_07_2022/nomFitxer'}
+        wiz_id = wiz_o.create(self.cursor, self.uid, wiz_content)
+
+        zip_handler = wiz_o._create_tmp_zip(self.cursor, self.uid, [wiz_id], 'testDirectory', 'F1_')
+
+        mock_open.assert_called_with('testDirectory/nomFitxer', 'w+')
+
     @mock.patch('giscedata_switching.wizard.wizard_import_atr_and_f1.datetime')
     @mock.patch('__builtin__.open')
     def test__import_ATR__nameChanged(self, mock_open, mock_datetime):

--- a/som_switching/wizard/wizard_import_atr_and_f1.py
+++ b/som_switching/wizard/wizard_import_atr_and_f1.py
@@ -17,9 +17,12 @@ class WizardImportAtrAndF1(osv.osv_memory):
 
         if prefix == 'F1_':
             wizard = self.browse(cursor, uid, ids[0])
+            tmp_filename = wizard.filename
+            if '/' in tmp_filename:
+                tmp_filename = tmp_filename.split('/')[-1] #when file from massive_importer file_name can contains subfolders
             tmp_zip = open('{temporal_folder}/{filename}'.format(
                 temporal_folder = directory,
-                filename = wizard.filename),
+                filename = tmp_filename),
                 'w+'
             )
             zip_handler = zipfile.ZipFile(tmp_zip, 'w')


### PR DESCRIPTION
## Objectiu
Treure el la referencia a la subcarpeta del nom del fitxer perque el wizard pugui trobar el fitxer temporal.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1955459970/12893351?folderId=3063374

## Comportament antic
Quan el wizard es cridat des del massive-importer el nom del fitxer conté la subcarpeta on s'ha guardat el fitxer (dia de baixada). El wizard guarda els fitxers xmls a pujar a l'erp en una carpeta temporal utilitzant el contingut del minio, no el nom del fitxer que té la subcarpeta com a part del nom. En un següent pass el wizard agafa els fitxers temporals per crear un zip i en aquesta funció si es té en compta el nom del fitxer per poder crear el zip amb el nom original, però la búsqueda del fitxer falla perquè busca una subcarpeta.

## Comportament nou
Quan es va crear el zip amb el nom original es treu el nom de la subcarpeta del nom del fitxer, si es que en té.

## Comprovacions

- [X] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
