### PR TITLE
Temps espera per adjunt de mongo configurable

### DIFF
--- a/som_crawlers/data/som_crawlers_config_data.xml
+++ b/som_crawlers/data/som_crawlers_config_data.xml
@@ -363,6 +363,11 @@
             <field name="value">/tmp/outputFiles</field>
             <field name="description">Ruta dels fitxers temporals del massive importer</field>
         </record>
+        <record model="res.config" id="som_crawlers_sleep_mongo_attachment">
+            <field name="name">som_crawlers_sleep_mongo_attachment</field>
+            <field name="value">100</field>
+            <field name="description">Segons d'espera abans de tornar a provar si s'ha pujat el zip a mongo</field>
+        </record>
         <!-- Executar tasques a partir d'un cron -->
         <record id="ir_cron_run_tasks_action" model="ir.cron">
             <field name="name">Executar crawlers programats distris</field>

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -177,9 +177,14 @@ class SomCrawlersTaskStep(osv.osv):
             except TypeError as e:
                 if 'a2b_base64' not in e.message:
                     raise e
-                sleep(10)
+                cfg_obj = self.pool.get('res.config')
+                sleep_time = int(cfg_obj.get(cursor, uid, 'som_crawlers_sleep_mongo_attachment', '100'))
+                sleep(sleep_time)
                 output = self.import_xml_files(cursor, uid, id, result_id, nivell-1, context)
                 return output
+            except Exception as e:
+                raise Exception("IMPORTANT: {}: {}".format(type(e).__name__, str(e)))
+
 
         task_step_obj.task_id.write({'ultima_tasca_executada': str(task_step_obj.name)+ ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
         classresult.write(cursor, uid, result_id, {'resultat_bool': True})


### PR DESCRIPTION
## Objectiu
Poder fer configurable el temps d'espera a recuperar l'adjunt

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2067162805/13735335?folderId=3063374

## Comportament antic
Estava hardcodejat i havíem de fer PR per modificar el temps.

## Comportament nou
Ara es pot fer per variable de configuració de l'ERP

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
