### PR TITLE
Arreglar error d'adreces al mailchimp

### DIFF
--- a/som_polissa_soci/res_partner_address.py
+++ b/som_polissa_soci/res_partner_address.py
@@ -286,6 +286,6 @@ class ResPartnerAddress(osv.osv):
 
         for mchimp_list in all_lists:
             list_id = mchimp_list['id']
-            self.archieve_mail_in_list(cursor, uid, old_email , list_id, MAILCHIMP_CLIENT)
+            self.archieve_mail_in_list(cursor, uid, ids, list_id, mailchimp_conn)
 
 ResPartnerAddress()

--- a/som_polissa_soci/res_partner_address.py
+++ b/som_polissa_soci/res_partner_address.py
@@ -72,7 +72,11 @@ class ResPartnerAddress(osv.osv):
                 email = vals['email']
                 if not old_email or old_email == email:
                     continue
-                self.update_client_email_in_all_lists_async(cursor, uid, _id, old_email, email, MAILCHIMP_CLIENT)
+
+                if not email:
+                    self.unsubscribe_client_email_in_all_lists_async(cursor, uid, _id, old_email, MAILCHIMP_CLIENT)
+                else:
+                    self.update_client_email_in_all_lists_async(cursor, uid, _id, old_email, email, MAILCHIMP_CLIENT)
 
         return super(ResPartnerAddress, self).write(cursor, uid, ids, vals, context=context)
 
@@ -263,5 +267,25 @@ class ResPartnerAddress(osv.osv):
                     )
                     logger.info("L'email {} s'ha actualitzat en la llista {}".format(client_data['email_address'],
                         mchimp_list["name"]))
+
+    @job(queue="mailchimp_tasks")
+    def unsubscribe_client_email_in_all_lists_async(self, cursor, uid, ids, old_email, mailchimp_conn, context=None):
+        self.unsubscribe_client_email_in_all_lists(cursor, uid, ids, old_email, mailchimp_conn, context=None)
+
+    def unsubscribe_client_email_in_all_lists(self, cursor, uid, ids, old_email, mailchimp_conn, context=None):
+        if not isinstance(ids, (list, tuple)):
+            ids = [ids]
+
+        logger = logging.getLogger('openerp.{0}.unsubscribe_client_email_in_all_lists'.format(__name__))
+
+        all_lists = mailchimp_conn.lists.get_all_lists(
+            fields=['lists.id,lists.name'],
+            count=100,
+            email=old_email
+        )['lists']
+
+        for mchimp_list in all_lists:
+            list_id = mchimp_list['id']
+            self.archieve_mail_in_list(cursor, uid, old_email , list_id, MAILCHIMP_CLIENT)
 
 ResPartnerAddress()

--- a/som_polissa_soci/res_partner_address.py
+++ b/som_polissa_soci/res_partner_address.py
@@ -97,6 +97,9 @@ class ResPartnerAddress(osv.osv):
 
     @job(queue="mailchimp_tasks")
     def archieve_mail_in_list(self, cursor, uid, ids, list_id, mailchimp_conn, context=None):
+        self.archieve_mail_in_list_sync(cursor, uid, ids, list_id, mailchimp_conn, context=None)
+
+    def archieve_mail_in_list_sync(self, cursor, uid, ids, list_id, mailchimp_conn, context=None):
         if not isinstance(ids, (list, tuple)):
             ids = [ids]
 

--- a/som_polissa_soci/res_partner_address.py
+++ b/som_polissa_soci/res_partner_address.py
@@ -289,6 +289,6 @@ class ResPartnerAddress(osv.osv):
 
         for mchimp_list in all_lists:
             list_id = mchimp_list['id']
-            self.archieve_mail_in_list(cursor, uid, ids, list_id, mailchimp_conn)
+            self.archieve_mail_in_list_sync(cursor, uid, ids, list_id, mailchimp_conn)
 
 ResPartnerAddress()

--- a/som_polissa_soci/tests/__init__.py
+++ b/som_polissa_soci/tests/__init__.py
@@ -1,1 +1,4 @@
 from .test_somenergia_soci import *
+from .tests_partner_address import *
+from .tests_facturacio import *
+from .tests_res_partner import *

--- a/som_polissa_soci/tests/tests_partner_address.py
+++ b/som_polissa_soci/tests/tests_partner_address.py
@@ -5,6 +5,7 @@ import mock
 from destral import testing
 from destral.transaction import Transaction
 
+from .. import res_partner_address
 
 class FakeMailchimpLists():
     def update_list_member(self, list_id, subscriber_hash, client_data):
@@ -95,3 +96,37 @@ class TestsPartnerAddress(testing.OOTestCase):
         mock_fakemailchimp.update_list_member.assert_called()
         mock_fakemailchimp.update_list_member.assert_any_call(1, subscriber_hash, client_data)
         mock_fakemailchimp.update_list_member.assert_any_call(2, subscriber_hash, client_data)
+
+    @mock.patch.object(res_partner_address.ResPartnerAddress, 'archieve_mail_in_list')
+    @mock.patch("som_polissa_soci.tests.tests_partner_address.fake_mchimp_client.lists")
+    def test_unsubscribe_client_email_in_all_lists(self, mock_fakemailchimp, archieve_mail_in_list_mock_function):
+        old_email = "test@test.test"
+
+        archieve_mail_in_list_mock_function.return_value = None
+        mock_fakemailchimp.get_all_lists.return_value = {
+            "lists": [
+                { "id": 1, "name": "som" },
+                { "id": 2, "name": "som" }
+            ]
+        }
+
+        partner_address_o = self.pool.get('res.partner.address')
+        partner_address_o.unsubscribe_client_email_in_all_lists(
+            self.cursor, self.txn, [1], old_email, fake_mchimp_client)
+
+        archieve_mail_in_list_mock_function.assert_called()
+
+    @mock.patch.object(res_partner_address.ResPartnerAddress, 'read')
+    @mock.patch('som_polissa_soci.res_partner_address.md5')
+    @mock.patch("som_polissa_soci.tests.tests_partner_address.fake_mchimp_client.lists")
+    def test_archieve_mail_in_list_sync(self, mock_fakemailchimp, mock_md5, res_partner_address_read_mock_function):
+        subscriber_hash = "12345"
+        email = "test@test.test"
+        mock_md5.return_value = FakeMD5(subscriber_hash)
+        res_partner_address_read_mock_function.return_value = [{'email': email}]
+
+        partner_address_o = self.pool.get('res.partner.address')
+        partner_address_o.archieve_mail_in_list_sync(
+            self.cursor, self.txn, [1], 1, fake_mchimp_client)
+
+        mock_fakemailchimp.delete_list_member.assert_called()

--- a/som_polissa_soci/tests/tests_partner_address.py
+++ b/som_polissa_soci/tests/tests_partner_address.py
@@ -97,12 +97,12 @@ class TestsPartnerAddress(testing.OOTestCase):
         mock_fakemailchimp.update_list_member.assert_any_call(1, subscriber_hash, client_data)
         mock_fakemailchimp.update_list_member.assert_any_call(2, subscriber_hash, client_data)
 
-    @mock.patch.object(res_partner_address.ResPartnerAddress, 'archieve_mail_in_list')
+    @mock.patch.object(res_partner_address.ResPartnerAddress, 'archieve_mail_in_list_sync')
     @mock.patch("som_polissa_soci.tests.tests_partner_address.fake_mchimp_client.lists")
-    def test_unsubscribe_client_email_in_all_lists(self, mock_fakemailchimp, archieve_mail_in_list_mock_function):
+    def test_unsubscribe_client_email_in_all_lists(self, mock_fakemailchimp, archieve_mail_in_list_sync_mock_function):
         old_email = "test@test.test"
 
-        archieve_mail_in_list_mock_function.return_value = None
+        archieve_mail_in_list_sync_mock_function.return_value = None
         mock_fakemailchimp.get_all_lists.return_value = {
             "lists": [
                 { "id": 1, "name": "som" },
@@ -114,7 +114,7 @@ class TestsPartnerAddress(testing.OOTestCase):
         partner_address_o.unsubscribe_client_email_in_all_lists(
             self.cursor, self.txn, [1], old_email, fake_mchimp_client)
 
-        archieve_mail_in_list_mock_function.assert_called()
+        archieve_mail_in_list_sync_mock_function.assert_called()
 
     @mock.patch.object(res_partner_address.ResPartnerAddress, 'read')
     @mock.patch('som_polissa_soci.res_partner_address.md5')


### PR DESCRIPTION
## Objectiu

Es detecta un error en una situació no controlada al mòdul som_polissa_soci al realitzar un write al model ResPartnerAddress que deriva la crida a update_client_email_in_all_lists. Mentre que el paràmetre old_email ve controlat pel mètode anterior, el paràmetre email (el nou email) no. Això genera problemes ja que update_client_email_in_all_lists no esta pensada per que sigui email buit.

update_client_email_in_all_lists realitza una cerca per totes les llistes on esta subscrit el correu realitzant-ne una substitució ple correu nou. El funcionament del write llavors es:

a) buit --> nou@correu.xyz --> no fa res a mailchimp

b) antic@correu.xyz --> nou@correu.ijk --> crida a update_client_email_in_all_lists que actualitza a totes les llistes de mailchimp on apareix el correu antic substituint-ho pel nou.

c) antic@correu.xyz --> buit --> Peta de forma incontrolada (incidència)

En aquesta PR volem canviar el comportament de c) per:

c) antic@correu.xyz --> buit --> dona de baixa el correu antic al mailchimp (en realitat arxiva)

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/1994006226/13102116/

## Comportament antic

Error incontrolat al erp

## Comportament nou

No error i dessubscriu de les llistes el correu donat.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
