### PR TITLE
Mostrar correctament el detall de Generation quan hi ha dos préstecs.

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1825,14 +1825,18 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
             days_per_year = is_leap_year(datetime.strptime(l.data_desde, '%Y-%m-%d').year) and 366 or 365
 
-            lines_data[block][l.name] = {
-                'quantity': l.quantity,
-                'atr_price': self.get_atr_price( fact, pol.llista_preu.id, l),
-                'price_subtotal': l.price_subtotal,
-                'price_unit_multi': l.price_unit_multi,
-                'price_unit': l.price_unit,
-                'extra': l.multi,
-            }
+            if lines_data.has_key(block) and lines_data[block].has_key(l.name):
+                linies_data[block][l.name]['quantity'] = linies_data[block][l.name]['quantity'] + l.quantity
+                linies_data[block][l.name]['price_subtotal'] = linies_data[block][l.name]['price_subtotal'] + l.price_subtotal
+            else:
+                lines_data[block][l.name] = {
+                    'quantity': l.quantity,
+                    'atr_price': self.get_atr_price( fact, pol.llista_preu.id, l),
+                    'price_subtotal': l.price_subtotal,
+                    'price_unit_multi': l.price_unit_multi,
+                    'price_unit': l.price_unit,
+                    'extra': l.multi,
+                }
             lines_data[block]['multi'] = l.multi
             lines_data[block]['days_per_year'] = days_per_year
             lines_data[block]['total'] += l.price_subtotal


### PR DESCRIPTION
## Objectiu
Mostrar correctament el detall de Generation quan hi ha dos préstecs que aporten kwh en una factura.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1982239566/13041507/

## Comportament antic
Quan hi havia dos préstecs aportant kwh al Generationkwh, no es mostraven correctament al PDF. Sortia el total correcte però el detall només del darrer préstec.
![image](https://user-images.githubusercontent.com/26488435/186622488-7934e674-7450-40b4-999d-86420324d27d.png)

## Comportament nou
Tant el parcial com el total surt correctament.
![image](https://user-images.githubusercontent.com/26488435/186638180-b2977700-17a4-4253-955b-1b029d696477.png)

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
