### PR TITLE
Afegir control d'errors a casos ATC

### DIFF
--- a/som_switching/__terp__.py
+++ b/som_switching/__terp__.py
@@ -17,7 +17,9 @@
         "giscedata_atc_switching",
     ],
     "init_xml": [],
-    "demo_xml": [],
+    "demo_xml": [
+        'demo/som_switching_demo_data.xml',
+    ],
     "update_xml": [
         'giscedata_switching_view.xml',
         'giscedata_switching_data.xml',

--- a/som_switching/demo/som_switching_demo_data.xml
+++ b/som_switching/demo/som_switching_demo_data.xml
@@ -4,6 +4,27 @@
         <record  model="giscedata.atc" id="cas_atc_0001">
             <field name="name">ccc</field>
             <field name="provincia">20</field>
+            <field name="section_id">1</field>
+            <field name="sector">electric</field>
+            <field name="subtipus_id">1</field>
+            <field name="reclamante">06</field>
+            <field name="agent_actual">06</field>
+		</record>
+        <record  model="giscedata.switching" id="sw_001">
+            <field name="ref_contracte">Test</fiel>
+            <field name="data_sollicitud">2022-01-02</field>
+            <field name="proces_id" ref='sw_proces_r1' />
+            <field name="step_id" ref='sw_proces_r1' />
+		</record>
+        <record  model="giscedata.atc" id="cas_atc_0002">
+            <field name="name">ccc</field>
+            <field name="provincia">20</field>
+            <field name="section_id">1</field>
+            <field name="sector">electric</field>
+            <field name="subtipus_id">1</field>
+            <field name="reclamante">06</field>
+            <field name="agent_actual">06</field>
+            <field name="ref" ref="sw_001" />
 		</record>
     </data>
 </openerp>

--- a/som_switching/demo/som_switching_demo_data.xml
+++ b/som_switching/demo/som_switching_demo_data.xml
@@ -11,20 +11,11 @@
             <field name="agent_actual">06</field>
 		</record>
         <record  model="giscedata.switching" id="sw_001">
-            <field name="ref_contracte">Test</fiel>
+            <field name="ref_contracte">Test</field>
             <field name="data_sollicitud">2022-01-02</field>
-            <field name="proces_id" ref='sw_proces_r1' />
-            <field name="step_id" ref='sw_proces_r1' />
-		</record>
-        <record  model="giscedata.atc" id="cas_atc_0002">
-            <field name="name">ccc</field>
-            <field name="provincia">20</field>
-            <field name="section_id">1</field>
-            <field name="sector">electric</field>
-            <field name="subtipus_id">1</field>
-            <field name="reclamante">06</field>
-            <field name="agent_actual">06</field>
-            <field name="ref" ref="sw_001" />
+            <field name="proces_id" ref='giscedata_switching.sw_proces_r1' />
+            <field name="step_id" ref='giscedata_switching.sw_step_r1_01' />
+            <field name="company_id" ref="base.main_company"/>
 		</record>
     </data>
 </openerp>

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -43,7 +43,79 @@ class GiscedataAtc(osv.osv):
         return res
 
     def unlink(self, cursor, uid, ids, context=None):
-        super(GiscedataAtc, self).case_cancel(cursor, uid, ids, context)
+        return self.case_cancel(cursor, uid, ids, context)
+
+    def case_cancel(self, cursor, uid, ids, *args):
+        if not isinstance(ids, (list, tuple)):
+            ids = [ids]
+
+        cancel_ids = []
+        warning_info = []
+        for atc_id in ids:
+            atc = self.browse(cursor, uid, atc_id)
+            r1 = atc.ref
+            if r1:
+                model, index = r1.split(',')
+                m_obj = self.pool.get(model)
+                r1 = m_obj.browse(cursor, uid, int(index))
+
+            if atc.state == 'open' and atc.process_step == '01' and r1 and r1.enviament_pendent == False:
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 01 enviat a distribuïdora, per cancel·lar cal anul·lar amb un 08 i esperar el 09").format(atc_id))
+
+            if atc.state == 'open'and atc.process_step == '02':
+                r1_finalitzat = self.has_r1_no_finalitzat(cursor, uid, atc_id)
+                if r1 and not r1_finalitzat:
+                    raise osv.except_osv(
+                            _(u"Warning"),
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 cal esperar passos finalitzadors (per exemple 05) ").format(atc_id))
+
+                if r1 and r1_finalitzat:
+                    raise osv.except_osv(
+                            _(u"Warning"),
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 amb passos finalitzats").format(atc_id))
+
+            if atc.state == 'open' and atc.process_step == '04':
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 04 en estat Obert - ERROR MANUAL -").format(atc_id))
+
+            if atc.state == 'pending' and atc.process_step == '04':
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 04 en estat Pendent").format(atc_id))
+
+            if atc.state == 'open' and atc.process_step == '05':
+                if r1 and r1.state != 'open':
+                    raise osv.except_osv(
+                            _(u"Warning"),
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 en estat Pendent - ERROR MANUAL").format(atc_id))
+                else:
+                    raise osv.except_osv(
+                            _(u"Warning"),
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 en estat obert s'ha de gestionar i tancar sefons tancament indicat (procedent/improcedent)").format(atc_id))
+
+            if atc.state == 'open' and atc.process_step == '08':
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 08 no pots cancel·lar una cancel·lació, cal esperar a rebre pas 09 de distribuïdora").format(atc_id))
+
+            if atc.state == 'open' and atc.process_step == '09':
+                if r1 and r1.rebuig:
+                    raise osv.except_osv(
+                            _(u"Warning"),
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 09 de rebuig no es pot cancel·lar ni tancar").format(atc_id))
+                else:
+                    raise osv.except_osv(
+                            _(u"Warning"),
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 09 d'acceptació s'ha de tancar i no cancel·lar").format(atc_id))
+
+            cancel_ids.append(atc_id)
+
+        if cancel_ids:
+            return super(GiscedataAtc, self).case_cancel(self, cursor, uid, cancel_ids, *args)
+        return True
 
     _columns = {
         'tag': fields.many2one('giscedata.atc.tag', "Etiqueta"),

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -120,7 +120,7 @@ class GiscedataAtc(osv.osv):
             cancel_ids.append(atc_id)
 
         if cancel_ids:
-            return super(GiscedataAtc, self).case_cancel(self, cursor, uid, cancel_ids, *args)
+            return super(GiscedataAtc, self).case_cancel(cursor, uid, cancel_ids, *args)
         return True
 
     _columns = {

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -50,12 +50,13 @@ class GiscedataAtc(osv.osv):
             ids = [ids]
 
         cancel_ids = []
-        warning_info = []
         for atc_id in ids:
             atc = self.browse(cursor, uid, atc_id)
-            r1 = atc.ref
+
+            r1 = atc.has_process
             if r1:
-                model, index = r1.split(',')
+                ref = atc.ref if atc.ref else atc.ref2
+                model, index = ref.split(',')
                 m_obj = self.pool.get(model)
                 r1 = m_obj.browse(cursor, uid, int(index))
 
@@ -110,6 +111,11 @@ class GiscedataAtc(osv.osv):
                     raise osv.except_osv(
                             _(u"Warning"),
                             _(u"Cas ATC {} no es pot cancel·lar: R1 09 d'acceptació s'ha de tancar i no cancel·lar").format(atc_id))
+
+            if atc.state not in ('draft', 'pending', 'open'):
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: L'estat no és Pendent, Esborrany o Obert").format(atc_id))
 
             cancel_ids.append(atc_id)
 

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -77,7 +77,12 @@ class GiscedataAtc(osv.osv):
                             _(u"Warning"),
                             _(u"Cas ATC {} no es pot cancel·lar: R1 02 amb passos finalitzats").format(atc_id))
 
-            if atc.state == 'pending' and atc.process_step == '03':
+            if atc.state == 'open' and atc.process_step == '03':
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 03 en estat Obert").format(atc_id))
+
+            if atc.state =='pending' and atc.process_step == '03':
                 raise osv.except_osv(
                         _(u"Warning"),
                         _(u"Cas ATC {} no es pot cancel·lar: R1 03 en estat Pendent").format(atc_id))
@@ -100,7 +105,7 @@ class GiscedataAtc(osv.osv):
                 else:
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 en estat obert s'ha de gestionar i tancar sefons tancament indicat (procedent/improcedent)").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 en estat obert s'ha de gestionar i tancar segons tancament indicat (procedent/improcedent)").format(atc_id))
 
             if atc.state == 'open' and atc.process_step == '08':
                 raise osv.except_osv(

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -60,22 +60,22 @@ class GiscedataAtc(osv.osv):
                 m_obj = self.pool.get(model)
                 r1 = m_obj.browse(cursor, uid, int(index))
 
-            if atc.state == 'open' and atc.process_step == '01' and r1 and r1.enviament_pendent == True:
+            if atc.state == 'pending' and atc.process_step == '01' and r1 and r1.enviament_pendent == False:
                 raise osv.except_osv(
                         _(u"Warning"),
-                        _(u"Cas ATC {} no es pot cancel·lar: R1 01 enviat a distribuïdora, per cancel·lar cal anul·lar amb un 08 i esperar el 09").format(atc_id))
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 01 està pendent del pas finalitzador").format(atc_id))
 
             if atc.state in ['open', 'pending'] and atc.process_step == '02':
                 r1_finalitzat = self.has_r1_no_finalitzat(cursor, uid, atc_id)
                 if r1 and not r1_finalitzat:
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 cal esperar passos finalitzadors (per exemple 05) ").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 està pendent del pas finalitzador").format(atc_id))
 
                 if r1 and r1_finalitzat:
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 amb passos finalitzats").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 l'heu de revisar i tancar").format(atc_id))
 
             if atc.state == 'open' and atc.process_step == '03':
                 raise osv.except_osv(
@@ -85,7 +85,7 @@ class GiscedataAtc(osv.osv):
             if atc.state =='pending' and atc.process_step == '03':
                 raise osv.except_osv(
                         _(u"Warning"),
-                        _(u"Cas ATC {} no es pot cancel·lar: R1 03 en estat Pendent").format(atc_id))
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 03 està pendent del pas finalitzador").format(atc_id))
 
             if atc.state == 'open' and atc.process_step == '04':
                 raise osv.except_osv(
@@ -101,13 +101,13 @@ class GiscedataAtc(osv.osv):
                 if r1 and r1.state != 'open':
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 en estat Pendent - ERROR MANUAL").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 l'heu de revisar i tancar - Error manual R1 no oberta").format(atc_id))
                 else:
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 en estat obert s'ha de gestionar i tancar segons tancament indicat (procedent/improcedent)").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 05 l'heu de revisar i tancar").format(atc_id))
 
-            if atc.state == 'open' and atc.process_step == '08':
+            if atc.state in ['open', 'pending'] and atc.process_step == '08':
                 raise osv.except_osv(
                         _(u"Warning"),
                         _(u"Cas ATC {} no es pot cancel·lar: R1 08 no pots cancel·lar una cancel·lació, cal esperar a rebre pas 09 de distribuïdora").format(atc_id))

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -70,12 +70,12 @@ class GiscedataAtc(osv.osv):
                 if r1 and not r1_finalitzat:
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 està pendent del pas finalitzador").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 l'heu de revisar i tancar").format(atc_id))
 
                 if r1 and r1_finalitzat:
                     raise osv.except_osv(
                             _(u"Warning"),
-                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 l'heu de revisar i tancar").format(atc_id))
+                            _(u"Cas ATC {} no es pot cancel·lar: R1 02 està pendent del pas finalitzador").format(atc_id))
 
             if atc.state == 'open' and atc.process_step == '03':
                 raise osv.except_osv(

--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -60,12 +60,12 @@ class GiscedataAtc(osv.osv):
                 m_obj = self.pool.get(model)
                 r1 = m_obj.browse(cursor, uid, int(index))
 
-            if atc.state == 'open' and atc.process_step == '01' and r1 and r1.enviament_pendent == False:
+            if atc.state == 'open' and atc.process_step == '01' and r1 and r1.enviament_pendent == True:
                 raise osv.except_osv(
                         _(u"Warning"),
                         _(u"Cas ATC {} no es pot cancel·lar: R1 01 enviat a distribuïdora, per cancel·lar cal anul·lar amb un 08 i esperar el 09").format(atc_id))
 
-            if atc.state == 'open'and atc.process_step == '02':
+            if atc.state in ['open', 'pending'] and atc.process_step == '02':
                 r1_finalitzat = self.has_r1_no_finalitzat(cursor, uid, atc_id)
                 if r1 and not r1_finalitzat:
                     raise osv.except_osv(
@@ -76,6 +76,11 @@ class GiscedataAtc(osv.osv):
                     raise osv.except_osv(
                             _(u"Warning"),
                             _(u"Cas ATC {} no es pot cancel·lar: R1 02 amb passos finalitzats").format(atc_id))
+
+            if atc.state == 'pending' and atc.process_step == '03':
+                raise osv.except_osv(
+                        _(u"Warning"),
+                        _(u"Cas ATC {} no es pot cancel·lar: R1 03 en estat Pendent").format(atc_id))
 
             if atc.state == 'open' and atc.process_step == '04':
                 raise osv.except_osv(

--- a/som_switching/tests/tests_unlink_atc.py
+++ b/som_switching/tests/tests_unlink_atc.py
@@ -3,11 +3,13 @@
 from destral import testing
 from destral.transaction import Transaction
 from osv.osv import except_osv
+from giscedata_switching.tests.common_tests import TestSwitchingImport
+from addons import get_module_resource
+from datetime import date, datetime
 import mock
-from .. import giscedata_switching
-from .. import giscedata_atc
+import giscedata_atc_switching
 
-class TestUnlinkATC(testing.OOTestCase):
+class TestUnlinkATC(TestSwitchingImport):
 
     def setUp(self):
         self.txn = Transaction().start(self.database)
@@ -50,9 +52,9 @@ class TestUnlinkATC(testing.OOTestCase):
 
         self.assertEqual(atc.state, 'cancel')
 
-    def test__case_cancel_ATC_with_R101__NOCancelATC(self):
+    def test__case_cancel_ATC_with_R101_enviament_pendentFalse__CancelATC(self):
         """
-        Test case_cancel for atc 'open' with R101 without enviament_pendent, ATC is NOT cancelled
+        Test case_cancel for atc 'open' with R101 without enviament_pendent, ATC is cancelled
         """
         atc_o = self.pool.get('giscedata.atc')
         imd_obj = self.openerp.pool.get('ir.model.data')
@@ -62,6 +64,37 @@ class TestUnlinkATC(testing.OOTestCase):
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
         atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,1'})
+
+        atc_o.case_cancel(self.cursor, self.uid, atc_id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'cancel')
+
+    def test__case_cancel_ATC_with_R101_enviament_pendentTrue__NOCancelATC(self):
+        """
+        Test case_cancel for atc 'open' with R101 with enviament_pendent, ATC is not cancelled
+        """
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        self.switch(self.txn, 'comer')
+        contract_id = self.get_contract_id(self.txn)
+
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '01')
+
+        step_obj = self.openerp.pool.get('giscedata.switching.r1.01')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+        r101 = step_obj.browse(self.cursor, self.uid, step_id)
+        sw_id = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        r101.write({'enviament_pendent': True})
 
         try:
             atc_o.case_cancel(self.cursor, self.uid, atc_id)
@@ -73,3 +106,370 @@ class TestUnlinkATC(testing.OOTestCase):
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
         self.assertEqual(atc.state, 'open')
+
+    @mock.patch.object(giscedata_atc_switching.giscedata_atc.GiscedataAtc,"has_r1_no_finalitzat")
+    def test__case_cancel_ATC_with_R102_no_finalizat__NOCancelATC(self, mock_has_r1_no_finalitzat):
+        """
+        Test case_cancel for atc 'open' with R102 no finalitzat, ATC is not cancelled
+        """
+        mock_has_r1_no_finalitzat.return_value = False
+
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r102_new.xml')
+
+        self.switch(self.txn, 'comer')
+
+        r101_obj = self.openerp.pool.get('giscedata.switching.r1.01')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+
+        act_obj = self.openerp.pool.get("giscedata.switching.activation.config")
+        act_obj.write(self.cursor, self.uid, act_obj.search(self.cursor, self.uid, [], context={"active_test": False}), {'active': True, 'is_automatic': True})
+
+        contract_id = self.get_contract_id(self.txn)
+        self.change_polissa_comer(self.txn)
+        self.update_polissa_distri(self.txn)
+        # Creates step R1-01
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '01')
+
+        r101 = r101_obj.browse(self.cursor, self.uid, step_id)
+        sw_obj.write(self.cursor, self.uid, r101.sw_id.id, {'codi_sollicitud': '201602231255'})
+        # El creem ara perque la data sigui posterior a la posada al r101
+        data_old = '<FechaSolicitud>2016-09-29T09:39:08'
+        with open(r1_xml_path, 'r') as f:
+            data_new = datetime.strftime(datetime.now(),'%Y-%m-%dT%H:%M:%S')
+            r1_xml = f.read()
+            r1_xml = r1_xml.replace(
+                data_old, "<FechaSolicitud>{}".format(data_new)
+            )
+
+        sw_obj.importar_xml(self.cursor, self.uid, r1_xml, 'r102.xml')
+        sw_id = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 02 cal esperar passos finalitzadors (per exemple 05) '.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+
+    @mock.patch.object(giscedata_atc_switching.giscedata_atc.GiscedataAtc,"has_r1_no_finalitzat")
+    def test__case_cancel_ATC_with_R102_finalizat__NOCancelATC(self, mock_has_r1_no_finalitzat):
+        """
+        Test case_cancel for atc 'open' with R102 finalitzat, ATC is not cancelled
+        """
+        mock_has_r1_no_finalitzat.return_value = True
+
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r102_new.xml')
+
+        self.switch(self.txn, 'comer')
+
+        r101_obj = self.openerp.pool.get('giscedata.switching.r1.01')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+
+        act_obj = self.openerp.pool.get("giscedata.switching.activation.config")
+        act_obj.write(self.cursor, self.uid, act_obj.search(self.cursor, self.uid, [], context={"active_test": False}), {'active': True, 'is_automatic': True})
+
+        contract_id = self.get_contract_id(self.txn)
+        self.change_polissa_comer(self.txn)
+        self.update_polissa_distri(self.txn)
+        # Creates step R1-01
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '01')
+
+        r101 = r101_obj.browse(self.cursor, self.uid, step_id)
+        sw_obj.write(self.cursor, self.uid, r101.sw_id.id, {'codi_sollicitud': '201602231255'})
+        # El creem ara perque la data sigui posterior a la posada al r101
+        data_old = '<FechaSolicitud>2016-09-29T09:39:08'
+        with open(r1_xml_path, 'r') as f:
+            data_new = datetime.strftime(datetime.now(),'%Y-%m-%dT%H:%M:%S')
+            r1_xml = f.read()
+            r1_xml = r1_xml.replace(
+                data_old, "<FechaSolicitud>{}".format(data_new)
+            )
+
+        sw_obj.importar_xml(self.cursor, self.uid, r1_xml, 'r102.xml')
+        sw_id = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 02 amb passos finalitzats'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+
+    def test__case_cancel_ATC_with_R103__NOCancelATC(self):
+        """
+        Test case_cancel for atc 'open' or 'pending' with R103, ATC is not cancelled
+        """
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r103_new.xml')
+        with open(r1_xml_path, 'r') as f:
+            r103_xml = f.read()
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r102_new.xml')
+        with open(r1_xml_path, 'r') as f:
+            r102_xml = f.read()
+
+        self.switch(self.txn, 'comer')
+
+        r101_obj = self.openerp.pool.get('giscedata.switching.r1.01')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+
+        act_obj = self.openerp.pool.get("giscedata.switching.activation.config")
+        act_obj.write(self.cursor, self.uid, act_obj.search(self.cursor, self.uid, [], context={"active_test": False}), {'active': True, 'is_automatic': True})
+
+        contract_id = self.get_contract_id(self.txn)
+        self.change_polissa_comer(self.txn)
+        self.update_polissa_distri(self.txn)
+        # Creates step R1-01
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '01')
+
+        r101 = r101_obj.browse(self.cursor, self.uid, step_id)
+        sw_obj.write(self.cursor, self.uid, r101.sw_id.id, {'codi_sollicitud': '201602231255'})
+        # El creem ara perque la data sigui posterior a la posada al r101
+        data_old = '<FechaSolicitud>2016-09-29T09:39:08'
+        with open(r1_xml_path, 'r') as f:
+            data_new = datetime.strftime(datetime.now(),'%Y-%m-%dT%H:%M:%S')
+            r1_xml = f.read()
+            r1_xml = r1_xml.replace(
+                data_old, "<FechaSolicitud>{}".format(data_new)
+            )
+
+        sw_obj.importar_xml(self.cursor, self.uid, r102_xml, 'r102.xml')
+        sw_obj.importar_xml(self.cursor, self.uid, r103_xml, 'r103.xml')
+
+        sw_id = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 03 en estat Obert'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'pending', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 03 en estat Pendent'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'pending')
+
+    def test__case_cancel_ATC_with_R104__NOCancelATC(self):
+        """
+        Test case_cancel for atc 'open' or 'pending' with R104, ATC is not cancelled
+        """
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        self.switch(self.txn, 'comer')
+        contract_id = self.get_contract_id(self.txn)
+
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '04')
+
+        step_obj = self.openerp.pool.get('giscedata.switching.r1.04')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+        r104 = step_obj.browse(self.cursor, self.uid, step_id)
+        sw_id = sw_obj.browse(self.cursor, self.uid, r104.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 04 en estat Obert - ERROR MANUAL -'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'pending', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 04 en estat Pendent'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'pending')
+
+    def test__case_cancel_ATC_with_R105__NOCancelATC(self):
+        """
+        Test case_cancel for atc 'open' with R105, ATC is not cancelled
+        """
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r105_new.xml')
+        with open(r1_xml_path, 'r') as f:
+            r105_xml = f.read()
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r102_new.xml')
+        with open(r1_xml_path, 'r') as f:
+            r102_xml = f.read()
+
+        self.switch(self.txn, 'comer')
+
+        r101_obj = self.openerp.pool.get('giscedata.switching.r1.01')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+
+        act_obj = self.openerp.pool.get("giscedata.switching.activation.config")
+        act_obj.write(self.cursor, self.uid, act_obj.search(self.cursor, self.uid, [], context={"active_test": False}), {'active': True, 'is_automatic': True})
+
+        contract_id = self.get_contract_id(self.txn)
+        self.change_polissa_comer(self.txn)
+        self.update_polissa_distri(self.txn)
+        # Creates step R1-01
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '01')
+
+        r101 = r101_obj.browse(self.cursor, self.uid, step_id)
+        sw_obj.write(self.cursor, self.uid, r101.sw_id.id, {'codi_sollicitud': '201602231255'})
+        # El creem ara perque la data sigui posterior a la posada al r101
+        data_old = '<FechaSolicitud>2016-09-29T09:39:08'
+        with open(r1_xml_path, 'r') as f:
+            data_new = datetime.strftime(datetime.now(),'%Y-%m-%dT%H:%M:%S')
+            r1_xml = f.read()
+            r1_xml = r1_xml.replace(
+                data_old, "<FechaSolicitud>{}".format(data_new)
+            )
+
+        sw_obj.importar_xml(self.cursor, self.uid, r102_xml, 'r102.xml')
+        sw_obj.importar_xml(self.cursor, self.uid, r105_xml, 'r105.xml')
+
+        sw_id = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, "Cas ATC {} no es pot cancel·lar: R1 05 en estat obert s'ha de gestionar i tancar segons tancament indicat (procedent/improcedent)".format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+
+        sw_obj.write(self.cursor, self.uid, sw_id.id, {'state': 'pending'})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 05 en estat Pendent - ERROR MANUAL'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+
+    def test__case_cancel_ATC_with_R108__NOCancelATC(self):
+        """
+        Test case_cancel for atc 'open' with R108, ATC is not cancelled
+        """
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        r1_xml_path = get_module_resource('giscedata_switching', 'tests', 'fixtures', 'r108_new.xml')
+
+        self.switch(self.txn, 'comer')
+
+        r101_obj = self.openerp.pool.get('giscedata.switching.r1.01')
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+
+        act_obj = self.openerp.pool.get("giscedata.switching.activation.config")
+        act_obj.write(self.cursor, self.uid, act_obj.search(self.cursor, self.uid, [], context={"active_test": False}), {'active': True, 'is_automatic': True})
+
+        contract_id = self.get_contract_id(self.txn)
+        self.change_polissa_comer(self.txn)
+        self.update_polissa_distri(self.txn)
+        # Creates step R1-01
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, 'R1', '01')
+
+        r101 = r101_obj.browse(self.cursor, self.uid, step_id)
+        sw_obj.write(self.cursor, self.uid, r101.sw_id.id, {'codi_sollicitud': '201607211259'})
+        # El creem ara perque la data sigui posterior a la posada al r101
+        data_old = '<FechaSolicitud>2016-09-29T09:39:08'
+        with open(r1_xml_path, 'r') as f:
+            data_new = datetime.strftime(datetime.now(),'%Y-%m-%dT%H:%M:%S')
+            r1_xml = f.read()
+            r1_xml = r1_xml.replace(
+                data_old, "<FechaSolicitud>{}".format(data_new)
+            )
+
+        self.switch(self.txn, 'distri')
+        sw_obj.importar_xml(self.cursor, self.uid, r1_xml, 'r108.xml')
+        sw_id = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 08 no pots cancel·lar una cancel·lació, cal esperar a rebre pas 09 de distribuïdora'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')
+

--- a/som_switching/tests/tests_unlink_atc.py
+++ b/som_switching/tests/tests_unlink_atc.py
@@ -2,6 +2,10 @@
 
 from destral import testing
 from destral.transaction import Transaction
+from osv.osv import except_osv
+import mock
+from .. import giscedata_switching
+from .. import giscedata_atc
 
 class TestUnlinkATC(testing.OOTestCase):
 
@@ -28,3 +32,44 @@ class TestUnlinkATC(testing.OOTestCase):
         atc.unlink()
 
         self.assertEqual(atc.state, 'cancel')
+
+    def test__case_cancel_ATC_without_R1associat__cancelATC(self):
+        """
+        Test case_cancel for atc without R1 associat ATC is cancelled
+        """
+
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open'})
+
+        atc_o.case_cancel(self.cursor, self.uid, atc_id)
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'cancel')
+
+    def test__case_cancel_ATC_with_R101__NOCancelATC(self):
+        """
+        Test case_cancel for atc 'open' with R101 without enviament_pendent, ATC is NOT cancelled
+        """
+        atc_o = self.pool.get('giscedata.atc')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        atc_id = imd_obj.get_object_reference(self.cursor, self.uid, 'som_switching', 'cas_atc_0001')[1]
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,1'})
+
+        try:
+            atc_o.case_cancel(self.cursor, self.uid, atc_id)
+        except Exception, e:
+            atc_e = e
+
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 01 enviat a distribuïdora, per cancel·lar cal anul·lar amb un 08 i esperar el 09'.format(atc_id))
+
+        atc = atc_o.browse(self.cursor, self.uid, atc_id)
+
+        self.assertEqual(atc.state, 'open')

--- a/som_switching/tests/tests_unlink_atc.py
+++ b/som_switching/tests/tests_unlink_atc.py
@@ -54,7 +54,7 @@ class TestUnlinkATC(TestSwitchingImport):
 
     def test__case_cancel_ATC_with_R101_enviament_pendentFalse__CancelATC(self):
         """
-        Test case_cancel for atc 'open' with R101 without enviament_pendent, ATC is cancelled
+        Test case_cancel for atc 'pending' with R101 without enviament_pendent, ATC is cancelled
         """
         atc_o = self.pool.get('giscedata.atc')
         imd_obj = self.openerp.pool.get('ir.model.data')
@@ -63,7 +63,7 @@ class TestUnlinkATC(TestSwitchingImport):
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
-        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,1'})
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'pending', 'ref': 'giscedata.switching,1'})
 
         atc_o.case_cancel(self.cursor, self.uid, atc_id)
 
@@ -73,7 +73,7 @@ class TestUnlinkATC(TestSwitchingImport):
 
     def test__case_cancel_ATC_with_R101_enviament_pendentTrue__NOCancelATC(self):
         """
-        Test case_cancel for atc 'open' with R101 with enviament_pendent, ATC is not cancelled
+        Test case_cancel for atc 'pending' with R101 with enviament_pendent, ATC is not cancelled
         """
         atc_o = self.pool.get('giscedata.atc')
         imd_obj = self.openerp.pool.get('ir.model.data')
@@ -92,7 +92,7 @@ class TestUnlinkATC(TestSwitchingImport):
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
-        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'open', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
+        atc_o.write(self.cursor, self.uid, atc_id, {'state': 'pending', 'ref': 'giscedata.switching,{}'.format(sw_id.id)})
 
         r101.write({'enviament_pendent': True})
 
@@ -158,7 +158,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 02 cal esperar passos finalitzadors (per exemple 05) '.format(atc_id))
+        self.assertEqual(atc_e.value, u'Cas ATC {} no es pot cancel·lar: R1 02 està pendent del pas finalitzador'.format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
@@ -215,7 +215,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 02 amb passos finalitzats'.format(atc_id))
+        self.assertEqual(atc_e.value, u"Cas ATC {} no es pot cancel·lar: R1 02 l'heu de revisar i tancar".format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
@@ -290,7 +290,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 03 en estat Pendent'.format(atc_id))
+        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 03 està pendent del pas finalitzador'.format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
@@ -399,7 +399,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, "Cas ATC {} no es pot cancel·lar: R1 05 en estat obert s'ha de gestionar i tancar segons tancament indicat (procedent/improcedent)".format(atc_id))
+        self.assertEqual(atc_e.value, "Cas ATC {} no es pot cancel·lar: R1 05 l'heu de revisar i tancar".format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
@@ -412,7 +412,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, 'Cas ATC {} no es pot cancel·lar: R1 05 en estat Pendent - ERROR MANUAL'.format(atc_id))
+        self.assertEqual(atc_e.value, u"Cas ATC {} no es pot cancel·lar: R1 05 l'heu de revisar i tancar - Error manual R1 no oberta".format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 

--- a/som_switching/tests/tests_unlink_atc.py
+++ b/som_switching/tests/tests_unlink_atc.py
@@ -159,7 +159,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, u'Cas ATC {} no es pot cancel·lar: R1 02 està pendent del pas finalitzador'.format(atc_id))
+        self.assertEqual(atc_e.value, u"Cas ATC {} no es pot cancel·lar: R1 02 l'heu de revisar i tancar".format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
@@ -216,7 +216,7 @@ class TestUnlinkATC(TestSwitchingImport):
         except Exception, e:
             atc_e = e
 
-        self.assertEqual(atc_e.value, u"Cas ATC {} no es pot cancel·lar: R1 02 l'heu de revisar i tancar".format(atc_id))
+        self.assertEqual(atc_e.value, u"Cas ATC {} no es pot cancel·lar: R1 02 està pendent del pas finalitzador".format(atc_id))
 
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 


### PR DESCRIPTION
## Objectiu

Afegir control d'errors a l'acció de esborrar o cancel·lar casos ATC

## Targeta on es demana o Incidència 

https://trello.com/c/jFeFA0Iv/5315-0-4-p29-ep271-pollir-lassistent-de-change-state-del-m%C3%B2dul-cac-per-introduir-restriccions-al-cas-cancellareclama33

## Comportament antic

Cancel·lava casos ATC que no es podien cancel·lar 

## Comportament nou

No permet cancel·lar casos ATC

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
