### PR TITLE
Modificacions al pdf de la factura per boe 18/2022 part 1

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1311,6 +1311,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     'name': l.name,
                     'base': l.base,
                     'amount': l.amount,
+                    'disclaimer_21_to_5': l.name == 'IVA 5%',
                 })
             if 'IGIC' in l.name:
                 igic_lines.append({
@@ -2067,7 +2068,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
     def get_component_invoice_details_info_td_data(self, fact, pol):
         data = {
-            'has_autoconsum': te_autoconsum(fact, pol)
+            'has_autoconsum': te_autoconsum(fact, pol),
+            'has_mag': True if self.get_mag_lines_info(fact) else False,
         }
         return data
 

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako
@@ -9,6 +9,9 @@
 <td class="td_text">
     ${_(u"Els preus dels termes de peatges de transport i distribució són els publicats en el BOE núm. 70, de 23 de març de 2021. Els preus dels càrrecs són els publicats a l'Ordre TED/371/2021. Els preus del lloguer dels comptadors són els publicats a l'Ordre ITC/3860/2007.")}
     <br>
+    % if id_info.has_mag:
+        ${_(u"Les comercialitzadores en mercat lliure poden triar voluntàriament repercutir l'import de l'energia associada a la compensació del mecanisme ibèric regulat pel Reial decret llei 10/2022, de 13 de maig, dins dels costos d'aprovisionament, o bé traslladar-lo de manera diferenciada els seus consumidors. En aquest cas, la seva comercialitzadora ha optat per aquesta última opció.")}
+    % endif
     % if id_info.has_autoconsum:
         <br>
         ${_(u"(1) Segons estableix el Reial Decret 244/2019 aquest import no serà mai superior al l'import per energia utilitzada. En cas que la compensació sigui superior a l'energia utilitzada, el terme d'energia serà igual a 0€")}

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako
@@ -61,7 +61,7 @@ first_energy_line = True
 % if id.mag_line_data:
     <tr class="tr_bold">
         <td class="detall_td">
-            ${_(u"Import associat al mecanisme d'ajust del gas RDL 10/2022 (%s kWh x %s €/kWh)") % (
+            ${_(u"Import de l'energia associada al mecanisme ibèric regulat pel Reial decret llei 10/2022, de 13 de maig. (%s kWh x %s €/kWh)") % (
                 locale.str(locale.atof(formatLang(id.mag_line_data.quantity, digits=3))),
                 locale.str(locale.atof(formatLang(id.mag_line_data.price, digits=6)))
             )}<br>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
@@ -40,12 +40,13 @@ first_pass = True
             <td class="detall_td" colspan="${id.number_of_columns}">
                 % if l.tax_type == '0.5percent':
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_iese']))}
+                    ${_(u"En virtut del Reial decret llei 17/2021, de 14 de setembre, l'impost especial sobre l'electricitat aplicable a la factura es troba reduït del 5,11269632%% al 0,5%%.")}
                 % elif l.tax_type == '1euroMWh':
                     ${_(u"%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense bonificació del 85%%)") % (formatLang(l['base_iese']))}
                 % elif l.tax_type == '0.5euroMWh':
                     ${_(u"%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense bonificació del 85%%)") % (formatLang(l['base_iese']))}
                 % elif l.tax_type == 'excempcio':
-                    ${_(u"%s € x 0,5%%") % (formatLang(l['base_iese']))}
+                    ${_(u"%s € x 0,5%% kaka") % (formatLang(l['base_iese']))}
                 % else:
                     ${_(u"%s € x 5,11269%%") % (formatLang(l['base_iese']))}
                 % endif
@@ -66,6 +67,7 @@ first_pass = True
             <td class="detall_td" colspan="${id.number_of_columns}">
                 % if l.tax_type == '0.5percent':
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_amount']))}
+                    ${_(u"En virtut del Reial decret llei 17/2021, de 14 de setembre, l'impost especial sobre l'electricitat aplicable a la factura es troba reduït del 5,11269632%% al 0,5%%.")}
                 % elif l.tax_type == '1euroMWh':
                     ${_(u"%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014)") % (formatLang(l['base_amount']))}
                 % elif l.tax_type == '0.5euroMWh':
@@ -88,7 +90,11 @@ first_pass = True
 % for l in id.iva_lines:
     <tr>
         <td class="td_first concepte_td">${l['name']}</td>
-        <td class="detall_td" colspan="${id.number_of_columns}">${_(u"%s € ") % (formatLang(l['base']))}${_(u"(BASE IMPOSABLE)")}</td>
+        <td class="detall_td" colspan="${id.number_of_columns}">${_(u"%s € ") % (formatLang(l['base']))}${_(u"(BASE IMPOSABLE)")}
+        %if l.disclaimer_21_to_5:
+            ${_(u"En virtut del Reial decret llei 12/2021, de 24 de juny, l'IVA aplicable a la factura es troba reduït del 21% al 5%.")}
+        %endif
+        </td>
         <td class="subtotal">${_(u"%s €") % formatLang(l['amount'])}</td>
     </tr>
 % endfor


### PR DESCRIPTION
## Objectiu

Aplicar les modificacions al pdf de la factura per l'entrada del BOE 18/2022 d'aplicació mediata.

## Targeta on es demana o Incidència 

https://trello.com/c/mQiGUFcw/5467-0-6-add-modificar-pdf-per-aplicaci%C3%B3-real-decreto-ley-18-2022-de-18-de-octubre-part-1

## Comportament antic

no complim amb el BOE 18/2022

## Comportament nou

complim parcialment el BOE 18/2022

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
    - Giscedata_facturacio_comer_som
- [ ] Script de migració
- [x] Modifica traduccions
