### PR TITLE
Add CAC cancel restrictions

### DIFF
--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from cmath import e
 from osv import osv, fields
 from tools.translate import _
 from datetime import datetime
@@ -41,6 +42,16 @@ class GiscedataAtc(osv.osv):
             pol_ids = [x['polissa_id'][0] for x in pol_ids]
             self.pool.get("giscedata.polissa").write(cursor, uid, pol_ids, {'facturacio_suspesa': False})
         return res
+
+    def case_cancel(self, cursor, uid, ids, *args):
+        if self.has_process:
+            process = []
+            if self.ref:
+                process.append(ref)
+            if self.ref2:
+                process.append(ref2)
+            if len(process) == 0 or (self.state == 'draft' or self.state =='pending'):
+                super(GiscedataAtc, self).case_cancel(cursor, uid, ids, args)
 
     def unlink(self, cursor, uid, ids, context=None):
         super(GiscedataAtc, self).case_cancel(cursor, uid, ids, context)

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -44,17 +44,11 @@ class GiscedataAtc(osv.osv):
         return res
 
     def case_cancel(self, cursor, uid, ids, *args):
-        if self.has_process:
-            process = []
-            if self.ref:
-                process.append(ref)
-            if self.ref2:
-                process.append(ref2)
-            if len(process) == 0 or (self.state == 'draft' or self.state =='pending'):
-                super(GiscedataAtc, self).case_cancel(cursor, uid, ids, args)
+        if not self.has_process or (self.state == 'draft' or self.state =='pending'):
+            super(GiscedataAtc, self).case_cancel(cursor, uid, ids, args)
 
     def unlink(self, cursor, uid, ids, context=None):
-        super(GiscedataAtc, self).case_cancel(cursor, uid, ids, context)
+        self.case_cancel(cursor, uid, ids, context)
 
     _columns = {
         'tag': fields.many2one('giscedata.atc.tag', "Etiqueta"),

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from cmath import e
 from osv import osv, fields
 from tools.translate import _
 from datetime import datetime
@@ -49,10 +48,11 @@ class GiscedataAtc(osv.osv):
 
         for id in ids:
             case = atc_obj.browse(cursor, uid, id)
-            if not case.has_process or (case.state == 'draft' or case.state =='pending'):
+            if not case.has_process or (case.state == 'draft' or case.state == 'pending'):
                 cancel_ids.append(id)
 
-        super(GiscedataAtc, self).case_cancel(cursor, uid, cancel_ids, args)
+        if len(cancel_ids) > 0:
+            super(GiscedataAtc, self).case_cancel(cursor, uid, cancel_ids, args)
 
     def unlink(self, cursor, uid, ids, context=None):
         self.case_cancel(cursor, uid, ids, context)

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -44,8 +44,15 @@ class GiscedataAtc(osv.osv):
         return res
 
     def case_cancel(self, cursor, uid, ids, *args):
-        if not self.has_process or (self.state == 'draft' or self.state =='pending'):
-            super(GiscedataAtc, self).case_cancel(cursor, uid, ids, args)
+        atc_obj = self.pool.get("giscedata.atc")
+        cancel_ids = []
+
+        for id in ids:
+            case = atc_obj.browse(cursor, uid, id)
+            if not case.has_process or (case.state == 'draft' or case.state =='pending'):
+                cancel_ids.append(id)
+
+        super(GiscedataAtc, self).case_cancel(cursor, uid, cancel_ids, args)
 
     def unlink(self, cursor, uid, ids, context=None):
         self.case_cancel(cursor, uid, ids, context)


### PR DESCRIPTION
## Objectiu
Només permetre cancel·lar CAC quan:
- Te una amb R1 en estat Esborrany o Pendent.
- No te R1 associada.

## Targeta on es demana o Incidència 
https://trello.com/c/1ovDqXIN/4920-0-4-p51-ep271-pollir-lassistent-de-change-state-del-m%C3%B2dul-cac-per-introduir-restriccions-al-cas-cancellareclama33?filter=member:erpcorreu

## Comportament antic
Es deixaven cancel·lar.

## Comportament nou
Ja no es poden cancel·lar en els casos mencionats.

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
