### PR TITLE
Support different servers

### DIFF
--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -93,9 +93,9 @@ class SomCrawlersTaskStep(osv.osv):
         output = ''
         if 'process' in task_step_params:
             name = config_obj.name + '_' + task_step_params['process']
-            path_to_zip = os.path.join(path,'spiders/selenium_spiders/tmp/', name)
+            path_to_zip = os.path.join(path, name)
         else:
-           path_to_zip = os.path.join(path,'spiders/selenium_spiders/tmp/', config_obj.name)
+           path_to_zip = os.path.join(path, config_obj.name)
         if not os.path.exists(path_to_zip):
             output = "zip directory doesn\'t exist"
         else:
@@ -108,8 +108,12 @@ class SomCrawlersTaskStep(osv.osv):
                     output = "files succesfully attached"
         return output
 
-    def attach_files_screenshot(self, cursor, uid, config_obj, path, result_id, context=None):
-        path_to_screenshot = os.path.join(path,'spiders/selenium_spiders/screenShots/' + config_obj.name)
+    def attach_files_screenshot(self, cursor, uid, config_obj, path, result_id, task_step_params, context=None):
+        if 'process' in task_step_params:
+            name = config_obj.name + '_' + task_step_params['process']
+            path_to_screenshot = os.path.join(path, name)
+        else:
+           path_to_screenshot = os.path.join(path, config_obj.name)
         if os.path.exists(path_to_screenshot):
             for file_name in os.listdir(path_to_screenshot):
                 self.attach_file(cursor, uid, path_to_screenshot, file_name, result_id, context)
@@ -133,12 +137,12 @@ class SomCrawlersTaskStep(osv.osv):
                 file_name = "output_" + config_obj.name + "_" + datetime.now().strftime("%Y-%m-%d_%H_%M_%S_%f") + ".txt"
                 args_str = self.create_script_args(config_obj, task_step_params, file_name)
                 ret_value = os.system("{} {} {}".format(path_python, script_path, args_str))
-                output_temp_path = self.get_output_path(cursor, uid)
-                output = self.readOutputFile(cursor, uid, output_temp_path, file_name)
+                output_path = self.get_output_path(cursor, uid)
+                output = self.readOutputFile(cursor, uid, output_path, file_name)
                 if output == 'Files have been successfully downloaded':
-                    output = self.attach_files_zip(cursor, uid, id, result_id, config_obj, path, task_step_params, context = context)
+                    output = self.attach_files_zip(cursor, uid, id, result_id, config_obj, output_path, task_step_params, context = context)
                 else:
-                    self.attach_files_screenshot(cursor, uid, config_obj, path, result_id, context)
+                    self.attach_files_screenshot(cursor, uid, config_obj, output_path, result_id, task_step_params, context)
                     raise Exception("%s" % output)
             else:
                 output = 'File or directory doesn\'t exist'
@@ -364,7 +368,7 @@ class SomCrawlersTaskStep(osv.osv):
                 else:
                     output = self.readOutputFile(cursor, uid, path_to_zip, execution_restult_file)
                 if output != 'Files have been successfully uploaded':
-                    self.attach_files_screenshot(cursor, uid, config_obj, path, result_id, context)
+                    self.attach_files_screenshot(cursor, uid, config_obj, path, result_id, task_step_params, context)
                     raise Exception("%s" % output)
             else:
                 output = 'File or directory doesn\'t exist'

--- a/som_crawlers/tests/wizard_executar_tasca_tests.py
+++ b/som_crawlers/tests/wizard_executar_tasca_tests.py
@@ -196,11 +196,12 @@ class WizardExecutarTascaTests(testing.OOTestCase):
             crawler_config_id= self.Data.get_object_reference(cursor,uid,'som_crawlers','anselmo_conf')[1]
             result_id = self.Data.get_object_reference(cursor, uid, 'som_crawlers', 'demo_result_2')[1]
             crawler_config_obj = self.Configuracio.browse(cursor,uid,crawler_config_id)
-            pathFileActual = os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')
+            empty_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),'anselmo')
+            current_path = os.path.dirname(os.path.realpath(__file__))
+            os.mkdir(empty_path)
             taskStepParams = {}
-
-            result = self.taskStep.attach_files_zip(cursor, uid, crawler_taskStep_id, result_id, crawler_config_obj, pathFileActual, taskStepParams, context=None)
-
+            result = self.taskStep.attach_files_zip(cursor, uid, crawler_taskStep_id, result_id, crawler_config_obj, current_path, taskStepParams, context=None)
+            os.rmdir(empty_path)
             self.assertEqual(result,'Directori doesn\'t contain any ZIP')
 
 
@@ -215,10 +216,13 @@ class WizardExecutarTascaTests(testing.OOTestCase):
             crawler_taskStep_id= self.Data.get_object_reference(cursor,uid,'som_crawlers','demo_taskStep_8')[1]
             crawler_config_obj = self.Configuracio.browse(cursor,uid,crawler_config_id)
             pathFileActual = os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')
-            os.system('cp ' + pathFileActual + '/demo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip ' + pathFileActual + '/spiders/selenium_spiders/tmp/anselmo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip')
+            path_desti = self.taskStep.get_output_path(cursor, uid)
+            if not os.path.exists(path_desti):
+                os.mkdir(path_desti)
+            os.system('cp ' + pathFileActual + '/demo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip ' + path_desti + '/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip')
             taskStepParams = {}
 
-            result = self.taskStep.attach_files_zip(cursor, uid, crawler_taskStep_id, result_id, crawler_config_obj, pathFileActual, taskStepParams, context=None)
+            result = self.taskStep.attach_files_zip(cursor, uid, crawler_taskStep_id, result_id, crawler_config_obj, path_desti, taskStepParams, context=None)
 
             self.assertEqual(result,'files succesfully attached')
 

--- a/som_crawlers/tests/wizard_executar_tasca_tests.py
+++ b/som_crawlers/tests/wizard_executar_tasca_tests.py
@@ -219,7 +219,7 @@ class WizardExecutarTascaTests(testing.OOTestCase):
             path_desti = self.taskStep.get_output_path(cursor, uid)
             if not os.path.exists(path_desti):
                 os.mkdir(path_desti)
-            os.system('cp ' + pathFileActual + '/demo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip ' + path_desti + '/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip')
+            os.system('cp ' + pathFileActual + '/demo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip ' + path_desti + '/anselmo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip')
             taskStepParams = {}
 
             result = self.taskStep.attach_files_zip(cursor, uid, crawler_taskStep_id, result_id, crawler_config_obj, path_desti, taskStepParams, context=None)

--- a/som_crawlers/tests/wizard_executar_tasca_tests.py
+++ b/som_crawlers/tests/wizard_executar_tasca_tests.py
@@ -216,9 +216,10 @@ class WizardExecutarTascaTests(testing.OOTestCase):
             crawler_taskStep_id= self.Data.get_object_reference(cursor,uid,'som_crawlers','demo_taskStep_8')[1]
             crawler_config_obj = self.Configuracio.browse(cursor,uid,crawler_config_id)
             pathFileActual = os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')
-            path_desti = self.taskStep.get_output_path(cursor, uid)
-            if not os.path.exists(path_desti):
-                os.mkdir(path_desti)
+            path_desti = os.path.join(os.path.dirname(os.path.realpath(__file__)),'tmpDir')
+            create_path = os.path.join(path_desti,'anselmo')
+            if not os.path.exists(create_path):
+                os.mkdir(create_path)
             os.system('cp ' + pathFileActual + '/demo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip ' + path_desti + '/anselmo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip')
             taskStepParams = {}
 

--- a/som_crawlers/tests/wizard_executar_tasca_tests.py
+++ b/som_crawlers/tests/wizard_executar_tasca_tests.py
@@ -219,6 +219,7 @@ class WizardExecutarTascaTests(testing.OOTestCase):
             path_desti = os.path.join(os.path.dirname(os.path.realpath(__file__)),'tmpDir')
             create_path = os.path.join(path_desti,'anselmo')
             if not os.path.exists(create_path):
+                os.mkdir(path_desti)
                 os.mkdir(create_path)
             os.system('cp ' + pathFileActual + '/demo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip ' + path_desti + '/anselmo/anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip')
             taskStepParams = {}


### PR DESCRIPTION
## Objectiu
Support having som_crawlers workers in servers different from erp01

## Targeta on es demana o Incidència 

https://trello.com/c/p7YTCg38/5507-0-0-p27-ep259-moure-els-workers-fora-derp01
## Comportament antic

Processes downloaded files inside som_crawlers path

## Comportament nou

Processes now write everything on /tmp/outputFiles

## Comprovacions
Needs: https://gitlab.somenergia.coop/IT/massive_importer_crawlers/-/merge_requests/64

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
