### PR TITLE
Arreglar factura quan no es troba telèfon de la distri

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -546,12 +546,15 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         partner_id = sw_obj.partner_map(self.cursor, self.uid,
                                         polissa.cups, polissa.distribuidora.id)
-        if partner_id:
-            pa_ids = pa_obj.search(self.cursor, self.uid, [('partner_id', '=', partner_id)])
-            return (pa_obj.read(self.cursor, self.uid, [pa_ids[0]],['phone'])[0]['phone'] or
-                    polissa.distribuidora.address[0].phone)
-        else:
-            return polissa.distribuidora.address[0].phone
+        try:
+            if partner_id:
+                pa_ids = pa_obj.search(self.cursor, self.uid, [('partner_id', '=', partner_id)])
+                return (pa_obj.read(self.cursor, self.uid, [pa_ids[0]],['phone'])[0]['phone'] or
+                        polissa.distribuidora.address[0].phone)
+            else:
+                return polissa.distribuidora.address[0].phone
+        except:
+            return polissa.distribuidora.www_phone
 
     def get_atr_price(self, fact, tarifa, linia):
         pricelist_obj = linia.pool.get('product.pricelist')


### PR DESCRIPTION
## Objectiu
Que es pugui imprimir factura quan hi ha problemes per trobar el telèfon d'incidències de la distri

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1993917151/13101852?folderId=3063411

## Comportament antic
Si no es trobava telèfon, no s'imprimia la factura.

## Comportament nou
Ara s'imprimeix sempre.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
