### PR TITLE
Add category energetica when contract creation

### DIFF
--- a/som_energetica/__terp__.py
+++ b/som_energetica/__terp__.py
@@ -12,6 +12,7 @@
         "giscedata_facturacio_comer",
         "som_polissa_soci",
         "som_switching",
+        "som_polissa_administradora",
     ],
     "init_xml": [],
     "demo_xml": [],

--- a/som_energetica/giscedata_polissa.py
+++ b/som_energetica/giscedata_polissa.py
@@ -116,5 +116,13 @@ class GiscedataPolissa(osv.osv):
                 'Added partner {} to Energética category'.format(p_data['name'])
             )
 
+    def create(self, cursor, uid, vals, context=None):
+        res_id = super(GiscedataPolissa,
+                       self).create(cursor, uid, vals, context)
+
+        if self.is_energetica(cursor, uid, res_id):
+            self.set_energetica(cursor, uid, [res_id], context)
+
+        return res_id
 
 GiscedataPolissa()

--- a/som_energetica/giscedata_polissa.py
+++ b/som_energetica/giscedata_polissa.py
@@ -75,6 +75,17 @@ class GiscedataPolissa(osv.osv):
             if contract.pagador and cat_energetica_id not in [x.id for x in contract.pagador.category_id]:
                 partners_list.append(contract.pagador.id)
 
+            if contract.altre_p and cat_energetica_id not in [x.id for x in contract.altre_p.category_id]:
+                partners_list.append(contract.altre_p.id)
+
+            if contract.administradora and cat_energetica_id not in [x.id for x in contract.administradora.category_id]:
+                partners_list.append(contract.administradora.id)
+
+            if contract.bank and \
+                contract.bank.partner_id and \
+                cat_energetica_id not in [x.id for x in contract.bank.partner_id.category_id]:
+                partners_list.append(contract.bank.partner_id.id)
+
             if contract.direccio_pagament and \
                 contract.direccio_pagament.partner_id and \
                 cat_energetica_id not in [x.id for x in contract.direccio_pagament.partner_id.category_id]:

--- a/som_energetica/giscedata_polissa.py
+++ b/som_energetica/giscedata_polissa.py
@@ -51,33 +51,39 @@ class GiscedataPolissa(osv.osv):
         :param context:
         :return: llista amb les partners a modificar
         """
-        contract_fields = ['titular', 'pagador', 'altre_p', 'propietari_bank']
+
         imd_obj = self.pool.get('ir.model.data')
-        partner_obj = self.pool.get('res.partner')
 
         if not isinstance(contract_ids, (list, tuple)):
             contract_ids = [contract_ids]
-
-        contracts_data = self.read(cursor, uid, contract_ids, contract_fields)
 
         cat_energetica_id = imd_obj.get_object_reference(
             cursor, uid, 'som_energetica', 'res_partner_category_energetica'
         )[1]
 
         partners_list = []
-        for contract_data in contracts_data:
-            contract_id = contract_data['id']
+
+        for contract_id in contract_ids:
             if not self.is_energetica(cursor, uid, contract_id):
                 continue
-            for contract_field in contract_fields:
-                if not contract_data[contract_field]:
-                    continue
-                partner_id = contract_data[contract_field][0]
-                partner_data = partner_obj.read(
-                    cursor, uid, partner_id, context=context
-                )
-                if cat_energetica_id not in partner_data['category_id']:
-                    partners_list.append(partner_id)
+
+            contract = self.browse(cursor, uid, contract_id, context)
+
+            if contract.titular and cat_energetica_id not in [x.id for x in contract.titular.category_id]:
+                partners_list.append(contract.titular.id)
+
+            if contract.pagador and cat_energetica_id not in [x.id for x in contract.pagador.category_id]:
+                partners_list.append(contract.pagador.id)
+
+            if contract.direccio_pagament and \
+                contract.direccio_pagament.partner_id and \
+                cat_energetica_id not in [x.id for x in contract.direccio_pagament.partner_id.category_id]:
+                partners_list.append(contract.direccio_pagament.partner_id.id)
+
+            if contract.direccio_notificacio and \
+                contract.direccio_notificacio.partner_id and \
+                cat_energetica_id not in [x.id for x in contract.direccio_notificacio.partner_id.category_id]:
+                partners_list.append(contract.direccio_notificacio.partner_id.id)
 
         return list(set(partners_list))
 

--- a/som_energetica/tests/test_som_energetica_contract.py
+++ b/som_energetica/tests/test_som_energetica_contract.py
@@ -69,7 +69,7 @@ class EnergeticaTests(testing.OOTestCase):
         contract_obj = self.openerp.pool.get('giscedata.polissa')
         imd_obj = self.openerp.pool.get('ir.model.data')
 
-        for field in 'titular', 'pagador', 'altre_p', 'propietari_bank':
+        for field in 'titular', 'pagador', 'altre_p':
             with Transaction().start(self.database) as txn:
                 cursor = txn.cursor
                 uid = txn.user
@@ -100,6 +100,102 @@ class EnergeticaTests(testing.OOTestCase):
                 )
 
                 expect(partners_ids).to_not(contain(field_object.id))
+
+    def test_bad_energetica_partners_full(self):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            contract_obj = self.openerp.pool.get('giscedata.polissa')
+            partner_obj = self.openerp.pool.get('res.partner')
+            address_obj = self.openerp.pool.get('res.partner.address')
+            bank_obj = self.openerp.pool.get('res.partner.bank')
+            imd_obj = self.openerp.pool.get('ir.model.data')
+
+            cat_energetica_id = imd_obj.get_object_reference(
+                cursor, uid,
+                'som_energetica', 'res_partner_category_energetica'
+            )[1]
+
+            contract_id = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_polissa', 'polissa_0001'
+            )[1]
+
+            partner_ids = partner_obj.search(cursor, uid, [])
+            bank_ids = bank_obj.search(cursor, uid, [])
+            address_ids = address_obj.search(cursor, uid, [])
+            contract_obj.write(cursor, uid ,contract_id,{
+                'titular': partner_ids[-1],
+                'pagador': partner_ids[-2],
+                'altre_p': partner_ids[-3],
+                'administradora': partner_ids[-4],
+                'bank': bank_ids[-1],
+                'direccio_pagament': address_ids[-1],
+                'direccio_notificacio': address_ids[-2],
+            })
+            address_obj.write(cursor, uid, address_ids[-1] , {'partner_id': partner_ids[-5]})
+            address_obj.write(cursor, uid, address_ids[-2] , {'partner_id': partner_ids[-6]})
+            bank_obj.write(cursor, uid, bank_ids[-1] , {'partner_id': partner_ids[-7]})
+
+            bad_ids = contract_obj.get_bad_energetica_partners(
+                cursor, uid, contract_id
+            )
+            expect(bad_ids).to(be_empty)
+
+            self.set_soci(cursor, uid, contract_id)
+
+            bad_ids = contract_obj.get_bad_energetica_partners(
+                cursor, uid, contract_id
+            )
+            expect(set(bad_ids)).to(equal(set(partner_ids[-7:])))
+
+    def test_bad_energetica_partners_one(self):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            contract_obj = self.openerp.pool.get('giscedata.polissa')
+            partner_obj = self.openerp.pool.get('res.partner')
+            address_obj = self.openerp.pool.get('res.partner.address')
+            bank_obj = self.openerp.pool.get('res.partner.bank')
+            imd_obj = self.openerp.pool.get('ir.model.data')
+
+            cat_energetica_id = imd_obj.get_object_reference(
+                cursor, uid,
+                'som_energetica', 'res_partner_category_energetica'
+            )[1]
+
+            contract_id = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_polissa', 'polissa_0001'
+            )[1]
+
+            partner_ids = partner_obj.search(cursor, uid, [])
+            bank_ids = bank_obj.search(cursor, uid, [])
+            address_ids = address_obj.search(cursor, uid, [])
+            contract_obj.write(cursor, uid ,contract_id,{
+                'titular': partner_ids[-1],
+                'pagador': partner_ids[-1],
+                'altre_p': partner_ids[-1],
+                'administradora': partner_ids[-1],
+                'bank': bank_ids[-1],
+                'direccio_pagament': address_ids[-1],
+                'direccio_notificacio': address_ids[-2],
+            })
+            address_obj.write(cursor, uid, address_ids[-1] , {'partner_id': partner_ids[-1]})
+            address_obj.write(cursor, uid, address_ids[-2] , {'partner_id': partner_ids[-1]})
+            bank_obj.write(cursor, uid, bank_ids[-1] , {'partner_id': partner_ids[-1]})
+
+            bad_ids = contract_obj.get_bad_energetica_partners(
+                cursor, uid, contract_id
+            )
+            expect(bad_ids).to(be_empty)
+
+            self.set_soci(cursor, uid, contract_id)
+
+            bad_ids = contract_obj.get_bad_energetica_partners(
+                cursor, uid, contract_id
+            )
+            expect(set(bad_ids)).to(equal(set(partner_ids[-1:])))
 
     def test_set_energetica(self):
         contract_obj = self.openerp.pool.get('giscedata.polissa')
@@ -202,7 +298,7 @@ class EnergeticaTests(testing.OOTestCase):
                 expect(partner_data['category_id']).not_to(contain(cat_energetica_id))
 
     def get_all_partners(self, cursor, uid, contract_id):
-        contract_fields = ['titular', 'pagador', 'altre_p', 'propietari_bank']
+        contract_fields = ['titular', 'pagador', 'altre_p', 'administradora']
         contract_obj = self.openerp.pool.get('giscedata.polissa')
         contract_data = contract_obj.read(cursor, uid, contract_id, contract_fields)
 
@@ -212,5 +308,16 @@ class EnergeticaTests(testing.OOTestCase):
                 continue
             partner_id = contract_data[contract_field][0]
             partners_list.append(partner_id)
+
+        contract = contract_obj.browse(cursor, uid, contract_id)
+
+        if contract.bank and contract.bank.partner_id:
+            partners_list.append(contract.bank.partner_id.id)
+
+        if contract.direccio_pagament and contract.direccio_pagament.partner_id:
+            partners_list.append(contract.direccio_pagament.partner_id.id)
+
+        if contract.direccio_notificacio and contract.direccio_notificacio.partner_id:
+            partners_list.append(contract.direccio_notificacio.partner_id.id)
 
         return list(set(partners_list))


### PR DESCRIPTION
## Objectiu
Quan creem una políssa amb soci d'Energètica, als partners s'els ha d'afergir la categoria Energètica. Els partners han de ser: titular, pagador, altre_p, i propietari_bank.

## Targeta on es demana o Incidència 
https://trello.com/c/NUAiUJbg/5363-0-0-p33-posar-categoria-als-clients-denerg%C3%A9tica-al-fer-una-alta-nova

## Comportament antic
No s'afegia la categoria Energètica als partners quan es creava un contracte.

## Comportament nou
S'afegeix la categoria Energètica quan es crea el contracte

## Comprovacions

- [X] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
