### PR TITLE
FIX: poder cancel·lar pòlisses de baixa i emplenar amb 0 a l'esquerra el nom de les pòlisses

### DIFF
--- a/som_infoenergia/som_infoenergia_lot.py
+++ b/som_infoenergia/som_infoenergia_lot.py
@@ -278,7 +278,7 @@ class SomInfoenergiaLotEnviament(osv.osv):
         elif tipus == 'altres':
             env_obj = self.pool.get('som.enviament.massiu')
 
-        env_ids = env_obj.search(cursor, uid, [('lot_enviament','=', ids), ('polissa_id.name', 'in', polissa_name_list)])
+        env_ids = env_obj.search(cursor, uid, [('lot_enviament','=', ids), ('polissa_id.name', 'in', polissa_name_list)], context={'active_test': False})
         env_obj.write(cursor, uid, env_ids, {'estat': 'cancellat'})
         env_obj.add_info_line(cursor, uid, env_ids, u'Enviament cancel·lat per ' + context['reason'])
 

--- a/som_infoenergia/som_infoenergia_lot.py
+++ b/som_infoenergia/som_infoenergia_lot.py
@@ -278,7 +278,9 @@ class SomInfoenergiaLotEnviament(osv.osv):
         elif tipus == 'altres':
             env_obj = self.pool.get('som.enviament.massiu')
 
-        env_ids = env_obj.search(cursor, uid, [('lot_enviament','=', ids), ('polissa_id.name', 'in', polissa_name_list)], context={'active_test': False})
+        env_ids = env_obj.search(cursor, uid, [
+            ('lot_enviament','=', ids), ('polissa_id.name', 'in', polissa_name_list)
+        ], context={'active_test': False})
         env_obj.write(cursor, uid, env_ids, {'estat': 'cancellat'})
         env_obj.add_info_line(cursor, uid, env_ids, u'Enviament cancel·lat per ' + context['reason'])
 

--- a/som_infoenergia/tests/test_lot_enviament.py
+++ b/som_infoenergia/tests/test_lot_enviament.py
@@ -380,6 +380,29 @@ class LotEnviamentTests(testing.OOTestCase):
         self.assertEqual(cancellats_post, cancellats_pre + 3)
         mock_add_info.assert_called_with(self.cursor, self.uid, mock.ANY, 'Enviament cancel·lat per Test cancel from polissa list')
 
+    @mock.patch('som_infoenergia.som_enviament_massiu.SomEnviamentMassiu.add_info_line')
+    def test_cancel_enviaments_from_polissa_names_polissaInactiva(self, mock_add_info):
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+        cursor = self.cursor
+        uid = self.uid
+        lot_enviament_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_infoenergia', 'lot_enviament_0002'
+        )[1]
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        pol_id = pol_obj.search(cursor, uid, [('name','=','0001C')])[0]
+        pol_obj.write(cursor, uid, pol_id, {'active': False})
+        lot_enviament = lot_env_obj.browse(cursor, uid, lot_enviament_id)
+        cancellats_pre = lot_enviament.total_cancelats
+
+        lot_enviament.cancel_enviaments_from_polissa_names(['0001C','0002'], {'reason': 'Test cancel from polissa list'})
+
+        lot_enviament = lot_env_obj.browse(cursor, uid, lot_enviament_id)
+        cancellats_post = lot_enviament.total_cancelats
+        self.assertEqual(cancellats_post, cancellats_pre + 2)
+        mock_add_info.assert_called_with(self.cursor, self.uid, mock.ANY, 'Enviament cancel·lat per Test cancel from polissa list')
+
+
     def test_ff_totals_ff_progress_altres(self):
         imd_obj = self.openerp.pool.get('ir.model.data')
         lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')

--- a/som_infoenergia/tests/test_wizards.py
+++ b/som_infoenergia/tests/test_wizards.py
@@ -263,6 +263,11 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
         imd_obj = self.openerp.pool.get('ir.model.data')
         env_obj = self.openerp.pool.get('som.infoenergia.enviament')
         lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        pol_id = pol_obj.search(self.cursor, self.uid, [], limit=1, order='id asc')[0]
+        pol_obj.write(self.cursor, self.uid, pol_id, {'name': '0001'})
+
         csv_content = "0001"
         encoded_csv = base64.b64encode(csv_content)
         vals = {
@@ -292,6 +297,11 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
         imd_obj = self.openerp.pool.get('ir.model.data')
         env_obj = self.openerp.pool.get('som.infoenergia.enviament')
         lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        pol_id = pol_obj.search(self.cursor, self.uid, [], limit=1, order='id asc')[0]
+        pol_obj.write(self.cursor, self.uid, pol_id, {'name': '0001'})
+
         csv_content = "0001\n0002"
         encoded_csv = base64.b64encode(csv_content)
         vals = {
@@ -322,6 +332,11 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
         imd_obj = self.openerp.pool.get('ir.model.data')
         env_obj = self.openerp.pool.get('som.infoenergia.enviament')
         lot_env_obj = self.openerp.pool.get('som.infoenergia.lot.enviament')
+
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        pol_id = pol_obj.search(self.cursor, self.uid, [], limit=1, order='id asc')[0]
+        pol_obj.write(self.cursor, self.uid, pol_id, {'name': '0001'})
+
         csv_content = "1\n2"
         encoded_csv = base64.b64encode(csv_content)
         vals = {
@@ -334,7 +349,6 @@ class WizardCancelFromCSVTestsAndAddContractsLot(testing.OOTestCase):
         ctx = {
             'active_id': lot_enviament_id, 'active_ids': [lot_enviament_id],
         }
-        env_ids = env_obj.search(self.cursor, self.uid, [('lot_enviament', '=', lot_enviament_id), ('polissa_id.name', '=', '0001')])
         wiz_id = wiz_obj.create(self.cursor, self.uid, vals,context=ctx)
 
         wiz_obj.cancel_from_file(self.cursor, self.uid, [wiz_id], context=ctx)

--- a/som_infoenergia/wizard/wizard_cancel_from_csv.py
+++ b/som_infoenergia/wizard/wizard_cancel_from_csv.py
@@ -30,7 +30,11 @@ class WizardCancelFromCSV(osv.osv_memory):
             context = {}
         lot_obj = self.pool.get('som.infoenergia.lot.enviament')
         pol_obj = self.pool.get('giscedata.polissa')
-        example_name = pol_obj.read(cursor, uid, pol_obj.search([], limit=1)[0], ['name'])['name']
+        example_name = pol_obj.read(
+            cursor, uid,
+            pol_obj.search(cursor, uid, [], limit=1, order='id asc')[0],
+            ['name']
+        )['name']
         wiz = self.browse(cursor, uid, ids[0], context=context)
 
         context['reason'] = wiz.reason

--- a/som_infoenergia/wizard/wizard_cancel_from_csv.py
+++ b/som_infoenergia/wizard/wizard_cancel_from_csv.py
@@ -29,11 +29,14 @@ class WizardCancelFromCSV(osv.osv_memory):
         if context is None:
             context = {}
         lot_obj = self.pool.get('som.infoenergia.lot.enviament')
+        pol_obj = self.pool.get('giscedata.polissa')
+        example_name = pol_obj.read(cursor, uid, pol_obj.search([], limit=1)[0], ['name'])['name']
         wiz = self.browse(cursor, uid, ids[0], context=context)
+
         context['reason'] = wiz.reason
         csv_file = StringIO(base64.b64decode(wiz.csv_file))
         reader = csv.reader(csv_file)
-        pol_list = [line[0] for line in list(reader)]
+        pol_list = [line[0].zfill(len(example_name)) for line in list(reader)]
 
         lot_id = context.get('active_id', [])
         lot_obj.cancel_enviaments_from_polissa_names(cursor, uid, lot_id, pol_list, context)

--- a/som_infoenergia/wizard/wizard_cancel_from_csv_view.xml
+++ b/som_infoenergia/wizard/wizard_cancel_from_csv_view.xml
@@ -10,6 +10,8 @@
                     <field name="state" invisible="1"/>
                     <group attrs="{'invisible': [('state', '!=', 'init')]}">
                         <label string="Cancel·lar enviaments de les pòlisses indicades al CSV" colspan="4"/>
+                        <label string="A la primera columna hi ha d'haver els números de contracte sense capçalera" colspan="4"/>
+                        <label string="(afegeix 0 a l'esquerra als números de pòlissa si en falten)" colspan="4"/>
                         <field name="csv_file" colspan="4" filename="name" string="Arxiu CSV"/>
                         <field name="reason" string="Motiu" colspan="4" width="500" />
                         <button name="cancel_from_file" type="object" string="Cancel·lar enviaments" icon="gtk-ok"/>


### PR DESCRIPTION
## Objectiu
poder cancel·lar pòlisses de baixa i emplenar amb 0 a l'esquerra el nom de les pòlisses

## Targeta on es demana o Incidència 
Incidència trobada mentre es feia la targeta: https://trello.com/c/t1ehaJPk/5277-0-0-p16-deadline-partida-enviament-de-correus-mort-al-pagador-3464-contractes

## Comportament antic
- Si la pòlissa està `active=False` no la trobava per canceŀlar-la.
- Si les pòlisses no tenen els 0 a l'esquerra no les troba. Freqüent quan l'usuària obre el CSV amb un editor per poder manipular-lo.

## Comportament nou
Es canceŀlen els enviaments de pòlisses de baixa.
No és imprescindible que els núm de pòlissa tinguin tots els 0 davant.

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
