### PR TITLE
Script renquar faileds del RQ

### DIFF
--- a/scripts/requeue_failed.py
+++ b/scripts/requeue_failed.py
@@ -11,53 +11,20 @@ import argparse
 
 INTERVAL = 7200  # Seconds
 MAX_ATTEMPTS = 5
-PERMANENT_FAILED = 'permanent'
+QUEUES_TO_REQUEUE = ['cups_cch']
+QUEUES_TO_DELETE = ['jobspool-autoworker']
 
 redis_conn = from_url(sys.argv[1])
 use_connection(redis_conn)
 
 all_queues = Queue().all()
-pfq = FailedJobRegistry(PERMANENT_FAILED)
-pq = Queue(name=PERMANENT_FAILED)
-
-for queue in all_queues:
-    fq = FailedJobRegistry(queue.name)
-    for job_id in fq.get_job_ids():
-        job = Job.fetch(job_id)
-        if not job.meta.get('requeue', True):
-            continue
-        job.meta.setdefault('attempts', 0)
-        if job.meta['attempts'] > MAX_ATTEMPTS:
-            print("Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (
-                    job.id, job.meta['attempts'], MAX_ATTEMPTS, job.origin
-            ))
-            print(job.description)
-            print(job.exc_info)
-            print()
-            fq.remove(job)
-            pq.enqueue_job(job)
-            print("Moved to %s FailedJobRegistry" % PERMANENT_FAILED)
-        else:
-            ago = (times.now() - job.enqueued_at).seconds
-            if ago >= INTERVAL:
-                print("%s: attemps: %s enqueued: %ss ago on %s (Requeue)" % (
-                    job.id, job.meta['attempts'], ago, job.origin
-                ))
-                job.meta['attempts'] += 1
-                job.save()
-                requeue_job(job.id, connection=redis_conn)
 
 
 def main(redis_conn, interval, max_attempts, permanent_failed):
     use_connection(redis_conn)
-
     all_queues = Queue().all()
-    pfq = FailedJobRegistry(permanent_failed)
-    pq = Queue(name=permanent_failed)
     print("{}: Try to requeu jobs".format(str(datetime.now())))
     for queue in all_queues:
-        if queue.name == 'jobspool-autoworker':
-            continue
         fq = FailedJobRegistry(queue.name)
         for job_id in fq.get_job_ids():
             try:
@@ -71,32 +38,38 @@ def main(redis_conn, interval, max_attempts, permanent_failed):
                     print("We cannot delete job in FailedJobRegistry")
                     print(job_id)
                     print(e)
-            if not job.meta.get('requeue', True):
-                print("Job {} of Queue {} was marked as job.meta.requeue=false but we requeue it.".format(job_id, queue.name))
-                #continue
+            #if not job.meta.get('requeue', True):
+            #    print("Job {} of Queue {} was marked as job.meta.requeue=false but we requeue it.".format(job_id, queue.name))
+            #    #continue
             if job.is_finished:
                 key_registry = fq.key
                 redis_conn.zrem(key_registry,job_id)
-            job.meta.setdefault('attempts', 0)
-            if job.meta['attempts'] > max_attempts:
-                print("Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (
-                        job.id, job.meta['attempts'], max_attempts, job.origin
-                ))
-                print(job.description)
-                print(job.exc_info)
-                print()
-                #fq.remove(job)
-                #pq.enqueue_job(job)
-                print("Moved to %s FailedJobRegistry" % permanent_failed)
-            else:
-                ago = (times.now() - job.enqueued_at).seconds
-                if ago >= interval:
-                    print("%s: attemps: %s enqueued: %ss ago on %s (Requeue)" % (
-                        job.id, job.meta['attempts'], ago, job.origin
+            if queue.name in QUEUES_TO_REQUEUE:
+                job.meta.setdefault('attempts', 0)
+                if job.meta['attempts'] > max_attempts:
+                    print("Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (
+                            job.id, job.meta['attempts'], max_attempts, job.origin
                     ))
-                    job.meta['attempts'] += 1
-                    job.save()
-                    #requeue_job(job.id, connection=redis_conn)
+                    print(job.description)
+                    print(job.exc_info)
+                    continue
+                else:
+                    ago = (times.now() - job.enqueued_at).seconds
+                    if ago >= interval:
+                        print("%s: attemps: %s enqueued: %ss ago on %s (Requeue)" % (
+                            job.id, job.meta['attempts'], ago, job.origin
+                        ))
+                        job.meta['attempts'] += 1
+                        job.save()
+                        requeue_job(job.id, connection=redis_conn)
+            elif queue.name in QUEUES_TO_DELETE:
+                try:
+                    key_registry = fq.key
+                    redis_conn.zrem(key_registry,job_id)
+                except Exception as e:
+                    print("We cannot delete job in FailedJobRegistry")
+                    print(job_id)
+                    print(e)
 
 
 if __name__ == '__main__':
@@ -108,6 +81,7 @@ if __name__ == '__main__':
     parser.add_argument(
         'redis_conn',
         type=str,
+        default='somenergia-redis.somenergia.lan',
         help="Connection address to Redis",
     )
     parser.add_argument(
@@ -123,13 +97,6 @@ if __name__ == '__main__':
         default=MAX_ATTEMPTS,
         type=int,
         help="Max attemps before move to permanent failed",
-    )
-    parser.add_argument(
-        '--permanent',
-        dest='permanent',
-        default=PERMANENT_FAILED,
-        type=str,
-        help="Name of permanent failed queue",
     )
 
     args = parser.parse_args()

--- a/scripts/requeue_failed.py
+++ b/scripts/requeue_failed.py
@@ -11,9 +11,10 @@ import argparse
 
 INTERVAL = 7200  # Seconds
 MAX_ATTEMPTS = 5
-QUEUES_TO_REQUEUE = ['cups_cch', 'tm_validate']
+QUEUES_TO_REQUEUE = ['cups_cch', 'tm_validate', 'make_invoices']
 QUEUES_TO_DELETE = ['jobspool-autoworker']
-EXECINFO_TO_DELETE = ['Work-horse process was terminated unexpectedly', 'es mes petita que la data inicial', 'ValueError: start date not found in coefficients']
+EXECINFO_TO_DELETE = ['Work-horse process was terminated unexpectedly', 'es mes petita que la data inicial', 'ValueError: start date not found in coefficients',
+        'No s\'han trobat versions de preus', 'InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block']
 
 redis_conn = from_url(sys.argv[1])
 use_connection(redis_conn)

--- a/scripts/requeue_failed.py
+++ b/scripts/requeue_failed.py
@@ -1,0 +1,139 @@
+V#!/usr/bin/env python
+from __future__ import print_function
+import sys
+import times
+from redis import from_url
+from rq import use_connection, requeue_job, Queue
+from rq.job import Job
+from rq.registry import FailedJobRegistry
+from datetime import datetime
+import argparse
+
+INTERVAL = 7200  # Seconds
+MAX_ATTEMPTS = 5
+PERMANENT_FAILED = 'permanent'
+
+redis_conn = from_url(sys.argv[1])
+use_connection(redis_conn)
+
+all_queues = Queue().all()
+pfq = FailedJobRegistry(PERMANENT_FAILED)
+pq = Queue(name=PERMANENT_FAILED)
+
+for queue in all_queues:
+    fq = FailedJobRegistry(queue.name)
+    for job_id in fq.get_job_ids():
+        job = Job.fetch(job_id)
+        if not job.meta.get('requeue', True):
+            continue
+        job.meta.setdefault('attempts', 0)
+        if job.meta['attempts'] > MAX_ATTEMPTS:
+            print("Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (
+                    job.id, job.meta['attempts'], MAX_ATTEMPTS, job.origin
+            ))
+            print(job.description)
+            print(job.exc_info)
+            print()
+            fq.remove(job)
+            pq.enqueue_job(job)
+            print("Moved to %s FailedJobRegistry" % PERMANENT_FAILED)
+        else:
+            ago = (times.now() - job.enqueued_at).seconds
+            if ago >= INTERVAL:
+                print("%s: attemps: %s enqueued: %ss ago on %s (Requeue)" % (
+                    job.id, job.meta['attempts'], ago, job.origin
+                ))
+                job.meta['attempts'] += 1
+                job.save()
+                requeue_job(job.id, connection=redis_conn)
+
+
+def main(redis_conn, interval, max_attempts, permanent_failed):
+    use_connection(redis_conn)
+
+    all_queues = Queue().all()
+    pfq = FailedJobRegistry(permanent_failed)
+    pq = Queue(name=permanent_failed)
+    print("{}: Try to requeu jobs".format(str(datetime.now())))
+    for queue in all_queues:
+        if queue.name == 'jobspool-autoworker':
+            continue
+        fq = FailedJobRegistry(queue.name)
+        for job_id in fq.get_job_ids():
+            try:
+                job = Job.fetch(job_id)
+            except:
+                print("Job {} not exist anymore. We will delete from FailedJobRegistry".format(job_id))
+                try:
+                    key_registry = fq.key
+                    redis_conn.zrem(key_registry,job_id)
+                except Exception as e:
+                    print("We cannot delete job in FailedJobRegistry")
+                    print(job_id)
+                    print(e)
+            if not job.meta.get('requeue', True):
+                print("Job {} of Queue {} was marked as job.meta.requeue=false but we requeue it.".format(job_id, queue.name))
+                #continue
+            if job.is_finished:
+                key_registry = fq.key
+                redis_conn.zrem(key_registry,job_id)
+            job.meta.setdefault('attempts', 0)
+            if job.meta['attempts'] > max_attempts:
+                print("Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (
+                        job.id, job.meta['attempts'], max_attempts, job.origin
+                ))
+                print(job.description)
+                print(job.exc_info)
+                print()
+                #fq.remove(job)
+                #pq.enqueue_job(job)
+                print("Moved to %s FailedJobRegistry" % permanent_failed)
+            else:
+                ago = (times.now() - job.enqueued_at).seconds
+                if ago >= interval:
+                    print("%s: attemps: %s enqueued: %ss ago on %s (Requeue)" % (
+                        job.id, job.meta['attempts'], ago, job.origin
+                    ))
+                    job.meta['attempts'] += 1
+                    job.save()
+                    #requeue_job(job.id, connection=redis_conn)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(
+            description="Requeue failed jobs"
+    )
+
+    parser.add_argument(
+        'redis_conn',
+        type=str,
+        help="Connection address to Redis",
+    )
+    parser.add_argument(
+        '--interval',
+        dest='interval',
+        default=INTERVAL,
+        type=int,
+        help="Interval before requeu (in seconds)",
+    )
+    parser.add_argument(
+        '--max-attempts',
+        dest='max_attempts',
+        default=MAX_ATTEMPTS,
+        type=int,
+        help="Max attemps before move to permanent failed",
+    )
+    parser.add_argument(
+        '--permanent',
+        dest='permanent',
+        default=PERMANENT_FAILED,
+        type=str,
+        help="Name of permanent failed queue",
+    )
+
+    args = parser.parse_args()
+    main(from_url(args.redis_conn), args.interval, args.max_attempts, args.permanent)
+
+# vim: et ts=4 sw=4
+

--- a/scripts/requeue_failed.py
+++ b/scripts/requeue_failed.py
@@ -74,7 +74,7 @@ def main(redis_conn, interval, max_attempts):
                     print("We cannot delete job in FailedJobRegistry")
                     print(job_id)
                     print(e)
-            if any(substring in j.exc_info  for substring in EXECINFO_TO_DELETE):
+            if any(substring in job.exc_info  for substring in EXECINFO_TO_DELETE):
                 try:
                     key_registry = fq.key
                     redis_conn.zrem(key_registry,job_id)


### PR DESCRIPTION
## Objectiu
Refer l'script de reencuat automàtic (he tornat a activar el cron). També es pot executar a mà. La idea és anar afegint/treient les cues i/o errors d'execució que volem que s'automatitzi el rencuat o l'eliminació.

## Targeta on es demana o Incidència 
Bugbuster

## Comportament antic
S'havien deixat de reencuar tots

## Comportament nou
Aquest nou escrip permet reencuar i eliminar alguns jobs, segons les constants:

- QUEUES_TO_REQUEUE: Cues que es reencuaran tots els jobs failed
- QUEUES_TO_DELETE: Cues que s'eliminaran tots els jobs failed
- EXECINFO_TO_DELETE: Resultats d'execució faileds que s'eliminaran

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
