### PR TITLE
New kallinfo module

### DIFF
--- a/callinfo/__init__.py
+++ b/callinfo/__init__.py
@@ -1,1 +1,2 @@
 import call_info_call_log
+import call_info_call_category

--- a/callinfo/__init__.py
+++ b/callinfo/__init__.py
@@ -1,0 +1,1 @@
+import call_info_call_log

--- a/callinfo/__terp__.py
+++ b/callinfo/__terp__.py
@@ -16,6 +16,7 @@
     "init_xml": [],
     "demo_xml": [],
     "update_xml":[
+        "call_info_call_log_view.xml",
         "security/ir.model.access.csv",
     ],
     "active": False,

--- a/callinfo/__terp__.py
+++ b/callinfo/__terp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Suport a app callinfo",
+    "description": """
+    This module provide :
+        * Model enmagatzemament
+        * Vistes associades
+    """,
+    "version": "0-dev",
+    "author": "SOM ENERGIA",
+    "category": "SomEnergia",
+    "depends":[
+        "base",
+        "giscedata_atc_switching",
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml":[
+        "security/ir.model.access.csv",
+    ],
+    "active": False,
+    "installable": True
+}

--- a/callinfo/__terp__.py
+++ b/callinfo/__terp__.py
@@ -11,12 +11,14 @@
     "category": "SomEnergia",
     "depends":[
         "base",
-        "giscedata_atc_switching",
+        "som_autoreclama",
     ],
     "init_xml": [],
     "demo_xml": [],
     "update_xml":[
         "call_info_call_log_view.xml",
+        "call_info_call_category_view.xml",
+        "call_info_call_category_data.xml",
         "security/ir.model.access.csv",
     ],
     "active": False,

--- a/callinfo/__terp__.py
+++ b/callinfo/__terp__.py
@@ -19,6 +19,8 @@
         "call_info_call_log_view.xml",
         "call_info_call_category_view.xml",
         "call_info_call_category_data.xml",
+        "giscedata_polissa_view.xml",
+        "res_partner_view.xml",
         "security/ir.model.access.csv",
     ],
     "active": False,

--- a/callinfo/call_info_call_category.py
+++ b/callinfo/call_info_call_category.py
@@ -61,6 +61,12 @@ class CallInfoCallCategory(osv.osv):
             size=8,
             help=_('Codi de la categoria')
         ),
+        'active': fields.boolean('Actiu'),
+        'subtipus_reclamacio_id': fields.many2one(
+            'giscedata.subtipus.reclamacio',
+            _('Tipus Reclamació'),
+            help=_('Subtipus de la reclamació associada')
+        ),
         'generate_atc_parameters': fields.json("Parametres de generació d'ATC"),
         'generate_atc_parameters_text': fields.function(
             _ff_generate_atc_parameters,
@@ -72,6 +78,8 @@ class CallInfoCallCategory(osv.osv):
     }
 
     _defaults = {
+        'active': lambda *a: True,
+        'generate_atc_parameters_text': lambda *a: '{}',
     }
 
 

--- a/callinfo/call_info_call_category.py
+++ b/callinfo/call_info_call_category.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+import json
+
+class CallInfoCallCategory(osv.osv):
+
+    _name = 'call.info.call.category'
+
+
+    def _ff_generate_atc_parameters(self, cursor, uid, ids, field_name, arg, context=None):
+        if not context:
+            context = {}
+
+        res = {}
+        for import_vals in self.read(cursor, uid, ids, ['generate_atc_parameters']):
+            res[import_vals['id']] = json.dumps(
+                import_vals['generate_atc_parameters'], indent=4
+            )
+        return res
+
+    def _fi_generate_atc_parameters(self, cursor, uid, ids, name, value, arg, context=None):
+        if not context:
+            context = {}
+
+        try:
+            parameters = json.loads(value)
+            self.write(cursor, uid, ids, {'generate_atc_parameters': parameters})
+        except ValueError as e:
+            pass
+
+    def check_correct_json(self, cursor, uid, ids, generate_atc_parameters_text):
+        try:
+            params = json.loads(generate_atc_parameters_text)
+        except ValueError as e:
+            return {
+                'warning': {
+                    'title': _(u'Atenció!'),
+                    'message': _('Els parametres entrats no tenen un format '
+                                 'correcte de JSON')
+                }
+            }
+        if not isinstance(params, dict):
+            return {
+                'warning': {
+                    'title': _(u'Atenció'),
+                    'message': _('Els parametres han de ser un diccionari')
+                }
+            }
+        return {}
+
+
+    _columns = {
+        'name': fields.char(
+            _(u'Nom'),
+            size=240,
+            help=_(u"Nom de la categoria")
+        ),
+        'code': fields.char(
+            _('Codi'),
+            size=8,
+            help=_('Codi de la categoria')
+        ),
+        'generate_atc_parameters': fields.json("Parametres de generació d'ATC"),
+        'generate_atc_parameters_text': fields.function(
+            _ff_generate_atc_parameters,
+            type='text',
+            method=True,
+            string=_("Parametres de generació d'ATC"),
+            fnct_inv=_fi_generate_atc_parameters
+        )
+    }
+
+    _defaults = {
+    }
+
+
+CallInfoCallCategory()

--- a/callinfo/call_info_call_category_data.xml
+++ b/callinfo/call_info_call_category_data.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data noupdate="1">
+        <record model="call.info.call.category" id="categ_AP01">
+            <field name="name">[APORTACIONS - GKWH] Aportacions al GkWh, capital social</field>
+            <field name="code">AP01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_AU01">
+            <field name="name">[AUTOPRODUCCIÓ] Info compres col·lectives, com instal·lar auto..</field>
+            <field name="code">AU01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CB01">
+            <field name="name">[COBRAMENTS] Dubtes  factures impagades i com fer pagament</field>
+            <field name="code">CB01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CB02">
+            <field name="name">[COBRAMENTS] Informació sobre tall subministrament</field>
+            <field name="code">CB01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CO01">
+            <field name="name">[COMUNICACIÓ] Comentar noticies blog, campanyes, newsletter, mai</field>
+            <field name="code">CO01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT01">
+            <field name="name">[CONTRACTES]  Consultes referents a ALTES d'un nou punt de subm</field>
+            <field name="code">CT01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT02">
+            <field name="name">[CONTRACTES] Consultes referents a BAIXES d’un punt subm</field>
+            <field name="code">CT02</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT06">
+            <field name="name">[CONTRACTES] Canvi de Titular - Pagador. Com es fa, on es fa</field>
+            <field name="code">CT06</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT03">
+            <field name="name">[CONTRACTES] Info procés contractació, endarreriments, rebuig</field>
+            <field name="code">CT03</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT04">
+            <field name="name">[CONTRACTES] Informació sobre possible canvi de comer fraudulent</field>
+            <field name="code">CT04</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT05">
+            <field name="name">[CONTRACTES] Quina potència necessito? Info sobre nova tarifa</field>
+            <field name="code">CT05</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_CT07">
+            <field name="name">[CONTRACTES] Tràmits autoconsum (com es fa, documentació)</field>
+            <field name="code">CT07</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_EE01">
+            <field name="name">[ENTITATS I EMPRESES] CCVV, Finques, Ajuntaments, Campanyes</field>
+            <field name="code">EE01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_EE02">
+            <field name="name">[ENTITATS I EMPRESES] Informació sobre tarifa 3.X TD i 6.X TD</field>
+            <field name="code">EE02</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_FA01">
+            <field name="name">[FACTURA] Dubtes informació sobre les seves factures</field>
+            <field name="code">FA01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_FA03">
+            <field name="name">[FACTURA] Info comptadors, lloguer, canvi a telegestió, trifàsic</field>
+            <field name="code">FA03</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_FA02">
+            <field name="name">[FACTURA] Dubtes  sobre les lectures - vol donar lectura</field>
+            <field name="code">FA02</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_PA01">
+            <field name="name">[GL - PARTICIPA - AULA POPULAR]  Assemblea, Participa, GL</field>
+            <field name="code">PA01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_IE01">
+            <field name="name">[INFOENERGIA] Consulta sobre els seus informes</field>
+            <field name="code">IE01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_IN03">
+            <field name="name">[INFO] Bo social (com es demana, qui hi pot tenir accés, etc)</field>
+            <field name="code">IN03</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_IN04">
+            <field name="name">[INFO] No tinc llum, què faig?</field>
+            <field name="code">IN04</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_IN02">
+            <field name="name">[INFO] Sóc Soci i vull Convidar. No sóc Soci i vull contractar</field>
+            <field name="code">IN02</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_">
+            <field name="name">[INFO] Dubtes amb formularis (informàtics, CNAE, adjunts..)</field>
+            <field name="code"></field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_IN01">
+            <field name="name">[INFO] Dubtes informació general (com fer-me soci, formulari)</field>
+            <field name="code">IN01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_">
+            <field name="name">[INFO] Explicació de la cooperativa (Primer contacte)</field>
+            <field name="code"></field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_OV01">
+            <field name="name">[OV] Demanen canvis que els hem de dirigir a l'OV </field>
+            <field name="code">OV01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_OV03">
+            <field name="name">[OV] Consultes sobre seccions (infoenergia, corbes, GkWh...)</field>
+            <field name="code">OV03</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_OV02">
+            <field name="name">[OV] Problemes accés a OV (contrassenya, usuari, activació)</field>
+            <field name="code">OV02</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_PR01">
+            <field name="name">[PROJECTES - GENERACIÓ] Informació sobre les nostres plantes</field>
+            <field name="code">PR01</field>
+            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+    </data>
+</openerp>

--- a/callinfo/call_info_call_category_data.xml
+++ b/callinfo/call_info_call_category_data.xml
@@ -111,9 +111,9 @@
             <field name="code">IN02</field>
             <field name="generate_atc_parameters_text">{}</field>
         </record>
-        <record model="call.info.call.category" id="categ_">
+        <record model="call.info.call.category" id="categ_IN05">
             <field name="name">[INFO] Dubtes amb formularis (informàtics, CNAE, adjunts..)</field>
-            <field name="code"></field>
+            <field name="code">IN05</field>
             <field name="generate_atc_parameters_text">{}</field>
         </record>
         <record model="call.info.call.category" id="categ_IN01">
@@ -121,30 +121,30 @@
             <field name="code">IN01</field>
             <field name="generate_atc_parameters_text">{}</field>
         </record>
-        <record model="call.info.call.category" id="categ_">
+        <record model="call.info.call.category" id="categ_IN06">
             <field name="name">[INFO] Explicació de la cooperativa (Primer contacte)</field>
-            <field name="code"></field>
-            <field name="generate_atc_parameters_text">{}</field>
+            <field name="code">IN06</field>
         </record>
         <record model="call.info.call.category" id="categ_OV01">
             <field name="name">[OV] Demanen canvis que els hem de dirigir a l'OV </field>
             <field name="code">OV01</field>
-            <field name="generate_atc_parameters_text">{}</field>
         </record>
         <record model="call.info.call.category" id="categ_OV03">
             <field name="name">[OV] Consultes sobre seccions (infoenergia, corbes, GkWh...)</field>
             <field name="code">OV03</field>
-            <field name="generate_atc_parameters_text">{}</field>
         </record>
         <record model="call.info.call.category" id="categ_OV02">
             <field name="name">[OV] Problemes accés a OV (contrassenya, usuari, activació)</field>
             <field name="code">OV02</field>
-            <field name="generate_atc_parameters_text">{}</field>
         </record>
         <record model="call.info.call.category" id="categ_PR01">
             <field name="name">[PROJECTES - GENERACIÓ] Informació sobre les nostres plantes</field>
             <field name="code">PR01</field>
-            <field name="generate_atc_parameters_text">{}</field>
+        </record>
+        <record model="call.info.call.category" id="categ_R006">
+            <field name="name">CONTRATOS ATR QUE NO SE FACTURAN</field>
+            <field name="code">R006</field>
+            <field name="subtipus_reclamacio_id" ref="giscedata_subtipus_reclamacio.subtipus_reclamacio_006" />
         </record>
     </data>
 </openerp>

--- a/callinfo/call_info_call_category_view.xml
+++ b/callinfo/call_info_call_category_view.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_call_info_call_category_tree">
+            <field name="name">call.info.call.category.tree</field>
+            <field name="model">call.info.call.category</field>
+            <field name="type">tree</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <tree string="Categoria de les trucades Call Info">
+                    <field name="name"/>
+                    <field name="code"/>
+                    <field name="generate_atc_parameters"/>
+                </tree>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_call_info_call_category_form">
+            <field name="name">call.info.call.category.form</field>
+            <field name="model">call.info.call.category</field>
+            <field name="type">form</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <form string="Categoria de trucades Call Info">
+                    <group colspan="2" col="2">
+                        <field name="name" select="1"/>
+                        <field name="code" select="1"/>
+                        <group colspan="2" col="2" string="Parametres del cas ATC a crear">
+                            <field name="generate_atc_parameters_text" select="2" on_change="check_correct_json(generate_atc_parameters_text)" height="100"  nolabel="1" />
+                        </group>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record id="action_call_info_call_category_tree" model="ir.actions.act_window">
+            <field name="name">Categoria de trucades Call Info</field>
+            <field name="res_model">call.info.call.category</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[]</field>
+        </record>
+        <menuitem id="menu_call_info_call_category_view" action="action_call_info_call_category_tree" parent="menu_folder_call_info"/>
+    </data>
+</openerp>

--- a/callinfo/call_info_call_category_view.xml
+++ b/callinfo/call_info_call_category_view.xml
@@ -10,6 +10,8 @@
                 <tree string="Categoria de les trucades Call Info">
                     <field name="name"/>
                     <field name="code"/>
+                    <field name="active"/>
+                    <field name="subtipus_reclamacio_id"/>
                     <field name="generate_atc_parameters"/>
                 </tree>
             </field>
@@ -21,10 +23,12 @@
             <field name="priority">16</field>
             <field name="arch" type="xml">
                 <form string="Categoria de trucades Call Info">
-                    <group colspan="2" col="2">
-                        <field name="name" select="1"/>
+                    <group colspan="2" col="4">
+                        <field name="name" select="1" colspan="4"/>
                         <field name="code" select="1"/>
-                        <group colspan="2" col="2" string="Parametres del cas ATC a crear">
+                        <field name="active" select="1"/>
+                        <field name="subtipus_reclamacio_id" select="2" colspan="4"/>
+                        <group colspan="4" col="2" string="Parametres del cas ATC a crear">
                             <field name="generate_atc_parameters_text" select="2" on_change="check_correct_json(generate_atc_parameters_text)" height="100"  nolabel="1" />
                         </group>
                     </group>

--- a/callinfo/call_info_call_log.py
+++ b/callinfo/call_info_call_log.py
@@ -10,22 +10,26 @@ class CallInfoCallLog(osv.osv):
 
 
     def _normalize_phone_number(self, phone_number):
-        clean_phone_number = re.sub(r'[ +-(),.]', '', phone_number)
-        return phone_number.lstrip('0')
+        clean_phone_number = re.sub(r'[ +(),.-]', '', phone_number)
+        return clean_phone_number.lstrip('0')
 
     def insert_call_log(self, cursor, uid, call_data, context=None):
         new_call = {
-            'phone': self._normalize_phone_number(call_data['phone']),
-            'partner_id': call_data['partner_id'],
-            'contract_id': call_data['polissa_id']
-            'date': datetime.now(),
+            'call_date': datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S'),
             'categ_id': call_data['categ_id'],
             'comment': call_data['notes'],
             'user_id': call_data['user_id'],
         }
-        if 'atc' in call_data:
-            new_atc['atc_id'] = call_data['atc']
-
+        if 'atc_id' in call_data:
+            new_call['atc_id'] = call_data['atc_id']
+        if 'phone' in call_data:
+            phone = self._normalize_phone_number(call_data['phone'])
+            if phone:
+                new_call['phone'] = phone
+        if 'partner_id' in call_data:
+            new_call['partner_id'] = call_data['partner_id'],
+        if 'polissa_id' in call_data:
+            new_call['contract_id'] = call_data['polissa_id'],
         return self.create(cursor, uid, new_call, context=context)
 
     _columns = {
@@ -44,7 +48,7 @@ class CallInfoCallLog(osv.osv):
             _('Pòlissa'),
             help=_('Pòlissa associada a la trucada')
         ),
-        'date': fields.datetime(
+        'call_date': fields.datetime(
             _('Data'),
             required=True,
             help=_('Dia i hora de la trucada')

--- a/callinfo/call_info_call_log.py
+++ b/callinfo/call_info_call_log.py
@@ -10,8 +10,11 @@ class CallInfoCallLog(osv.osv):
 
 
     def _normalize_phone_number(self, phone_number):
-        clean_phone_number = re.sub(r'[ +(),.-]', '', phone_number)
-        return clean_phone_number.lstrip('0')
+        clean_phone_number = re.sub('\D', '', phone_number)
+        no_zeros = clean_phone_number.lstrip('0')
+        if no_zeros.startswith('34'):
+            no_zeros = no_zeros[2:]
+        return no_zeros
 
     def insert_call_log(self, cursor, uid, call_data, context=None):
         new_call = {

--- a/callinfo/call_info_call_log.py
+++ b/callinfo/call_info_call_log.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+from datetime import datetime
+import re
+
+class CallInfoCallLog(osv.osv):
+
+    _name = 'call.info.call.log'
+
+
+    def _normalize_phone_number(self, phone_number):
+        clean_phone_number = re.sub(r'[ +-(),.]', '', phone_number)
+        return phone_number.lstrip('0')
+
+    def insert_call_log(self, cursor, uid, call_data, context=None):
+        new_call = {
+            'phone': self._normalize_phone_number(call_data['phone']),
+            'partner_id': call_data['partner_id'],
+            'contract_id': call_data['polissa_id']
+            'date': datetime.now(),
+            'categ_id': call_data['categ_id'],
+            'comment': call_data['notes'],
+            'user_id': call_data['user_id'],
+        }
+        if 'atc' in call_data:
+            new_atc['atc_id'] = call_data['atc']
+
+        return self.create(cursor, uid, new_call, context=context)
+
+    _columns = {
+        'phone': fields.char(
+            _('Telèfon'),
+            size=32,
+            help=_('Telèfon associat a la trucada')
+        ),
+        'partner_id': fields.many2one(
+            'res.partner',
+            _('Client'),
+            help=_('Client associat a la trucada')
+        ),
+        'contract_id': fields.many2one(
+            'giscedata.polissa',
+            _('Pòlissa'),
+            help=_('Pòlissa associada a la trucada')
+        ),
+        'date': fields.datetime(
+            _('Data'),
+            required=True,
+            help=_('Dia i hora de la trucada')
+        ),
+        'categ_id': fields.many2one(
+            'crm.case.categ',
+            _('Categoria'),
+            required=True,
+            help=_('Categoria de la trucada')
+        ),
+        'comment': fields.text(
+            _(u'Comentari'),
+            help=_(u"Explicació de la trucada")
+        ),
+        'atc_id': fields.many2one(
+            'giscedata.atc',
+            _(u'ATC'),
+            help=_('Cas ATC creat amb la trucada - Reclamació')
+        ),
+        'user_id': fields.many2one(
+            'res.users',
+            _('Usuari'),
+            required=True,
+            help=_('Usuari que va atendre la trucada')
+        )
+    }
+
+    _defaults = {
+    }
+
+
+CallInfoCallLog()

--- a/callinfo/call_info_call_log.py
+++ b/callinfo/call_info_call_log.py
@@ -2,6 +2,7 @@
 from osv import osv, fields
 from tools.translate import _
 from datetime import datetime
+import call_info_call_category
 import re
 
 class CallInfoCallLog(osv.osv):
@@ -18,11 +19,14 @@ class CallInfoCallLog(osv.osv):
 
     def insert_call_log(self, cursor, uid, call_data, context=None):
         new_call = {
-            'call_date': datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S'),
             'categ_id': call_data['categ_id'],
             'comment': call_data['notes'],
             'user_id': call_data['user_id'],
         }
+        if 'call_date' in call_data:
+            new_call['call_date'] = call_data['call_date']
+        else:
+            new_call['call_date'] = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
         if 'atc_id' in call_data:
             new_call['atc_id'] = call_data['atc_id']
         if 'phone' in call_data:
@@ -57,7 +61,7 @@ class CallInfoCallLog(osv.osv):
             help=_('Dia i hora de la trucada')
         ),
         'categ_id': fields.many2one(
-            'crm.case.categ',
+            'call.info.call.category',
             _('Categoria'),
             required=True,
             help=_('Categoria de la trucada')

--- a/callinfo/call_info_call_log_view.xml
+++ b/callinfo/call_info_call_log_view.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_call_info_call_log_tree">
+            <field name="name">call.info.call.log.tree</field>
+            <field name="model">call.info.call.log</field>
+            <field name="type">tree</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <tree string="Log de trucades Call Info">
+                    <field name="phone"/>
+                    <field name="partner_id"/>
+                    <field name="contract_id"/>
+                    <field name="call_date"/>
+                    <field name="user_id"/>
+                    <field name="categ_id"/>
+                    <field name="comment"/>
+                </tree>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_call_info_call_log_form">
+            <field name="name">call.info.call.log.form</field>
+            <field name="model">call.info.call.log</field>
+            <field name="type">form</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <form string="Log de trucades Call Info">
+                    <group colspan="2" col="6">
+                        <group colspan="6" col="6" string="Dades de la persona">
+                            <field name="phone" select="1"/>
+                            <field name="partner_id" select="1"/>
+                            <field name="contract_id" select="1"/>
+                        </group>
+                        <group colspan="6" col="6" string="Dades d'atenció">
+
+                            <field name="call_date" select="1"/>
+                            <field name="user_id" select="1"/>
+
+                            <field name="categ_id" select="2"/>
+                            <field name="comment" select="2" colspan="6" height="500"/>
+                        </group>
+                        <field name="atc_id"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record id="action_call_info_call_log_tree" model="ir.actions.act_window">
+            <field name="name">Log de trucades Call Info</field>
+            <field name="res_model">call.info.call.log</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[]</field>
+        </record>
+        <menuitem id="menu_folder_call_info" parent="crm.menu_crm" name="Call Info" sequence="11"/>
+        <menuitem id="menu_call_info_call_log_view" action="action_call_info_call_log_tree" parent="menu_folder_call_info"/>
+    </data>
+</openerp>

--- a/callinfo/giscedata_polissa_view.xml
+++ b/callinfo/giscedata_polissa_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record model="ir.actions.act_window" id="action_open_contract_call_info_logs">
+            <field name="name">Trucades Call Info</field>
+            <field name="res_model">call.info.call.log</field>
+            <field name="src_model">giscedata.polissa</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('contract_id','=',active_id)]</field>
+        </record>
+        <record id="value_action_open_contract_call_info_logs" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Trucades Call Info</field>
+            <field name="key2">client_action_relate</field>
+            <field name="key">action</field>
+            <field name="model">giscedata.polissa</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_open_contract_call_info_logs'))" />
+        </record>
+    </data>
+</openerp>

--- a/callinfo/res_partner_view.xml
+++ b/callinfo/res_partner_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record model="ir.actions.act_window" id="action_open_partner_call_info_logs">
+            <field name="name">Trucades Call Info</field>
+            <field name="res_model">call.info.call.log</field>
+            <field name="src_model">res.partner</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('partner_id', '=', active_id)]</field>
+        </record>
+
+        <record id="value_action_open_partner_call_info_logs" model="ir.values">
+			<field name="object" eval="1"/>
+			<field name="name">Trucades Call Info</field>
+            <field name="key2">client_action_relate</field>
+			<field name="key">action</field>
+			<field name="model">res.partner</field>
+			<field name="value" eval="'ir.actions.act_window,'+str(ref('action_open_partner_call_info_logs'))" />
+		</record>
+    </data>
+</openerp>

--- a/callinfo/security/ir.model.access.csv
+++ b/callinfo/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"

--- a/callinfo/security/ir.model.access.csv
+++ b/callinfo/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"access_call_info_call_log_rcw","call.info.call.log","model_call_info_call_log","crm.group_crm_manager",1,0,1,0
+"access_call_info_call_log_rc","call.info.call.log","model_call_info_call_log","crm.group_crm_manager",1,1,1,0
+"access_call_info_call_category_rcw","call.info.call.category","model_call_info_call_category","crm.group_crm_manager",1,1,1,0

--- a/callinfo/security/ir.model.access.csv
+++ b/callinfo/security/ir.model.access.csv
@@ -1,1 +1,2 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_call_info_call_log_rcw","call.info.call.log","model_call_info_call_log","crm.group_crm_manager",1,0,1,0

--- a/callinfo/tests/__init__.py
+++ b/callinfo/tests/__init__.py
@@ -1,0 +1,1 @@
+from test_call_info_call_log import *

--- a/callinfo/tests/test_call_info_call_log.py
+++ b/callinfo/tests/test_call_info_call_log.py
@@ -43,3 +43,33 @@ class CallInfoCallLogTest(CallInfoBaseTests):
     def test_normalize_phone_dummy(self):
         self.assertEqual(1,1)
 
+    def test_normalize_phone_ok(self):
+        cil_obj = self.get_model('call.info.call.log')
+
+        phone_clean = cil_obj._normalize_phone_number('872.202.550')
+        self.assertEqual(phone_clean, '872202550')
+
+        phone_clean = cil_obj._normalize_phone_number('900.103.605')
+        self.assertEqual(phone_clean, '900103605')
+
+    def test_normalize_phone_various(self):
+        cil_obj = self.get_model('call.info.call.log')
+
+        samples = [
+            {'raw': '123456789', 'clean': '123456789'},
+            {'raw': '123.456.789', 'clean': '123456789'},
+            {'raw': '123.45.67.89', 'clean': '123456789'},
+            {'raw': '123-456-789', 'clean': '123456789'},
+            {'raw': '123-45-67-89', 'clean': '123456789'},
+            {'raw': '(+34)123456789', 'clean': '123456789'},
+            {'raw': '0034 123-456.789', 'clean': '123456789'},
+            {'raw': '(+49)123456789', 'clean': '49123456789'},
+            {'raw': '0049 123-456.789', 'clean': '49123456789'},
+            {'raw': ' 123456789  ', 'clean': '123456789'},
+            {'raw': '000  00123456789', 'clean': '123456789'},
+            {'raw': '00000000000', 'clean': ''},
+            {'raw': '123 45.6.78-9 someone', 'clean': '123456789'},
+        ]
+        for sample in samples:
+            result = cil_obj._normalize_phone_number(sample['raw'])
+            self.assertEqual(result, sample['clean'])

--- a/callinfo/tests/test_call_info_call_log.py
+++ b/callinfo/tests/test_call_info_call_log.py
@@ -2,7 +2,7 @@
 from destral import testing
 from destral.transaction import Transaction
 from expects import *
-from datetime import datetime
+from datetime import datetime,date
 
 
 def today_str():
@@ -40,9 +40,6 @@ class CallInfoBaseTests(testing.OOTestCase):
 
 class CallInfoCallLogTest(CallInfoBaseTests):
 
-    def test_normalize_phone_dummy(self):
-        self.assertEqual(1,1)
-
     def test_normalize_phone_ok(self):
         cil_obj = self.get_model('call.info.call.log')
 
@@ -73,3 +70,122 @@ class CallInfoCallLogTest(CallInfoBaseTests):
         for sample in samples:
             result = cil_obj._normalize_phone_number(sample['raw'])
             self.assertEqual(result, sample['clean'])
+
+    def create_dummy_category(self):
+        sec_obj = self.get_model('crm.case.section')
+        cat_obj = self.get_model('crm.case.categ')
+        sec_id = sec_obj.create(self.cursor, self.uid, {'name':'dummy_section','code':'dummy'})
+        cat_id = cat_obj.create(self.cursor, self.uid, {'name':'dummy_section_cat','section_id': sec_id})
+        return sec_id, cat_id
+
+    def test_insert_call_log__basic(self):
+        cil_obj = self.get_model('call.info.call.log')
+        self.create_dummy_category()
+
+        call_data = {
+            'user_id': self.search_in('res.users',[]),
+            'categ_id': self.search_in('crm.case.categ',[]),
+            'notes': 'bla bla bla, complex explanation, ...',
+        }
+
+        call_id = cil_obj.insert_call_log(self.cursor, self.uid, call_data, {})
+        call = cil_obj.browse(self.cursor, self.uid, call_id)
+
+        self.assertEqual(call.comment, call_data['notes'])
+        self.assertEqual(call.call_date[:10], today_str())
+        self.assertEqual(call.user_id.id, call_data['user_id'])
+        self.assertEqual(call.categ_id.id, call_data['categ_id'])
+        self.assertEqual(call.phone, False)
+        self.assertEqual(call.polissa_id, False)
+        self.assertEqual(call.partner_id.id, False)
+
+    def test_insert_call_log__phone(self):
+        cil_obj = self.get_model('call.info.call.log')
+        self.create_dummy_category()
+
+        call_data = {
+            'user_id': self.search_in('res.users',[]),
+            'categ_id': self.search_in('crm.case.categ',[]),
+            'notes': 'bla bla bla, complex explanation, ...',
+            'phone': '0034900103605 som'
+        }
+
+        call_id = cil_obj.insert_call_log(self.cursor, self.uid, call_data, {})
+        call = cil_obj.browse(self.cursor, self.uid, call_id)
+
+        self.assertEqual(call.comment, call_data['notes'])
+        self.assertEqual(call.call_date[:10], today_str())
+        self.assertEqual(call.user_id.id, call_data['user_id'])
+        self.assertEqual(call.categ_id.id, call_data['categ_id'])
+        self.assertEqual(call.phone, '900103605')
+
+    def test_insert_call_log__contract(self):
+        cil_obj = self.get_model('call.info.call.log')
+        ir_obj = self.get_model('ir.model.data')
+        polissa_id = ir_obj.get_object_reference(self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001')[1]
+        self.create_dummy_category()
+
+        call_data = {
+            'user_id': self.search_in('res.users',[]),
+            'categ_id': self.search_in('crm.case.categ',[]),
+            'notes': 'bla bla bla, complex explanation, ...',
+            'polissa_id': polissa_id,
+        }
+
+        call_id = cil_obj.insert_call_log(self.cursor, self.uid, call_data, {})
+        call = cil_obj.browse(self.cursor, self.uid, call_id)
+
+        self.assertEqual(call.comment, call_data['notes'])
+        self.assertEqual(call.call_date[:10], today_str())
+        self.assertEqual(call.user_id.id, call_data['user_id'])
+        self.assertEqual(call.categ_id.id, call_data['categ_id'])
+        self.assertEqual(call.contract_id.id, polissa_id)
+
+    def test_insert_call_log__partner(self):
+        cil_obj = self.get_model('call.info.call.log')
+        ir_obj = self.get_model('ir.model.data')
+        partner_id = ir_obj.get_object_reference(self.cursor, self.uid, 'base', 'main_partner')[1]
+        self.create_dummy_category()
+
+        call_data = {
+            'user_id': self.search_in('res.users',[]),
+            'categ_id': self.search_in('crm.case.categ',[]),
+            'notes': 'bla bla bla, complex explanation, ...',
+            'partner_id': partner_id,
+        }
+
+        call_id = cil_obj.insert_call_log(self.cursor, self.uid, call_data, {})
+        call = cil_obj.browse(self.cursor, self.uid, call_id)
+
+        self.assertEqual(call.comment, call_data['notes'])
+        self.assertEqual(call.call_date[:10], today_str())
+        self.assertEqual(call.user_id.id, call_data['user_id'])
+        self.assertEqual(call.categ_id.id, call_data['categ_id'])
+        self.assertEqual(call.partner_id.id, partner_id)
+
+    def test_insert_call_log__all_identifiers(self):
+        cil_obj = self.get_model('call.info.call.log')
+        ir_obj = self.get_model('ir.model.data')
+        polissa_id = ir_obj.get_object_reference(self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001')[1]
+        partner_id = ir_obj.get_object_reference(self.cursor, self.uid, 'base', 'main_partner')[1]
+        self.create_dummy_category()
+
+        call_data = {
+            'user_id': self.search_in('res.users',[]),
+            'categ_id': self.search_in('crm.case.categ',[]),
+            'notes': 'bla bla bla, complex explanation, ...',
+            'partner_id': partner_id,
+            'polissa_id': polissa_id,
+            'phone': '(0034)900.103.605 som'
+        }
+
+        call_id = cil_obj.insert_call_log(self.cursor, self.uid, call_data, {})
+        call = cil_obj.browse(self.cursor, self.uid, call_id)
+
+        self.assertEqual(call.comment, call_data['notes'])
+        self.assertEqual(call.call_date[:10], today_str())
+        self.assertEqual(call.user_id.id, call_data['user_id'])
+        self.assertEqual(call.categ_id.id, call_data['categ_id'])
+        self.assertEqual(call.partner_id.id, partner_id)
+        self.assertEqual(call.phone, '900103605')
+        self.assertEqual(call.contract_id.id, polissa_id)

--- a/callinfo/tests/test_call_info_call_log.py
+++ b/callinfo/tests/test_call_info_call_log.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+from expects import *
+from datetime import datetime
+
+
+def today_str():
+    return date.today().strftime("%Y-%m-%d")
+
+def today_minus_str(d):
+    return (date.today() - timedelta(days=d)).strftime("%Y-%m-%d")
+
+
+class CallInfoBaseTests(testing.OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def get_model(self, model_name):
+        return self.openerp.pool.get(model_name)
+
+    def search_in(self, model, params):
+        model_obj = self.get_model(model)
+        found_ids = model_obj.search(self.cursor, self.uid, params)
+        return found_ids[0] if found_ids else None
+
+    def browse_referenced(self, reference):
+        model, id = reference.split(',')
+        model_obj = self.get_model(model)
+        return model_obj.browse(self.cursor, self.uid, int(id))
+
+
+
+class CallInfoCallLogTest(CallInfoBaseTests):
+
+    def test_normalize_phone_dummy(self):
+        self.assertEqual(1,1)
+


### PR DESCRIPTION
## Objectiu

Crear els models i eines necessaris per tal de fer la integració entre Call Info i ERP de manera que ens permeti generar registre de trucades i assistir a la creació de reclamacions directes des de la app web.

## Targeta on es demana o Incidència 

https://trello.com/c/RGaGHksl/4913-0-6-p39-centraleta-kalinfo-unificar-i-implementar-punt-dentrada-per-trucades-atc-i-r1-des-de-kalinfo

## Comportament antic

No existia integració, treball manual dels usuaris, pèrdua d'informació

## Comportament nou

En construcció

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
 - callinfo
- [ ] Script de migració
- [ ] Modifica traduccions
