### PR TITLE
Guardar al resultat la informació final del wizard d'importació

### DIFF
--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -160,11 +160,12 @@ class SomCrawlersTaskStep(osv.osv):
             import_wizard_id = WizardImportAtrF1.create(cursor,uid,values)
             import_wizard  = WizardImportAtrF1.browse(cursor, uid, import_wizard_id)
             context = {'active_ids': [import_wizard.id], 'active_id': import_wizard.id}
+
             try:
                 import_wizard.action_import_xmls(context)
                 if import_wizard.state == 'load':
                     import_wizard.action_send_xmls(context=context)
-                return import_wizard.info
+                return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
             except Exception as e:
                 msg = "An error ocurred importing {}:{}".format("asd", "asd")
                 return msg


### PR DESCRIPTION
## Objectiu
- Que es guardi al `result` la informació final que dona el `wizard` d'importació. Abans es guardava un missatge intermedi que no aportava informació.

## Targeta on es demana o Incidència 
https://trello.com/c/5wTzFoGH/5369-0-0-p20-ep259-crawlers-altres-distris-de-lexcel

## Comportament antic
Exemple del missatge que es guardava abans:
![image](https://user-images.githubusercontent.com/66311413/193259884-9004ccbb-7f31-4543-9fd1-1e1a44b83fca.png)


## Comportament nou
Exemple del missatge que es guarda ara:
![image](https://user-images.githubusercontent.com/66311413/193259943-f92029ac-559d-44e3-936f-1cb4dbc030d5.png)


## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
