### PR TITLE
Add f1 to original file name

### DIFF
--- a/som_switching/tests/tests_wizard_import_atr_and_f1.py
+++ b/som_switching/tests/tests_wizard_import_atr_and_f1.py
@@ -24,7 +24,7 @@ class TestWizardImportAtrAndF1(testing.OOTestCase):
 
         zip_handler = wiz_o._create_tmp_zip(self.cursor, self.uid, [wiz_id], 'testDirectory', 'F1_')
 
-        mock_open.assert_called_with('testDirectory/nomFitxer', 'w+')
+        mock_open.assert_called_with('testDirectory/F1_nomFitxer', 'w+')
 
     @mock.patch('__builtin__.open')
     def test__import_F1_subfolder__originalName(self, mock_open):
@@ -34,7 +34,7 @@ class TestWizardImportAtrAndF1(testing.OOTestCase):
 
         zip_handler = wiz_o._create_tmp_zip(self.cursor, self.uid, [wiz_id], 'testDirectory', 'F1_')
 
-        mock_open.assert_called_with('testDirectory/nomFitxer', 'w+')
+        mock_open.assert_called_with('testDirectory/F1_nomFitxer', 'w+')
 
     @mock.patch('giscedata_switching.wizard.wizard_import_atr_and_f1.datetime')
     @mock.patch('__builtin__.open')

--- a/som_switching/wizard/wizard_import_atr_and_f1.py
+++ b/som_switching/wizard/wizard_import_atr_and_f1.py
@@ -20,8 +20,9 @@ class WizardImportAtrAndF1(osv.osv_memory):
             tmp_filename = wizard.filename
             if '/' in tmp_filename:
                 tmp_filename = tmp_filename.split('/')[-1] #when file from massive_importer file_name can contains subfolders
-            tmp_zip = open('{temporal_folder}/{filename}'.format(
+            tmp_zip = open('{temporal_folder}/{pref}{filename}'.format(
                 temporal_folder = directory,
+                pref=prefix,
                 filename = tmp_filename),
                 'w+'
             )
@@ -31,20 +32,5 @@ class WizardImportAtrAndF1(osv.osv_memory):
                 cursor, uid, ids, directory, prefix, context
             )
         return zip_handler
-
-    @staticmethod
-    def _get_b64_zip_files(zip_path, context=None):
-
-        _type = context['type']
-        if _type == 'F1':
-            zip_filename = glob.glob(
-                '{path}/*.zip.b64'.format(path=zip_path)
-            )[0]
-        else:
-            zip_filename = glob.glob(
-                '{path}/{type}_*.zip.b64'.format(path=zip_path, type=_type)
-            )[0]
-        with open(zip_filename, 'r') as zip_handler:
-            return zip_filename, zip_handler.read()
 
 WizardImportAtrAndF1()


### PR DESCRIPTION
## Objectiu
Afegir F1 al nom del fitxer

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1955459970/12893351?folderId=3063374

## Comportament antic
El nom del fitxer no contenia F1 i a l'hora de buscar el fitxer en el directory per pujar-lo a l'erp agafava el primer que trobés.

## Comportament nou
El fitxer es cercat considerant el tipus F1 o ATR (el zip comença amb F1 o ATR)

## Comprovacions

- [X] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
