### PR TITLE
Add wizard to close obsolete ATR cases 

### DIFF
--- a/som_switching/__terp__.py
+++ b/som_switching/__terp__.py
@@ -39,6 +39,7 @@
         'wizard/wizard_create_atc_from_polissa.xml',
         'giscedata_atc_view.xml',
         'wizard/giscedata_switching_wizard_b1.xml',
+        'wizard/wizard_close_obsolete_cases.xml',
     ],
     "active": False,
     "installable": True

--- a/som_switching/wizard/__init__.py
+++ b/som_switching/wizard/__init__.py
@@ -9,3 +9,4 @@ import giscedata_switching_mod_con_wizard
 import wizard_create_atc_from_polissa
 import giscedata_switching_wizard_b1
 import wizard_import_atr_and_f1
+import wizard_close_obsolete_cases

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -6,6 +6,8 @@ from tools.translate import _
 class WizardCloseObsoleteCases(osv.osv_memory):
 
     _name = "wizard.close.obsolete.cases"
+    _inherit = 'wizard.crm.multi.close'
+
 
     def _get_info_default(self, cursor, uid, context=None):
         if not context:
@@ -39,11 +41,11 @@ class WizardCloseObsoleteCases(osv.osv_memory):
                 ):
                     case_ids.append(sw.case_id)
 
-            ctx = context.copy()
-            ctx.update({"active_ids": case_ids})
-            self.perform_close(cursor, uid, ids, context=ctx)
+        ctx = context.copy()
+        ctx.update({"active_ids": case_ids})
+        self.perform_close(cursor, uid, ids, context=ctx)
 
-            # info += "%s: %s\n\n" % (res[0], res[1]) TODO
+        info = "S'han tancat %s casos obsolets\n" % len(case_ids)
 
         wizard.write({"info": info, "state": "done"})
 

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -6,15 +6,14 @@ from tools.translate import _
 class WizardCloseObsoleteCases(osv.osv_memory):
 
     _name = "wizard.close.obsolete.cases"
-    _inherit = 'wizard.crm.multi.close'
-
+    _inherit = "wizard.crm.multi.close"
 
     def _get_info_default(self, cursor, uid, context=None):
         if not context:
             context = {}
         return _(
-            u"Només els casos oberts:\n"
-            u" * D1 01 amb motiu 04 amb pólissa de baixa o autoconsum activat\n"
+            "Només els casos oberts:\n"
+            " * D1 01 amb motiu 04 amb pólissa de baixa o autoconsum activat\n"
         )
 
     def close_obsolete_cases(self, cursor, uid, ids, context=None):
@@ -34,14 +33,16 @@ class WizardCloseObsoleteCases(osv.osv_memory):
             if sw.state != "open":
                 continue
             if sw.proces_id.name == "D1" and sw.step_id.name == "01":  # D101
-                step_info = swsi_obj.browse(cursor, uid, sw.step_ids[0], context)
-                if step_info.pas_id.motiu_canvi != "04":
+                pas_str = sw.step_ids[0].pas_id
+                swsi_obj, pas_id = pas_str.split(",")
+                pas_obj = self.pool.get(swsi_obj).browse(cursor, uid, eval(pas_id))
+                if pas_obj.motiu_canvi != "04":
                     continue
                 if (
                     not sw.cups_polissa_id.active
                     or sw.cups_polissa_id.autoconsumo != "00"
                 ):
-                    case_ids.append(sw.case_id)
+                    case_ids.append(sw.case_id.id)
 
         ctx = context.copy()
         ctx.update({"active_ids": case_ids})

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -62,6 +62,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
     _defaults = {
         "state": lambda *a: "init",
         "info": _get_info_default,
+        "result": lambda *a: '0',
     }
 
 

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -19,6 +19,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
 
     def close_obsolete_cases(self, cursor, uid, ids, context=None):
         sw_obj = self.pool.get("giscedata.switching")
+        swsi_obj = self.pool.get("giscedata.switching.step.info")
 
         if not context:
             context = {}
@@ -33,7 +34,8 @@ class WizardCloseObsoleteCases(osv.osv_memory):
             if sw.state != "open":
                 continue
             if sw.proces_id.name == "D1" and sw.step_id.name == "01":  # D101
-                if sw.step_ids[0].pas_id.motiu_canvi != "04":
+                step_info = swsi_obj.browse(cursor, uid, sw.step_ids[0], context)
+                if step_info.pas_id.motiu_canvi != "04":
                     continue
                 if (
                     not sw.cups_polissa_id.active

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+
+
+class WizardCloseObsoleteCases(osv.osv_memory):
+
+    _name = "wizard.close.obsolete.cases"
+
+    def _get_info_default(self, cursor, uid, context=None):
+        if not context:
+            context = {}
+        return _(
+            u"Només els casos oberts:\n"
+            u" * D1 01 amb motiu 04 amb pólissa de baixa o autoconsum activat\n"
+        )
+
+    def close_obsolete_cases(self, cursor, uid, ids, context=None):
+        sw_obj = self.pool.get("giscedata.switching")
+
+        if not context:
+            context = {}
+        wizard = self.browse(cursor, uid, ids[0], context)
+
+        sw_ids = context.get("active_ids", [])
+
+        info = ""
+        case_ids = []  # Casos a tancar
+        for sw_id in sw_ids:
+            sw = sw_obj.browse(cursor, uid, sw_id, context)
+            if sw.state != "open":
+                continue
+            if sw.proces_id.name == "R1" and sw.step_id.name == "01":  # R101
+                if sw.step_ids[0].pas_id.motiu_canvi != "04":
+                    continue
+                if (
+                    not sw.cups_polissa_id.active
+                    or sw.cups_polissa_id.autoconsumo != "01"
+                ):
+                    case_ids.append(sw.case_id)
+
+            ctx = context.copy()
+            ctx.update({"active_ids": case_ids})
+            self.perform_close(cursor, uid, ids, context=ctx)
+
+            # info += "%s: %s\n\n" % (res[0], res[1]) TODO
+
+        wizard.write({"info": info, "state": "done"})
+
+        return
+
+    _columns = {
+        "state": fields.char("State", size=16),
+        "info": fields.text("Info"),
+    }
+
+    _defaults = {
+        "state": lambda *a: "init",
+        "info": _get_info_default,
+    }
+
+
+WizardCloseObsoleteCases()

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -30,7 +30,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
             sw = sw_obj.browse(cursor, uid, sw_id, context)
             if sw.state != "open":
                 continue
-            if sw.proces_id.name == "R1" and sw.step_id.name == "01":  # R101
+            if sw.proces_id.name == "D1" and sw.step_id.name == "01":  # D101
                 if sw.step_ids[0].pas_id.motiu_canvi != "04":
                     continue
                 if (

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -35,7 +35,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
                     continue
                 if (
                     not sw.cups_polissa_id.active
-                    or sw.cups_polissa_id.autoconsumo != "01"
+                    or sw.cups_polissa_id.autoconsumo != "00"
                 ):
                     case_ids.append(sw.case_id)
 

--- a/som_switching/wizard/wizard_close_obsolete_cases.xml
+++ b/som_switching/wizard/wizard_close_obsolete_cases.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="view_wizard_close_obsolete_cases_form" model="ir.ui.view">
+            <field name="name">wizard.close.obsolete.cases.form</field>
+            <field name="model">wizard.close.obsolete.cases</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Tancar casos ATR obsolets">
+                    <label string="Tancar casos ATR obsolets"/>
+                    <separator colspan="4"/>
+                    <field name="state" invisible="1"/>
+                    <group colspan="4">
+                        <field nolabel="1" name="info" height="200" readonly="1"/>
+                    </group>
+                    <group>
+                        <button special="cancel" string="Cancel·lar" type="object" icon="gtk-no"/>
+                        <button name="close_obsolete_cases" string="Tancar casos" type="object" icon="gtk-execute"
+                                attrs="{'invisible': [('state','!=','init')]}"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record id="action_wizard_delete_obsolete_cases" model="ir.actions.act_window">
+            <field name="name">Tancar casos ATR obsolets</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.close.obsolete.cases</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_wizard_close_obsolete_cases_form"/>
+            <field name="target">new</field>
+        </record>
+        <record id="value_wizard_close_obsolete_cases" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Tancar casos ATR obsolets</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">giscedata.switching</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_delete_obsolete_cases'))" />
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu
Afegir un assistent per tancar massivament, totes les D1 01 d'autoconsum que ja no cal que s'activin (perquè la pòlissa ja té activat l'autoconsum o perquè la pòlissa està de baixa)

## Targeta on es demana o Incidència 
https://trello.com/c/aCadIruY/5425-add-versi%C3%B3-25-retard-activaci%C3%B3-auto

## Comportament antic
No hi havia aquest assitent

## Comportament nou
Hi ha aquest assistent
![image](https://user-images.githubusercontent.com/26488435/194037461-5dd9f02a-c615-42e5-afb1-5e947b89ed26.png)


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul: som_switching
- [ ] Script de migració
- [ ] Modifica traduccions
