### PR TITLE
[MAJ] Fer readonly el camp de pòlissa de `coef_repercusio_gas`

### DIFF
--- a/som_facturacio_comer/__terp__.py
+++ b/som_facturacio_comer/__terp__.py
@@ -15,6 +15,7 @@
         "som_polissa",
         "som_switching",
         "som_generationkwh",
+        "giscedata_repercussio_mecanismo_ajuste_gas",
     ],
     "init_xml": [],
     "demo_xml": [],
@@ -28,6 +29,7 @@
         "giscedata_facturacio_factura_view.xml",
         "giscedata_facturacio_data.xml",
         "giscedata_lectures_view.xml",
+        "giscedata_polissa_view.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_comer/giscedata_polissa_view.xml
+++ b/som_facturacio_comer/giscedata_polissa_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+	<data>
+        <!-- Fer readonly el camp del MAG de pòlissa-->
+        <record model="ir.ui.view" id="giscedata_polissa_mag_readonly_som_tree">
+            <field name="name">giscedata.polissa.mag.readonly.som.tree</field>
+            <field name="model">giscedata.polissa</field>
+            <field name="type">tree</field>
+            <field name="inherit_id" ref="giscedata_repercussio_mecanismo_ajuste_gas.view_giscedata_polissa_form"/>
+            <field name="arch" type="xml">
+                <field name="coef_repercusio_gas" position="replace" >
+                    <field name="coef_repercusio_gas" readonly="1"/>
+                </field>
+            </field>
+        </record>
+	</data>
+</openerp>


### PR DESCRIPTION
## Dendències
Depèn de que el mecanisme de facturació per repercutir el preu de l'ajust del gas en tarifa fixa estigui instal·lat

## Objectiu
Fer readonly el camp de pòlissa de `coef_repercusio_gas`, ja que nosaltres utilitzarem la llista de preus per configurar aquest nou preu. 

## Targeta on es demana o Incidència 
https://trello.com/c/hEyJMXcl/5222-0-2-p23-ep286-configurar-m%C3%B2dul-mecanismo-ajuste-gas-indexat

## Comportament antic
El camp era editable i fent scroll per sobre la fitxa era fàcil canviar-ne el valor.

## Comportament nou
El camp és readonly

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul : som_switching
- [ ] Script de migració
- [ ] Modifica traduccions
