### PR TITLE
FIX: ids repetits feien que desaparegués l'acció des de pòlissa

### DIFF
--- a/som_infoenergia/wizard/wizard_create_enviaments_from_object_view.xml
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_object_view.xml
@@ -59,7 +59,7 @@
             <field name="model">res.partner</field>
             <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_create_enviaments_from_partner'))"/>
         </record>
-        <record model="ir.actions.act_window" id="action_wizard_create_enviaments_from_object">
+        <record model="ir.actions.act_window" id="action_wizard_create_enviaments_from_invoice">
             <field name="name">Afegir factures al Lot d'Enviaments Infoenergia/Massiu</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">wizard.infoenergia.create.enviaments.from.object</field>
@@ -69,13 +69,13 @@
             <field name="view_id" ref="view_wizard_create_enviaments_from_object_form"/>
             <field name="context">{'from_model':'invoice_id'}</field>
         </record>
-        <record id="values_wizard_create_enviaments_from_object_form" model="ir.values">
+        <record id="values_wizard_create_enviaments_from_invoice_form" model="ir.values">
             <field name="object" eval="1"/>
             <field name="name">Afegir factures al Lot d'Enviaments Infoenergia/Massiu</field>
             <field name="key2">client_action_multi</field>
             <field name="key">action</field>
             <field name="model">account.invoice</field>
-            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_create_enviaments_from_object'))"/>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_create_enviaments_from_invoice'))"/>
         </record>
     </data>
 </openerp>

--- a/som_infoenergia/wizard/wizard_send_reports_view.xml
+++ b/som_infoenergia/wizard/wizard_send_reports_view.xml
@@ -21,7 +21,7 @@
                             <separator string="Enviament de test" colspan="4"/>
                             <field name="email_to" colspan="4" width="500"/>
                             <field name="email_subject" colspan="4" width="500"/>
-                            <label string="Els correus s'enviaran exactament amb aquest assumpte (sense traduir)" colspan="4" />
+                            <label string="Els correus de test s'enviaran exactament amb aquest assumpte (sense traduir)" colspan="4" />
                         </group>
                     </group>
                     <group colspan="6" attrs="{'invisible': [('state', '=', 'finished')]}">


### PR DESCRIPTION
## Objectiu
Arreglar l'error que feia que desaparegués l'acció "Afegir pòlisses a lot infoenergia/enviament"

## Targeta on es demana o Incidència 


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
