### PR TITLE
Refactor inicial del generador de dades de la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -854,19 +854,19 @@ class GiscedataFacturacioFacturaReport(osv.osv):
     #         data['has_agreement_partner'] = False
     #     return data
 
-    def get_component_company_data(self, fact, pol):
-        """
-        returns a dictionary with all required company address data
-        """
-        data = {
-                'name': fact.company_id.partner_id.name,
-                'cif': fact.company_id.partner_id.vat.replace('ES', ''),
-                'street': fact.company_id.partner_id.address[0].street,
-                'zip': fact.company_id.partner_id.address[0].zip,
-                'city': fact.company_id.partner_id.address[0].city,
-                'email': fact.company_id.partner_id.address[0].email,
-                }
-        return data
+    # def get_component_company_data(self, fact, pol):
+    #     """
+    #     returns a dictionary with all required company address data
+    #     """
+    #     data = {
+    #             'name': fact.company_id.partner_id.name,
+    #             'cif': fact.company_id.partner_id.vat.replace('ES', ''),
+    #             'street': fact.company_id.partner_id.address[0].street,
+    #             'zip': fact.company_id.partner_id.address[0].zip,
+    #             'city': fact.company_id.partner_id.address[0].city,
+    #             'email': fact.company_id.partner_id.address[0].email,
+    #             }
+    #     return data
 
     def get_component_gdo_data(self, fact, pol):
         """

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -976,29 +976,29 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data['segment_tariff'] = segment_tarif.get(pol.tarifa.name,"")
         return data
 
-    def get_component_readings_table_data(self, fact, pol):
-        """
-        return a dictionary with all readings table component needed data
-        """
-        (periodes_a, _, _, _, lectures_a, _, _, _, _, _, _, _, total_lectures_a, _, _, _, _, _, _) = self.get_readings_data(fact)
+    # def get_component_readings_table_data(self, fact, pol):
+    #     """
+    #     return a dictionary with all readings table component needed data
+    #     """
+    #     (periodes_a, _, _, _, lectures_a, _, _, _, _, _, _, _, total_lectures_a, _, _, _, _, _, _) = self.get_readings_data(fact)
 
-        dies_factura = (datetime.strptime(fact.data_final, '%Y-%m-%d') - datetime.strptime(fact.data_inici, '%Y-%m-%d')).days + 1
-        diari_factura_actual_eur = fact.total_energia / (dies_factura or 1.0)
-        diari_factura_actual_kwh = (fact.energia_kwh * 1.0) / (dies_factura or 1.0)
+    #     dies_factura = (datetime.strptime(fact.data_final, '%Y-%m-%d') - datetime.strptime(fact.data_inici, '%Y-%m-%d')).days + 1
+    #     diari_factura_actual_eur = fact.total_energia / (dies_factura or 1.0)
+    #     diari_factura_actual_kwh = (fact.energia_kwh * 1.0) / (dies_factura or 1.0)
 
-        lang = fact.lang_partner
+    #     lang = fact.lang_partner
 
-        data = {
-                'periodes_a': periodes_a,
-                'lectures_a': lectures_a,
-                'total_lectures_a' : total_lectures_a,
-                'dies_factura' : dies_factura,
-                'diari_factura_actual_eur' : diari_factura_actual_eur,
-                'diari_factura_actual_kwh' : diari_factura_actual_kwh,
-                'has_autoconsum': te_autoconsum(fact, pol),
-                }
+    #     data = {
+    #             'periodes_a': periodes_a,
+    #             'lectures_a': lectures_a,
+    #             'total_lectures_a' : total_lectures_a,
+    #             'dies_factura' : dies_factura,
+    #             'diari_factura_actual_eur' : diari_factura_actual_eur,
+    #             'diari_factura_actual_kwh' : diari_factura_actual_kwh,
+    #             'has_autoconsum': te_autoconsum(fact, pol),
+    #             }
 
-        return data
+    #     return data
 
     def is_visible_readings_g_table(self, fact, pol):
         (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, has_adjust_g, has_readings_g) = self.get_readings_data(fact)

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -9,6 +9,7 @@ from gestionatr.defs import TENEN_AUTOCONSUM
 import json
 from operator import attrgetter
 from collections import Counter
+from invoice_data_container import SmartInvoiceDataContainer
 
 SENSE_EXCEDENTS = ['31','32','33']
 
@@ -201,7 +202,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 ctxt = context
                 ctxt['date'] = val(fac.data_final)
             pol = pol_obj.browse(cursor, uid, fac.polissa_id.id, ctxt)
-            res[fac_id] = self.fill_all_components_data(fill_methods, fac, pol, ctxt)
+            res[fac_id] = self.get_components_data_container(fill_methods, fac, pol, ctxt)
         return res
 
     def get_report_data(self, cursor, uid, objects, context=None):
@@ -252,6 +253,12 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         self.cleanup_data(fac)
         return ns.loads(ns(data).dump())
+
+    def get_components_data_container(self, fill_methods, fact, pol, ctxt):
+        data_cont = SmartInvoiceDataContainer(self.cursor, self.uid, self, fact, pol, ctxt)
+        old_data = self.fill_all_components_data(fill_methods, fact, pol, ctxt)
+        data_cont.set_old_data(old_data)
+        return data_cont
 
     def cleanup_data(self, fact):
         self.del_historic_data(fact)

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -841,17 +841,18 @@ class GiscedataFacturacioFacturaReport(osv.osv):
     # -----------------------------
     # Component fill data functions
     # -----------------------------
-    def get_component_logo_data(self, fact, pol):
-        """
-        returns a dictionary with all required logo component data
-        """
-        data = {'logo': 'logo_som.png'}
-        if pol.soci.ref in agreementPartners.keys():
-            data['has_agreement_partner'] = True
-            data['logo_agreement_partner'] = agreementPartners[pol.soci.ref]['logo']
-        else:
-            data['has_agreement_partner'] = False
-        return data
+
+    # def get_component_logo_data(self, fact, pol):
+    #     """
+    #     returns a dictionary with all required logo component data
+    #     """
+    #     data = {'logo': 'logo_som.png'}
+    #     if pol.soci.ref in agreementPartners.keys():
+    #         data['has_agreement_partner'] = True
+    #         data['logo_agreement_partner'] = agreementPartners[pol.soci.ref]['logo']
+    #     else:
+    #         data['has_agreement_partner'] = False
+    #     return data
 
     def get_component_company_data(self, fact, pol):
         """

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1853,16 +1853,16 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data['profiled_curve'] = data['factura_data'] and 'REEPROFILE' in data['factura_data']
         return data
 
-    def get_component_globals_data(self, fact, pol):
-        (periodes_a, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = self.get_readings_data(fact)
-        data = {
-            'num_periodes': len(periodes_a),
-            'is_6x': is_6X(pol),
-            'is_TD': is_TD(pol),
-            'is_6xTD': is_6XTD(pol),
-            'is_indexed': is_indexed(fact),
-        }
-        return data
+    # def get_component_globals_data(self, fact, pol):
+    #     (periodes_a, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = self.get_readings_data(fact)
+    #     data = {
+    #         'num_periodes': len(periodes_a),
+    #         'is_6x': is_6X(pol),
+    #         'is_TD': is_TD(pol),
+    #         'is_6xTD': is_6XTD(pol),
+    #         'is_indexed': is_indexed(fact),
+    #     }
+    #     return data
 
     def get_component_rectificative_banner_data(self, fact, pol):
         data = {

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2526,240 +2526,240 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         }
         return data
 
-    def get_component_energy_consumption_detail_td_data(self, fact, pol):
-        if not is_TD(pol):
-            return {}
+    # def get_component_energy_consumption_detail_td_data(self, fact, pol):
+    #     if not is_TD(pol):
+    #         return {}
 
-        adjust_reason = []
-        meters = []
-        for meter in pol.comptadors:
-            data = self.get_sub_component_energy_consumption_detail_meter_td_data(fact, pol, meter)
-            if data['is_visible']:
-                meters.append(data)
+    #     adjust_reason = []
+    #     meters = []
+    #     for meter in pol.comptadors:
+    #         data = self.get_sub_component_energy_consumption_detail_meter_td_data(fact, pol, meter)
+    #         if data['is_visible']:
+    #             meters.append(data)
 
-            adjust_reason.append(data['adjust_reason'])
+    #         adjust_reason.append(data['adjust_reason'])
 
 
-        highest_adjust_reason = self.adjust_readings_priority(adjust_reason)
-        data = {
-            'meters': meters,
-            'info': self.get_sub_component_energy_consumption_detail_td_info_data(fact, pol, highest_adjust_reason),
-        }
-        return data
+    #     highest_adjust_reason = self.adjust_readings_priority(adjust_reason)
+    #     data = {
+    #         'meters': meters,
+    #         'info': self.get_sub_component_energy_consumption_detail_td_info_data(fact, pol, highest_adjust_reason),
+    #     }
+    #     return data
 
-    def get_sub_component_energy_consumption_detail_meter_td_data(self, fact, pol, meter):
+    # def get_sub_component_energy_consumption_detail_meter_td_data(self, fact, pol, meter):
 
-        def visibility(subs):
-            return any([sub['is_visible'] for sub in subs])
+    #     def visibility(subs):
+    #         return any([sub['is_visible'] for sub in subs])
 
-        def adjust_reason(subs):
-            return [sub['adjust_reason'] for sub in subs]
+    #     def adjust_reason(subs):
+    #         return [sub['adjust_reason'] for sub in subs]
 
-        def add_last_visible(item, subs):
-            item['last_visible'] = not visibility(subs)
-            return item
+    #     def add_last_visible(item, subs):
+    #         item['last_visible'] = not visibility(subs)
+    #         return item
 
-        active = self.get_sub_component_energy_consumption_detail_td_active_data(fact, pol, meter)
-        surplus = self.get_sub_component_energy_consumption_detail_td_surplus_data(fact, pol, meter)
-        inductive = self.get_sub_component_energy_consumption_detail_td_inductive_data(fact, pol, meter)
-        capacitive = self.get_sub_component_energy_consumption_detail_td_capacitive_data(fact, pol, meter)
-        maximeter = self.get_sub_component_energy_consumption_detail_td_maximeter_data(fact, pol, meter)
+    #     active = self.get_sub_component_energy_consumption_detail_td_active_data(fact, pol, meter)
+    #     surplus = self.get_sub_component_energy_consumption_detail_td_surplus_data(fact, pol, meter)
+    #     inductive = self.get_sub_component_energy_consumption_detail_td_inductive_data(fact, pol, meter)
+    #     capacitive = self.get_sub_component_energy_consumption_detail_td_capacitive_data(fact, pol, meter)
+    #     maximeter = self.get_sub_component_energy_consumption_detail_td_maximeter_data(fact, pol, meter)
 
-        data = {
-            'name': meter.name,
-            'showing_periods': self.get_matrix_show_periods(pol),
-            'active': add_last_visible(active, [surplus, inductive, capacitive, maximeter]),
-            'surplus': add_last_visible(surplus, [inductive, capacitive, maximeter]),
-            'inductive': add_last_visible(inductive, [capacitive, maximeter]),
-            'capacitive': add_last_visible(capacitive, [maximeter]),
-            'maximeter': maximeter,
-            'is_visible': visibility([active, surplus, inductive, capacitive]),
-            'adjust_reason': self.adjust_readings_priority(adjust_reason([active, surplus, inductive, capacitive, maximeter])),
-        }
-        return data
+    #     data = {
+    #         'name': meter.name,
+    #         'showing_periods': self.get_matrix_show_periods(pol),
+    #         'active': add_last_visible(active, [surplus, inductive, capacitive, maximeter]),
+    #         'surplus': add_last_visible(surplus, [inductive, capacitive, maximeter]),
+    #         'inductive': add_last_visible(inductive, [capacitive, maximeter]),
+    #         'capacitive': add_last_visible(capacitive, [maximeter]),
+    #         'maximeter': maximeter,
+    #         'is_visible': visibility([active, surplus, inductive, capacitive]),
+    #         'adjust_reason': self.adjust_readings_priority(adjust_reason([active, surplus, inductive, capacitive, maximeter])),
+    #     }
+    #     return data
 
-    def adjust_readings_priority(self, adjust_readings_list):
-        adjust_readings_list = [adjust for adjust in adjust_readings_list if adjust != False]
-        if len(adjust_readings_list) == 0:
-            return False
+    # def adjust_readings_priority(self, adjust_readings_list):
+    #     adjust_readings_list = [adjust for adjust in adjust_readings_list if adjust != False]
+    #     if len(adjust_readings_list) == 0:
+    #         return False
 
-        adjust_auto = '98' in adjust_readings_list
-        adjust_trTD = '97' in adjust_readings_list
-        adjust_deci = '96' in adjust_readings_list
-        adjust_remaining = [adjust for adjust in adjust_readings_list if adjust not in ('98', '97', '96')]
-        if len(adjust_remaining) > 0:
-            return '99'
-        if adjust_auto:
-            return '98'
-        if adjust_trTD:
-            return '97'
-        return False
+    #     adjust_auto = '98' in adjust_readings_list
+    #     adjust_trTD = '97' in adjust_readings_list
+    #     adjust_deci = '96' in adjust_readings_list
+    #     adjust_remaining = [adjust for adjust in adjust_readings_list if adjust not in ('98', '97', '96')]
+    #     if len(adjust_remaining) > 0:
+    #         return '99'
+    #     if adjust_auto:
+    #         return '98'
+    #     if adjust_trTD:
+    #         return '97'
+    #     return False
 
-    def get_sub_component_energy_consumption_detail_td_active_data(self, fact, pol, meter):
-        (a, a, a, a, lectures_a, a, a, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
-        lectures = lectures_a
-        data = {
-            'showing_periods': self.get_matrix_show_periods(pol),
-            'is_visible': False,
-            'title': _(u"Energia Activa (kWh)"),
-            'is_active': True,
-        }
+    # def get_sub_component_energy_consumption_detail_td_active_data(self, fact, pol, meter):
+    #     (a, a, a, a, lectures_a, a, a, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
+    #     lectures = lectures_a
+    #     data = {
+    #         'showing_periods': self.get_matrix_show_periods(pol),
+    #         'is_visible': False,
+    #         'title': _(u"Energia Activa (kWh)"),
+    #         'is_active': True,
+    #     }
 
-        adjust_reason = []
-        if meter.name in lectures:
-            data['is_visible'] = len(lectures[meter.name]) > 0
-            for reading in lectures[meter.name]:
-                data[reading[0]] = {
-                    'initial': reading[1],
-                    'final': reading[2],
-                    'total': reading[3],
-                }
-                data['initial_date'] = reading[4]
-                if 'initial_type' not in data or reading[6] != u'real':
-                    data['initial_type'] = reading[6]
-                data['final_date'] = reading[5]
-                if 'final_type' not in data or reading[7] != u'real':
-                    data['final_type'] = reading[7]
-                adjust_reason.append(reading[9])
+    #     adjust_reason = []
+    #     if meter.name in lectures:
+    #         data['is_visible'] = len(lectures[meter.name]) > 0
+    #         for reading in lectures[meter.name]:
+    #             data[reading[0]] = {
+    #                 'initial': reading[1],
+    #                 'final': reading[2],
+    #                 'total': reading[3],
+    #             }
+    #             data['initial_date'] = reading[4]
+    #             if 'initial_type' not in data or reading[6] != u'real':
+    #                 data['initial_type'] = reading[6]
+    #             data['final_date'] = reading[5]
+    #             if 'final_type' not in data or reading[7] != u'real':
+    #                 data['final_type'] = reading[7]
+    #             adjust_reason.append(reading[9])
 
-        data['adjust_reason'] = self.adjust_readings_priority(adjust_reason)
-        return data
+    #     data['adjust_reason'] = self.adjust_readings_priority(adjust_reason)
+    #     return data
 
-    def get_sub_component_energy_consumption_detail_td_surplus_data(self, fact, pol, meter):
-        (a, a, a, a, a, a, a, lectures_g, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
-        lectures = lectures_g
-        data = {
-            'showing_periods': self.get_matrix_show_periods(pol),
-            'is_visible': False,
-            'title': _(u'Energia Excedentària (kWh)'),
-            'is_active': False,
-        }
+    # def get_sub_component_energy_consumption_detail_td_surplus_data(self, fact, pol, meter):
+    #     (a, a, a, a, a, a, a, lectures_g, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
+    #     lectures = lectures_g
+    #     data = {
+    #         'showing_periods': self.get_matrix_show_periods(pol),
+    #         'is_visible': False,
+    #         'title': _(u'Energia Excedentària (kWh)'),
+    #         'is_active': False,
+    #     }
 
-        adjust_reason = []
-        if meter.name in lectures:
-            data['is_visible'] = len(lectures[meter.name]) > 0 and te_autoconsum_amb_excedents(fact, pol)
-            for reading in lectures[meter.name]:
-                data[reading[0]] = {
-                    'initial': reading[1],
-                    'final': reading[2],
-                    'total': reading[3],
-                }
-                data['initial_date'] = reading[4]
-                if 'initial_type' not in data or reading[6] != u'real':
-                    data['initial_type'] = reading[6]
-                data['final_date'] = reading[5]
-                if 'final_type' not in data or reading[7] != u'real':
-                    data['final_type'] = reading[7]
-                adjust_reason.append(reading[9])
+    #     adjust_reason = []
+    #     if meter.name in lectures:
+    #         data['is_visible'] = len(lectures[meter.name]) > 0 and te_autoconsum_amb_excedents(fact, pol)
+    #         for reading in lectures[meter.name]:
+    #             data[reading[0]] = {
+    #                 'initial': reading[1],
+    #                 'final': reading[2],
+    #                 'total': reading[3],
+    #             }
+    #             data['initial_date'] = reading[4]
+    #             if 'initial_type' not in data or reading[6] != u'real':
+    #                 data['initial_type'] = reading[6]
+    #             data['final_date'] = reading[5]
+    #             if 'final_type' not in data or reading[7] != u'real':
+    #                 data['final_type'] = reading[7]
+    #             adjust_reason.append(reading[9])
 
-        data['adjust_reason'] = self.adjust_readings_priority(adjust_reason)
-        return data
+    #     data['adjust_reason'] = self.adjust_readings_priority(adjust_reason)
+    #     return data
 
-    def get_sub_component_energy_consumption_detail_td_inductive_data(self, fact, pol, meter):
-        (a, a, a, a, a, lectures_r, a, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
-        data = {
-            'showing_periods': self.get_matrix_show_periods(pol),
-            'is_visible': False,
-            'title': _(u"Energia Reactiva Inductiva (kVArh)"),
-            'adjust_reason': False,
-            'is_active': False,
-        }
-        if meter.name in lectures_r:
-            readings_list = lectures_r[meter.name]
-            for reading in readings_list:
-                data['is_visible'] = True,
-                data[reading[0]] = {
-                    'initial': reading[1],
-                    'final': reading[2],
-                    'total': reading[3],
-                }
-                data['initial_date'] = reading[4]
-                if 'initial_type' not in data or reading[6] != u'real':
-                    data['initial_type'] = reading[6]
-                data['final_date'] = reading[5]
-                if 'final_type' not in data or reading[7] != u'real':
-                    data['final_type'] = reading[7]
-                if len(reading) == 9 and reading[8] != 0.0:
-                    data['has_adjust'] = True
+    # def get_sub_component_energy_consumption_detail_td_inductive_data(self, fact, pol, meter):
+    #     (a, a, a, a, a, lectures_r, a, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
+    #     data = {
+    #         'showing_periods': self.get_matrix_show_periods(pol),
+    #         'is_visible': False,
+    #         'title': _(u"Energia Reactiva Inductiva (kVArh)"),
+    #         'adjust_reason': False,
+    #         'is_active': False,
+    #     }
+    #     if meter.name in lectures_r:
+    #         readings_list = lectures_r[meter.name]
+    #         for reading in readings_list:
+    #             data['is_visible'] = True,
+    #             data[reading[0]] = {
+    #                 'initial': reading[1],
+    #                 'final': reading[2],
+    #                 'total': reading[3],
+    #             }
+    #             data['initial_date'] = reading[4]
+    #             if 'initial_type' not in data or reading[6] != u'real':
+    #                 data['initial_type'] = reading[6]
+    #             data['final_date'] = reading[5]
+    #             if 'final_type' not in data or reading[7] != u'real':
+    #                 data['final_type'] = reading[7]
+    #             if len(reading) == 9 and reading[8] != 0.0:
+    #                 data['has_adjust'] = True
 
-        return data
+    #     return data
 
-    def get_sub_component_energy_consumption_detail_td_capacitive_data(self, fact, pol, meter):
-        (a, a, a, a, a, a, lectures_c, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
-        data = {
-            'showing_periods': self.get_matrix_show_periods(pol),
-            'is_visible': False,
-            'title': _(u"Energia Reactiva Capacitiva (kVArh)"),
-            'adjust_reason': False,
-            'is_active': False,
-        }
-        if meter.name in lectures_c:
-            readings_list = lectures_c[meter.name]
-            for reading in readings_list:
-                data['is_visible'] = True,
-                data[reading[0]] = {
-                    'initial': reading[1],
-                    'final': reading[2],
-                    'total': reading[3],
-                }
-                data['initial_date'] = reading[4]
-                if 'initial_type' not in data or reading[6] != u'real':
-                    data['initial_type'] = reading[6]
-                data['final_date'] = reading[5]
-                if 'final_type' not in data or reading[7] != u'real':
-                    data['final_type'] = reading[7]
-                if len(reading) == 9 and reading[8] != 0.0:
-                    data['has_adjust'] = True
+    # def get_sub_component_energy_consumption_detail_td_capacitive_data(self, fact, pol, meter):
+    #     (a, a, a, a, a, a, lectures_c, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(fact)
+    #     data = {
+    #         'showing_periods': self.get_matrix_show_periods(pol),
+    #         'is_visible': False,
+    #         'title': _(u"Energia Reactiva Capacitiva (kVArh)"),
+    #         'adjust_reason': False,
+    #         'is_active': False,
+    #     }
+    #     if meter.name in lectures_c:
+    #         readings_list = lectures_c[meter.name]
+    #         for reading in readings_list:
+    #             data['is_visible'] = True,
+    #             data[reading[0]] = {
+    #                 'initial': reading[1],
+    #                 'final': reading[2],
+    #                 'total': reading[3],
+    #             }
+    #             data['initial_date'] = reading[4]
+    #             if 'initial_type' not in data or reading[6] != u'real':
+    #                 data['initial_type'] = reading[6]
+    #             data['final_date'] = reading[5]
+    #             if 'final_type' not in data or reading[7] != u'real':
+    #                 data['final_type'] = reading[7]
+    #             if len(reading) == 9 and reading[8] != 0.0:
+    #                 data['has_adjust'] = True
 
-        return data
+    #     return data
 
-    def get_sub_component_energy_consumption_detail_td_maximeter_data(self, fact, pol, meter):
-        excess_lines = [l for l in fact.linia_ids if l.tipus == 'exces_potencia']
+    # def get_sub_component_energy_consumption_detail_td_maximeter_data(self, fact, pol, meter):
+    #     excess_lines = [l for l in fact.linia_ids if l.tipus == 'exces_potencia']
 
-        data = {
-            'showing_periods': self.get_matrix_show_periods(pol),
-            'is_visible': pol.facturacio_potencia=='max',
-            'title': _(u"Maxímetre (kW)"),
-            'adjust_reason': False,
-            'is_active': False,
-            'is_visible_surplus': len(excess_lines) > 0 and te_quartihoraria(pol),
-        }
+    #     data = {
+    #         'showing_periods': self.get_matrix_show_periods(pol),
+    #         'is_visible': pol.facturacio_potencia=='max',
+    #         'title': _(u"Maxímetre (kW)"),
+    #         'adjust_reason': False,
+    #         'is_active': False,
+    #         'is_visible_surplus': len(excess_lines) > 0 and te_quartihoraria(pol),
+    #     }
 
-        periodes_m = sorted(list(set([lectura.name for lectura in fact.lectures_potencia_ids])))
+    #     periodes_m = sorted(list(set([lectura.name for lectura in fact.lectures_potencia_ids])))
 
-        lectures_m = []
-        for lectura in fact.lectures_potencia_ids:
-            lectures_m.append((lectura.name, lectura.pot_contract, lectura.pot_maximetre ))
+    #     lectures_m = []
+    #     for lectura in fact.lectures_potencia_ids:
+    #         lectures_m.append((lectura.name, lectura.pot_contract, lectura.pot_maximetre ))
 
-        fact_potencia = dict([(p,0) for p in periodes_m])
-        for p in [(p.product_id.name, p.quantity) for p in excess_lines]:
-            fact_potencia.update({p[0]: max(fact_potencia.get(p[0], 0), p[1])})
+    #     fact_potencia = dict([(p,0) for p in periodes_m])
+    #     for p in [(p.product_id.name, p.quantity) for p in excess_lines]:
+    #         fact_potencia.update({p[0]: max(fact_potencia.get(p[0], 0), p[1])})
 
-        for reading in lectures_m:
-            data[reading[0]] = {
-                'contracted': reading[1],
-                'reading': reading[2],
-                'surplus': fact_potencia[reading[0]],
-            }
-        return data
+    #     for reading in lectures_m:
+    #         data[reading[0]] = {
+    #             'contracted': reading[1],
+    #             'reading': reading[2],
+    #             'surplus': fact_potencia[reading[0]],
+    #         }
+    #     return data
 
-    def get_sub_component_energy_consumption_detail_td_info_data(self, fact, pol, adjust_reason):
-        dies_factura = (datetime.strptime(fact.data_final, '%Y-%m-%d') - datetime.strptime(fact.data_inici, '%Y-%m-%d')).days + 1
-        diari_factura_actual_eur = fact.total_energia / (dies_factura or 1.0)
-        diari_factura_actual_kwh = (fact.energia_kwh * 1.0) / (dies_factura or 1.0)
-        lang = fact.lang_partner.lower()
+    # def get_sub_component_energy_consumption_detail_td_info_data(self, fact, pol, adjust_reason):
+    #     dies_factura = (datetime.strptime(fact.data_final, '%Y-%m-%d') - datetime.strptime(fact.data_inici, '%Y-%m-%d')).days + 1
+    #     diari_factura_actual_eur = fact.total_energia / (dies_factura or 1.0)
+    #     diari_factura_actual_kwh = (fact.energia_kwh * 1.0) / (dies_factura or 1.0)
+    #     lang = fact.lang_partner.lower()
 
-        data = {
-            'diari_factura_actual_eur': diari_factura_actual_eur,
-            'diari_factura_actual_kwh': diari_factura_actual_kwh,
-            'dies_factura': dies_factura,
-            'lang': lang,
-            'adjust_reason': adjust_reason,
-            'has_web': bool(pol.distribuidora.website),
-            'web_distri': pol.distribuidora.website,
-            'distri_name': pol.distribuidora.name,
-        }
-        return data
+    #     data = {
+    #         'diari_factura_actual_eur': diari_factura_actual_eur,
+    #         'diari_factura_actual_kwh': diari_factura_actual_kwh,
+    #         'dies_factura': dies_factura,
+    #         'lang': lang,
+    #         'adjust_reason': adjust_reason,
+    #         'has_web': bool(pol.distribuidora.website),
+    #         'web_distri': pol.distribuidora.website,
+    #         'distri_name': pol.distribuidora.name,
+    #     }
+    #     return data
 
     def get_component_cnmc_comparator_qr_link_data(self, fact, pol):
         # fact needs to have max_potencies_demandades for the QR to be correct

--- a/giscedata_facturacio_comer_som/invoice_data_container.py
+++ b/giscedata_facturacio_comer_som/invoice_data_container.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+class SmartInvoiceDataContainer():
+
+    def __init__(self, cursor, uid, report, fact, pol, context):
+        self.data = {}
+        self.cursor = cursor
+        self.uid = uid
+        self.report = report
+        self.factura = fact
+        self.polissa = pol
+        self.context = context
+
+    def set_old_data(self, data):
+        self.data = data
+    
+    def __getattr__(self, key):
+        if key in self.data:
+            return self.data[key]
+        return {}

--- a/giscedata_facturacio_comer_som/invoice_data_container.py
+++ b/giscedata_facturacio_comer_som/invoice_data_container.py
@@ -31,6 +31,6 @@ class SmartInvoiceDataContainer():
             data_generator = SmartInvoiceDataContainer.factory_data_generator(key)
             data_generator.set_data(self.cursor, self.uid, self.factura, self.polissa, self, self.report)
             data = data_generator.get_data()
-            self.data[key] = ns(data)
+            self.data[key] = ns.loads(ns(data).dump())
 
         return self.data[key]

--- a/giscedata_facturacio_comer_som/invoice_data_container.py
+++ b/giscedata_facturacio_comer_som/invoice_data_container.py
@@ -15,13 +15,20 @@ class SmartInvoiceDataContainer():
     def set_old_data(self, data):
         self.data = data
 
-    def factory_data_generator(self, component_name):
-        exec("from report.components."+component_name+" import "+component_name+";generator = "+component_name+"."+component_name+"()")
+    @staticmethod
+    def _component_class_name(component_name):
+        parts = component_name.split('_')
+        ComponentName = u''.join([part.title() for part in parts])
+        return u"Component" + ComponentName + u"Data"
+
+    @staticmethod
+    def factory_data_generator(component_name):
+        exec(u"from report.components."+component_name+u" import "+component_name+u";generator = "+component_name+u"."+SmartInvoiceDataContainer._component_class_name(component_name)+u"()")
         return generator
 
     def __getattr__(self, key):
         if key not in self.data:
-            data_generator = self.factory_data_generator(key)
+            data_generator = SmartInvoiceDataContainer.factory_data_generator(key)
             data_generator.set_data(self.polissa)
             data = data_generator.get_data()
             self.data[key] = ns(data)

--- a/giscedata_facturacio_comer_som/invoice_data_container.py
+++ b/giscedata_facturacio_comer_som/invoice_data_container.py
@@ -29,7 +29,7 @@ class SmartInvoiceDataContainer():
     def __getattr__(self, key):
         if key not in self.data:
             data_generator = SmartInvoiceDataContainer.factory_data_generator(key)
-            data_generator.set_data(self.factura, self.polissa)
+            data_generator.set_data(self.cursor, self.uid, self.factura, self.polissa, self, self.report)
             data = data_generator.get_data()
             self.data[key] = ns(data)
 

--- a/giscedata_facturacio_comer_som/invoice_data_container.py
+++ b/giscedata_facturacio_comer_som/invoice_data_container.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from yamlns import namespace as ns
 
 class SmartInvoiceDataContainer():
 
     def __init__(self, cursor, uid, report, fact, pol, context):
-        self.data = {}
+        self.data = ns({})
         self.cursor = cursor
         self.uid = uid
         self.report = report
@@ -13,8 +14,16 @@ class SmartInvoiceDataContainer():
 
     def set_old_data(self, data):
         self.data = data
-    
+
+    def factory_data_generator(self, component_name):
+        exec("from report.components."+component_name+" import "+component_name+";generator = "+component_name+"."+component_name+"()")
+        return generator
+
     def __getattr__(self, key):
-        if key in self.data:
-            return self.data[key]
-        return {}
+        if key not in self.data:
+            data_generator = self.factory_data_generator(key)
+            data_generator.set_data(self.polissa)
+            data = data_generator.get_data()
+            self.data[key] = ns(data)
+
+        return self.data[key]

--- a/giscedata_facturacio_comer_som/invoice_data_container.py
+++ b/giscedata_facturacio_comer_som/invoice_data_container.py
@@ -29,7 +29,7 @@ class SmartInvoiceDataContainer():
     def __getattr__(self, key):
         if key not in self.data:
             data_generator = SmartInvoiceDataContainer.factory_data_generator(key)
-            data_generator.set_data(self.polissa)
+            data_generator.set_data(self.factura, self.polissa)
             data = data_generator.get_data()
             self.data[key] = ns(data)
 

--- a/giscedata_facturacio_comer_som/report/components/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/__init__.py
@@ -1,1 +1,2 @@
+import base_component_data
 import logo

--- a/giscedata_facturacio_comer_som/report/components/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/__init__.py
@@ -1,3 +1,6 @@
+import base_component_utils
 import base_component_data
 import logo
 import company
+import readings_table
+import readings_data

--- a/giscedata_facturacio_comer_som/report/components/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/__init__.py
@@ -1,2 +1,3 @@
 import base_component_data
 import logo
+import company

--- a/giscedata_facturacio_comer_som/report/components/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/__init__.py
@@ -1,3 +1,4 @@
+import global_data
 import base_component_utils
 import base_component_data
 import logo

--- a/giscedata_facturacio_comer_som/report/components/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/__init__.py
@@ -1,0 +1,1 @@
+import logo

--- a/giscedata_facturacio_comer_som/report/components/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/__init__.py
@@ -5,3 +5,4 @@ import logo
 import company
 import readings_table
 import readings_data
+import energy_consumption_detail_td

--- a/giscedata_facturacio_comer_som/report/components/base_component_data.py
+++ b/giscedata_facturacio_comer_som/report/components/base_component_data.py
@@ -4,7 +4,8 @@ class BaseComponentData():
     def __init__(self):
         pass
 
-    def set_data(self, pol):
+    def set_data(self, fact, pol):
+        self.fact = fact
         self.pol = pol
 
     def is_visible(self):

--- a/giscedata_facturacio_comer_som/report/components/base_component_data.py
+++ b/giscedata_facturacio_comer_som/report/components/base_component_data.py
@@ -4,9 +4,17 @@ class BaseComponentData():
     def __init__(self):
         pass
 
-    def set_data(self, fact, pol):
+    def te_autoconsum(self):
+        ctxt = {'date': self.fact.data_final }
+        return self.pol.te_autoconsum(amb_o_sense_excedents=2, context=ctxt)
+
+    def set_data(self, cursor, uid, fact, pol, cont, report):
+        self.cursor = cursor
+        self.uid = uid
         self.fact = fact
         self.pol = pol
+        self.container = cont
+        self.report = report
 
     def is_visible(self):
         return True

--- a/giscedata_facturacio_comer_som/report/components/base_component_data.py
+++ b/giscedata_facturacio_comer_som/report/components/base_component_data.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+class BaseComponentData():
+    def __init__(self):
+        pass
+
+    def set_data(self, pol):
+        self.pol = pol
+
+    def is_visible(self):
+        return True
+
+    def get_data(self):
+        return {
+            'is_visible': self.is_visible()
+        }

--- a/giscedata_facturacio_comer_som/report/components/base_component_utils.py
+++ b/giscedata_facturacio_comer_som/report/components/base_component_utils.py
@@ -2,10 +2,7 @@
 from datetime import datetime,timedelta
 
 def val(object):
-    try:
-        return object.val
-    except Exception as e:
-        return object
+    return getattr(object, 'val', object)
 
 def dateformat(date):
     return datetime.strptime(val(date), '%Y-%m-%d').strftime('%d/%m/%Y')

--- a/giscedata_facturacio_comer_som/report/components/base_component_utils.py
+++ b/giscedata_facturacio_comer_som/report/components/base_component_utils.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime,timedelta
+
+def val(object):
+    try:
+        return object.val
+    except Exception as e:
+        return object
+
+def dateformat(date):
+    return datetime.strptime(val(date), '%Y-%m-%d').strftime('%d/%m/%Y')
+
+def getYMDdate(date):
+    return datetime.strptime(date, '%Y-%m-%d')

--- a/giscedata_facturacio_comer_som/report/components/company/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/company/__init__.py
@@ -1,0 +1,1 @@
+import company

--- a/giscedata_facturacio_comer_som/report/components/company/company.py
+++ b/giscedata_facturacio_comer_som/report/components/company/company.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from .. import base_component_data
+
+class ComponentCompanyData(base_component_data.BaseComponentData):
+
+    def get_data(self):
+        data = base_component_data.BaseComponentData.get_data(self)
+        """
+        returns a dictionary with all required company address data
+        """
+        data['name'] = self.fact.company_id.partner_id.name
+        data['cif'] = self.fact.company_id.partner_id.vat.replace('ES', '')
+        data['street'] = self.fact.company_id.partner_id.address[0].street
+        data['zip'] = self.fact.company_id.partner_id.address[0].zip
+        data['city'] = self.fact.company_id.partner_id.address[0].city
+        data['email'] = self.fact.company_id.partner_id.address[0].email
+        return data

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/__init__.py
@@ -1,0 +1,1 @@
+import energy_consumption_detail_td

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.py
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+from tools.translate import _
+from .. import base_component_data
+from ..base_component_utils import getYMDdate
+
+def adjust_readings_priority(adjust_readings_list):
+    adjust_readings_list = [adjust for adjust in adjust_readings_list if adjust != False]
+    if len(adjust_readings_list) == 0:
+        return False
+
+    adjust_auto = '98' in adjust_readings_list
+    adjust_trTD = '97' in adjust_readings_list
+    adjust_deci = '96' in adjust_readings_list
+    adjust_remaining = [adjust for adjust in adjust_readings_list if adjust not in ('98', '97', '96')]
+    if len(adjust_remaining) > 0:
+        return '99'
+    if adjust_auto:
+        return '98'
+    if adjust_trTD:
+        return '97'
+    return False
+
+def visibility(subs):
+    return any([sub['is_visible'] for sub in subs])
+
+def adjust_reason(subs):
+    return [sub['adjust_reason'] for sub in subs]
+
+def add_last_visible(item, subs):
+    item['last_visible'] = not visibility(subs)
+    return item
+
+class ComponentEnergyConsumptionDetailTdData(base_component_data.BaseComponentData):
+
+    def get_data(self):
+        global_data = self.container.global_data
+
+        data = base_component_data.BaseComponentData.get_data(self)
+        if not global_data.is_TD:
+            return data
+
+        adjust_reason = []
+        meters = []
+        for meter in self.pol.comptadors:
+            data = self.get_meter_data(meter)
+            if data['is_visible']:
+                meters.append(data)
+
+            adjust_reason.append(data['adjust_reason'])
+
+        highest_adjust_reason = adjust_readings_priority(adjust_reason)
+
+        data['meters'] = meters
+        data['info'] =  self.get_info_data(highest_adjust_reason)
+        return data
+
+    def get_meter_data(self, meter):
+
+        active = self.get_meter_active_data(meter)
+        surplus = self.get_meter_surplus_data(meter)
+        inductive = self.get_meter_inductive_data(meter)
+        capacitive = self.get_meter_capacitive_data(meter)
+        maximeter = self.get_meter_maximeter_data(meter)
+
+        data = {
+            'name': meter.name,
+            'showing_periods': self.container.global_data.matrix_show_periods,
+            'active': add_last_visible(active, [surplus, inductive, capacitive, maximeter]),
+            'surplus': add_last_visible(surplus, [inductive, capacitive, maximeter]),
+            'inductive': add_last_visible(inductive, [capacitive, maximeter]),
+            'capacitive': add_last_visible(capacitive, [maximeter]),
+            'maximeter': maximeter,
+            'is_visible': visibility([active, surplus, inductive, capacitive]),
+            'adjust_reason': adjust_readings_priority(adjust_reason([active, surplus, inductive, capacitive, maximeter])),
+        }
+        return data
+
+
+    def get_meter_generic_data(self, meter, lectures, title, visible, active):
+        data = {
+            'showing_periods': self.container.global_data.matrix_show_periods,
+            'is_visible': False,
+            'title': title,
+            'is_active': active,
+        }
+
+        adjust_reason = []
+        if meter.name in lectures:
+            data['is_visible'] = visible
+            for reading in lectures[meter.name]:
+                data[reading[0]] = {
+                    'initial': reading[1],
+                    'final': reading[2],
+                    'total': reading[3],
+                }
+                data['initial_date'] = reading[4]
+                if 'initial_type' not in data or reading[6] != u'real':
+                    data['initial_type'] = reading[6]
+                data['final_date'] = reading[5]
+                if 'final_type' not in data or reading[7] != u'real':
+                    data['final_type'] = reading[7]
+                adjust_reason.append(reading[9])
+
+        data['adjust_reason'] = adjust_readings_priority(adjust_reason)
+        return data
+
+    def get_meter_active_data(self, meter):
+        return self.get_meter_generic_data(
+            meter,
+            self.container.readings_data.lectures_a,
+            _(u"Energia Activa (kWh)"),
+            len(self.container.readings_data.lectures_a[meter.name]) > 0 if meter.name in self.container.readings_data.lectures_a else False,
+            True
+        )
+
+    def get_meter_surplus_data(self, meter):
+        return self.get_meter_generic_data(
+            meter,
+            self.container.readings_data.lectures_g,
+            _(u"Energia Excedentària (kWh)"),
+            (len(self.container.readings_data.lectures_g[meter.name]) > 0 and self.container.global_data.te_autoconsum_amb_excedents) if meter.name in self.container.readings_data.lectures_g else False,
+            False
+        )
+
+    def get_meter_generic_reactiva_data(self, meter, lectures, title):
+        data = {
+            'showing_periods': self.container.global_data.matrix_show_periods,
+            'is_visible': False,
+            'title': title,
+            'adjust_reason': False,
+            'is_active': False,
+        }
+        if meter.name in lectures:
+            readings_list = lectures[meter.name]
+            for reading in readings_list:
+                data['is_visible'] = True,
+                data[reading[0]] = {
+                    'initial': reading[1],
+                    'final': reading[2],
+                    'total': reading[3],
+                }
+                data['initial_date'] = reading[4]
+                if 'initial_type' not in data or reading[6] != u'real':
+                    data['initial_type'] = reading[6]
+                data['final_date'] = reading[5]
+                if 'final_type' not in data or reading[7] != u'real':
+                    data['final_type'] = reading[7]
+                if len(reading) == 9 and reading[8] != 0.0:
+                    data['has_adjust'] = True
+
+        return data
+
+    def get_meter_inductive_data(self, meter):
+        return self.get_meter_generic_reactiva_data(
+            meter,
+            self.container.readings_data.lectures_r,
+            _(u"Energia Reactiva Inductiva (kVArh)")
+        )
+
+    def get_meter_capacitive_data(self, meter):
+        return self.get_meter_generic_reactiva_data(
+            meter,
+            self.container.readings_data.lectures_c,
+            _(u"Energia Reactiva Capacitiva (kVArh)")
+        )
+
+    def get_meter_maximeter_data(self, meter):
+        global_data = self.container.global_data
+
+        excess_lines = [l for l in self.fact.linia_ids if l.tipus == 'exces_potencia']
+
+        data = {
+            'showing_periods': global_data.matrix_show_periods,
+            'is_visible': self.pol.facturacio_potencia=='max',
+            'title': _(u"Maxímetre (kW)"),
+            'adjust_reason': False,
+            'is_active': False,
+            'is_visible_surplus': len(excess_lines) > 0 and global_data.te_quartihoraria,
+        }
+
+        periodes_m = sorted(list(set([lectura.name for lectura in self.fact.lectures_potencia_ids])))
+
+        lectures_m = []
+        for lectura in self.fact.lectures_potencia_ids:
+            lectures_m.append((lectura.name, lectura.pot_contract, lectura.pot_maximetre ))
+
+        fact_potencia = dict([(p,0) for p in periodes_m])
+        for p in [(p.product_id.name, p.quantity) for p in excess_lines]:
+            fact_potencia.update({p[0]: max(fact_potencia.get(p[0], 0), p[1])})
+
+        for reading in lectures_m:
+            data[reading[0]] = {
+                'contracted': reading[1],
+                'reading': reading[2],
+                'surplus': fact_potencia[reading[0]],
+            }
+        return data
+
+    def get_info_data(self, adjust_reason):
+        dies_factura = (getYMDdate(self.fact.data_final) - getYMDdate(self.fact.data_inici)).days + 1
+        diari_factura_actual_eur = self.fact.total_energia / (dies_factura or 1.0)
+        diari_factura_actual_kwh = (self.fact.energia_kwh * 1.0) / (dies_factura or 1.0)
+
+        data = {
+            'diari_factura_actual_eur': diari_factura_actual_eur,
+            'diari_factura_actual_kwh': diari_factura_actual_kwh,
+            'dies_factura': dies_factura,
+            'lang': self.container.global_data.lang,
+            'adjust_reason': adjust_reason,
+            'has_web': bool(self.pol.distribuidora.website),
+            'web_distri': self.pol.distribuidora.website,
+            'distri_name': self.pol.distribuidora.name,
+        }
+        return data

--- a/giscedata_facturacio_comer_som/report/components/global_data/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/global_data/__init__.py
@@ -1,0 +1,1 @@
+import global_data

--- a/giscedata_facturacio_comer_som/report/components/global_data/global_data.py
+++ b/giscedata_facturacio_comer_som/report/components/global_data/global_data.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from .. import base_component_data
+
+def is_6X(pol):
+    return pol.tarifa.codi_ocsum in ('012', '013', '014', '015', '016', '017')
+
+def is_TD(pol):
+    return pol.tarifa.codi_ocsum in ('018', '019', '020', '021', '022', '023', '024', '025')
+
+def is_6XTD(pol):
+    return pol.tarifa.codi_ocsum in ('020', '021', '022', '023', '025')
+
+def is_indexed(fact):
+    return 'Indexada' in fact.llista_preu.name
+
+def te_autoconsum(fact, pol):
+    ctxt = {'date': fact.data_final }
+    return pol.te_autoconsum(amb_o_sense_excedents=2, context=ctxt)
+
+class ComponentGlobalDataData(base_component_data.BaseComponentData):
+
+    def get_data(self):
+        readings = self.container.readings_data
+
+        data = base_component_data.BaseComponentData.get_data(self)
+        data['num_periodes'] = len(readings.periodes_a)
+        data['is_6x'] = is_6X(self.pol)
+        data['is_TD'] = is_TD(self.pol)
+        data['is_6xTD'] = is_6XTD(self.pol)
+        data['is_indexed'] = is_indexed(self.fact)
+        data['te_autoconsum'] = te_autoconsum(self.fact, self.pol)
+        return data

--- a/giscedata_facturacio_comer_som/report/components/global_data/global_data.py
+++ b/giscedata_facturacio_comer_som/report/components/global_data/global_data.py
@@ -9,6 +9,9 @@ def is_6X(pol):
 def is_TD(pol):
     return pol.tarifa.codi_ocsum in ('018', '019', '020', '021', '022', '023', '024', '025')
 
+def is_2XTD(pol):
+    return pol.tarifa.codi_ocsum in ('018')
+
 def is_6XTD(pol):
     return pol.tarifa.codi_ocsum in ('020', '021', '022', '023', '025')
 
@@ -18,6 +21,13 @@ def is_indexed(fact):
 def te_autoconsum(fact, pol):
     ctxt = {'date': fact.data_final }
     return pol.te_autoconsum(amb_o_sense_excedents=2, context=ctxt)
+
+def te_autoconsum_amb_excedents(fact, pol):
+    ctxt = {'date': fact.data_final }
+    return pol.te_autoconsum(amb_o_sense_excedents=3, context=ctxt)
+
+def te_quartihoraria(pol):
+    return pol.tipo_medida in ['01', '02', '03']
 
 class ComponentGlobalDataData(base_component_data.BaseComponentData):
 
@@ -31,7 +41,11 @@ class ComponentGlobalDataData(base_component_data.BaseComponentData):
         data['is_6xTD'] = is_6XTD(self.pol)
         data['is_indexed'] = is_indexed(self.fact)
         data['te_autoconsum'] = te_autoconsum(self.fact, self.pol)
+        data['te_autoconsum_amb_excedents'] = te_autoconsum_amb_excedents(self.fact, self.pol)
+        data['te_quartihoraria'] = te_quartihoraria(self.pol)
         data['has_agreement_partner'] = self.pol.soci.ref in agreementPartners
         data['is_energetica'] = self.pol.soci.ref in agreementPartners and self.pol.soci.ref == "S019753"
+        data['matrix_show_periods'] = ['P{}'.format(i+1) for i in range(0, 3 if is_2XTD(self.pol) else 6)]
+        data['lang'] = self.fact.lang_partner.lower()
 
         return data

--- a/giscedata_facturacio_comer_som/report/components/global_data/global_data.py
+++ b/giscedata_facturacio_comer_som/report/components/global_data/global_data.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from .. import base_component_data
 
+agreementPartners = ['S019753','S076331']
+
 def is_6X(pol):
     return pol.tarifa.codi_ocsum in ('012', '013', '014', '015', '016', '017')
 
@@ -29,4 +31,7 @@ class ComponentGlobalDataData(base_component_data.BaseComponentData):
         data['is_6xTD'] = is_6XTD(self.pol)
         data['is_indexed'] = is_indexed(self.fact)
         data['te_autoconsum'] = te_autoconsum(self.fact, self.pol)
+        data['has_agreement_partner'] = self.pol.soci.ref in agreementPartners
+        data['is_energetica'] = self.pol.soci.ref in agreementPartners and self.pol.soci.ref == "S019753"
+
         return data

--- a/giscedata_facturacio_comer_som/report/components/logo/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/logo/__init__.py
@@ -1,0 +1,1 @@
+import logo

--- a/giscedata_facturacio_comer_som/report/components/logo/logo.py
+++ b/giscedata_facturacio_comer_som/report/components/logo/logo.py
@@ -1,22 +1,18 @@
 # -*- coding: utf-8 -*-
 from .. import base_component_data
 
-agreementPartners = {
-        'S019753': {'logo': 'logo_S019753.png'},
-        'S076331': {'logo': 'logo_S076331.png'},
-        }
-
 class ComponentLogoData(base_component_data.BaseComponentData):
 
     def get_data(self):
         """
         returns a dictionary with all required logo component data
         """
+        global_data = self.container.global_data
+
         data = base_component_data.BaseComponentData.get_data(self)
         data['logo'] = 'logo_som.png'
-        if self.pol.soci.ref in agreementPartners.keys():
-            data['has_agreement_partner'] = True
-            data['logo_agreement_partner'] = agreementPartners[self.pol.soci.ref]['logo']
-        else:
-            data['has_agreement_partner'] = False
+        data['has_agreement_partner'] = global_data.has_agreement_partner
+        if global_data.has_agreement_partner:
+            data['logo_agreement_partner'] = u'logo_' + self.pol.soci.ref + u".png"
+
         return data

--- a/giscedata_facturacio_comer_som/report/components/logo/logo.py
+++ b/giscedata_facturacio_comer_som/report/components/logo/logo.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+agreementPartners = {
+        'S019753': {'logo': 'logo_S019753.png'},
+        'S076331': {'logo': 'logo_S076331.png'},
+        }
+
+class logo:
+    def __init__(self):
+        pass
+
+    def set_data(self, pol):
+        self.pol = pol
+
+    def is_visible(self):
+        return True
+
+    def get_data(self):
+        """
+        returns a dictionary with all required logo component data
+        """
+        data = {'logo': 'logo_som.png'}
+        if self.pol.soci.ref in agreementPartners.keys():
+            data['has_agreement_partner'] = True
+            data['logo_agreement_partner'] = agreementPartners[self.pol.soci.ref]['logo']
+        else:
+            data['has_agreement_partner'] = False
+        return data
+
+

--- a/giscedata_facturacio_comer_som/report/components/logo/logo.py
+++ b/giscedata_facturacio_comer_som/report/components/logo/logo.py
@@ -1,30 +1,22 @@
 # -*- coding: utf-8 -*-
+from .. import base_component_data
 
 agreementPartners = {
         'S019753': {'logo': 'logo_S019753.png'},
         'S076331': {'logo': 'logo_S076331.png'},
         }
 
-class logo:
-    def __init__(self):
-        pass
-
-    def set_data(self, pol):
-        self.pol = pol
-
-    def is_visible(self):
-        return True
+class ComponentLogoData(base_component_data.BaseComponentData):
 
     def get_data(self):
         """
         returns a dictionary with all required logo component data
         """
-        data = {'logo': 'logo_som.png'}
+        data = base_component_data.BaseComponentData.get_data(self)
+        data['logo'] = 'logo_som.png'
         if self.pol.soci.ref in agreementPartners.keys():
             data['has_agreement_partner'] = True
             data['logo_agreement_partner'] = agreementPartners[self.pol.soci.ref]['logo']
         else:
             data['has_agreement_partner'] = False
         return data
-
-

--- a/giscedata_facturacio_comer_som/report/components/readings_data/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/readings_data/__init__.py
@@ -1,0 +1,1 @@
+import readings_data

--- a/giscedata_facturacio_comer_som/report/components/readings_data/readings_data.py
+++ b/giscedata_facturacio_comer_som/report/components/readings_data/readings_data.py
@@ -55,9 +55,6 @@ class ComponentReadingsDataData(base_component_data.BaseComponentData):
         return res
 
     def get_data(self):
-
-        data = base_component_data.BaseComponentData.get_data(self)
-
         self.init_origens()
         fact = self.fact
         """
@@ -209,24 +206,24 @@ class ComponentReadingsDataData(base_component_data.BaseComponentData):
                 if l[8] != 0:
                     has_adjust_g = True
 
-        return {
-            'periodes_a': periodes_a,
-            'periodes_r': periodes_r,
-            'periodes_c': periodes_c,
-            'periodes_g': periodes_g,
-            'lectures_a': lectures_a,
-            'lectures_r': lectures_r,
-            'lectures_c': lectures_c,
-            'lectures_g': lectures_g,
-            'lectures_real_a': lectures_real_a,
-            'lectures_real_r': lectures_real_r,
-            'lectures_real_c': lectures_real_c,
-            'lectures_real_g': lectures_real_g,
-            'total_lectures_a': total_lectures_a,
-            'total_lectures_r': total_lectures_r,
-            'total_lectures_c': total_lectures_c,
-            'total_lectures_g': total_lectures_g,
-            'has_adjust_a': has_adjust_a,
-            'has_adjust_g' : has_adjust_g,
-            'has_readings_g': has_readings_g,
-        }
+        data = base_component_data.BaseComponentData.get_data(self)
+        data['periodes_a'] = periodes_a
+        data['periodes_r'] = periodes_r
+        data['periodes_c'] = periodes_c
+        data['periodes_g'] = periodes_g
+        data['lectures_a'] = lectures_a
+        data['lectures_r'] = lectures_r
+        data['lectures_c'] = lectures_c
+        data['lectures_g'] = lectures_g
+        data['lectures_real_a'] = lectures_real_a
+        data['lectures_real_r'] = lectures_real_r
+        data['lectures_real_c'] = lectures_real_c
+        data['lectures_real_g'] = lectures_real_g
+        data['total_lectures_a'] = total_lectures_a
+        data['total_lectures_r'] = total_lectures_r
+        data['total_lectures_c'] = total_lectures_c
+        data['total_lectures_g'] = total_lectures_g
+        data['has_adjust_a'] = has_adjust_a
+        data['has_adjust_g'] = has_adjust_g
+        data['has_readings_g'] = has_readings_g
+        return data

--- a/giscedata_facturacio_comer_som/report/components/readings_data/readings_data.py
+++ b/giscedata_facturacio_comer_som/report/components/readings_data/readings_data.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+from tools.translate import _
+from .. import base_component_data
+from ..base_component_utils import val, dateformat, getYMDdate
+
+class ComponentReadingsDataData(base_component_data.BaseComponentData):
+
+    def init_origens(self):
+        origen_obj = self.report.pool.get('giscedata.lectures.origen')
+        origen_comer_obj = self.report.pool.get('giscedata.lectures.origen_comer')
+
+        self.estimada_id = origen_obj.search(self.cursor, self.uid, [('codi', '=', '40')])[0]
+        self.sin_lectura_id = origen_obj.search(self.cursor, self.uid, [('codi', '=', '99')])[0]
+        self.estimada_som_id = origen_comer_obj.search(self.cursor, self.uid, [('codi', '=', 'ES')])[0]
+        self.calculada_som_id = origen_obj.search(self.cursor, self.uid, [('codi', '=', 'LC')])
+        self.calculada_som_id = self.calculada_som_id[0] if self.calculada_som_id else None
+
+    def get_origen_lectura(self, lectura):
+        """Busquem l'origen de la lectura cercant-la a les lectures de facturació"""
+        res = {lectura.data_actual: '',
+            lectura.data_anterior: ''}
+
+        lectura_obj = self.report.pool.get('giscedata.lectures.lectura')
+        tarifa_obj = self.report.pool.get('giscedata.polissa.tarifa')
+
+        #Busquem la tarifa
+        tarifa_id = tarifa_obj.search(self.cursor, self.uid, [('name', '=', lectura.name[:-5])])
+        if tarifa_id:
+            tipus = lectura.tipus == 'activa' and 'A' or 'R'
+
+            search_vals = [('comptador', '=', lectura.comptador),
+                        ('periode.name', '=', lectura.name[-3:-1]),
+                        ('periode.tarifa', '=', tarifa_id[0]),
+                        ('tipus', '=', tipus),
+                        ('name', 'in', [lectura.data_actual,
+                                        lectura.data_anterior])]
+            lect_ids = lectura_obj.search(self.cursor, self.uid, search_vals)
+            lect_vals = lectura_obj.read(self.cursor, self.uid, lect_ids,
+                                        ['name', 'origen_comer_id', 'origen_id'])
+            for lect in lect_vals:
+                # En funció dels origens, escrivim el text
+                # Si Estimada (40) o Sin Lectura (99) i Estimada (ES): Estimada Somenergia
+                # Si Estimada (40) o Sin Lectura (99) i F1/Q1/etc...(!ES): Estimada distribuïdora
+                # La resta: Real
+                origen_txt = _(u"real")
+                if lect['origen_id'][0] in [ self.estimada_id, self.sin_lectura_id ]:
+                    if lect['origen_comer_id'][0] == self.estimada_som_id:
+                        origen_txt = _(u"calculada per Som Energia")
+                    else:
+                        origen_txt = _(u"estimada distribuïdora")
+                if lect['origen_id'][0] == self.calculada_som_id:
+                    origen_txt = _(u"calculada")
+                res[lect['name']] = "%s" % (origen_txt)
+
+        return res
+
+    def get_data(self):
+
+        data = base_component_data.BaseComponentData.get_data(self)
+
+        self.init_origens()
+        fact = self.fact
+        """
+        Calculate the active and reactive energy readings data
+        """
+
+        periodes_a = sorted(list(set([lectura.name[-3:-1]
+                                    for lectura in fact.lectures_energia_ids
+                                    if lectura.tipus == 'activa' and lectura.magnitud == 'AE'])))
+        periodes_r = sorted(list(set([lectura.name[-3:-1]
+                                    for lectura in fact.lectures_energia_ids
+                                    if lectura.tipus == 'reactiva' and lectura.magnitud == 'R1'])))
+        periodes_c = sorted(list(set([lectura.name[-3:-1]
+                                    for lectura in fact.lectures_energia_ids
+                                    if lectura.tipus == 'reactiva' and lectura.magnitud == 'R4'])))
+        periodes_g = sorted(list(set([lectura.name[-3:-1]
+                                    for lectura in fact.lectures_energia_ids
+                                    if lectura.tipus == 'activa' and lectura.magnitud == 'AS'])))
+
+        lectures_a = {}
+        lectures_r = {}
+        lectures_c = {}
+        lectures_g = {}
+
+        lectures_real_a = {}
+        lectures_real_r = {}
+        lectures_real_c = {}
+        lectures_real_g = {}
+
+        for lectura in fact.lectures_energia_ids:
+            origens = self.get_origen_lectura(lectura)
+            if lectura.tipus == 'activa' and lectura.magnitud == 'AE':
+                lectures_a.setdefault(lectura.comptador,[])
+                lectures_a[lectura.comptador].append((lectura.name[-3:-1],
+                                                    val(lectura.lect_anterior),
+                                                    val(lectura.lect_actual),
+                                                    val(lectura.consum),
+                                                    dateformat(lectura.data_anterior),
+                                                    dateformat(lectura.data_actual),
+                                                    origens[lectura.data_anterior],
+                                                    origens[lectura.data_actual],
+                                                    val(lectura.ajust),
+                                                    val(lectura.motiu_ajust),
+                                                    ))
+                lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.pool_lectures if lectura_real.tipus == "A" and "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,9,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                lectures_real_a.setdefault(lectura.comptador,[])
+                if len(lectura_real)>0:
+                    lectures_real_a[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura),dateformat(lectura_real[0].name)))
+                else:
+                    lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.lectures if lectura_real.tipus == "A" and  "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,9,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                    if len(lectura_real)>0:
+                        lectures_real_a[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura), dateformat(lectura_real[0].name)))
+
+            elif lectura.tipus == 'activa' and lectura.magnitud == 'AS':
+                lectures_g.setdefault(lectura.comptador,[])
+                lectures_g[lectura.comptador].append((lectura.name[-3:-1],
+                                                    val(lectura.lect_anterior),
+                                                    val(lectura.lect_actual),
+                                                    val(lectura.consum),
+                                                    dateformat(lectura.data_anterior),
+                                                    dateformat(lectura.data_actual),
+                                                    origens[lectura.data_anterior],
+                                                    origens[lectura.data_actual],
+                                                    val(lectura.ajust),
+                                                    val(lectura.motiu_ajust),
+                                                    ))
+                lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.pool_lectures if lectura_real.tipus == "A" and "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,9,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                lectures_real_g.setdefault(lectura.comptador,[])
+                if len(lectura_real)>0:
+                    lectures_real_g[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura),dateformat(lectura_real[0].name)))
+                else:
+                    lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.lectures if lectura_real.tipus == "A" and  "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,9,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                    if len(lectura_real)>0:
+                        lectures_real_g[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura), dateformat(lectura_real[0].name)))
+
+            elif lectura.tipus == 'reactiva' and lectura.magnitud == 'R1':
+                lectures_r.setdefault(lectura.comptador,[])
+                lectures_r[lectura.comptador].append((lectura.name[-3:-1],
+                                                    val(lectura.lect_anterior),
+                                                    val(lectura.lect_actual),
+                                                    val(lectura.consum),
+                                                    dateformat(lectura.data_anterior),
+                                                    dateformat(lectura.data_actual),
+                                                    origens[lectura.data_anterior],
+                                                    origens[lectura.data_actual],
+                                                    ))
+                lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.pool_lectures if lectura_real.tipus == "R" and "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                lectures_real_r.setdefault(lectura.comptador,[])
+                if len(lectura_real)>0:
+                    lectures_real_r[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura),dateformat(lectura_real[0].name)))
+                else:
+                    lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.lectures if lectura_real.tipus == "R" and  "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                    if len(lectura_real)>0:
+                        lectures_real_r[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura),dateformat(lectura_real[0].name)))
+
+            elif lectura.tipus == 'reactiva' and lectura.magnitud == 'R4':
+                lectures_c.setdefault(lectura.comptador,[])
+                lectures_c[lectura.comptador].append((lectura.name[-3:-1],
+                                                    val(lectura.lect_anterior),
+                                                    val(lectura.lect_actual),
+                                                    val(lectura.consum),
+                                                    dateformat(lectura.data_anterior),
+                                                    dateformat(lectura.data_actual),
+                                                    origens[lectura.data_anterior],
+                                                    origens[lectura.data_actual],
+                                                    ))
+                lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.pool_lectures if lectura_real.tipus == "R" and "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                lectures_real_c.setdefault(lectura.comptador,[])
+                if len(lectura_real)>0:
+                    lectures_real_c[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura),dateformat(lectura_real[0].name)))
+                else:
+                    lectura_real = sorted([lectura_real for lectura_real in lectura.comptador_id.lectures if lectura_real.tipus == "R" and  "{} ({})".format(lectura_real.periode.tarifa.name,lectura_real.periode.product_id.name) == lectura.name and lectura_real.origen_id.id not in [7,22,23] and getYMDdate(lectura_real.name)<getYMDdate(lectura.data_actual)], reverse=True, key=lambda l:l.name)
+                    if len(lectura_real)>0:
+                        lectures_real_c[lectura.comptador].append((lectura.name[-3:-1],val(lectura_real[0].lectura),dateformat(lectura_real[0].name)))
+
+        total_lectures_a = dict([(p, 0) for p in periodes_a])
+        total_lectures_r = dict([(p, 0) for p in periodes_r])
+        total_lectures_c = dict([(p, 0) for p in periodes_c])
+        total_lectures_g = dict([(p, 0) for p in periodes_g])
+
+        for c, ls in lectures_a.items():
+            for l in ls:
+                total_lectures_a[l[0]] += l[3]
+
+        for c, ls in lectures_r.items():
+            for l in ls:
+                total_lectures_r[l[0]] += l[3]
+
+        for c, ls in lectures_c.items():
+            for l in ls:
+                total_lectures_c[l[0]] += l[3]
+
+        for c, ls in lectures_g.items():
+            for l in ls:
+                total_lectures_g[l[0]] += l[3]
+
+        has_adjust_a = False
+        for k,v in lectures_a.items():
+            for l in v:
+                if l[8] != 0:
+                    has_adjust_a = True
+
+        has_readings_g = False
+        has_adjust_g = False
+        for k,v in lectures_g.items():
+            for l in v:
+                if l[1] != 0 or  l[2] != 0 :
+                    has_readings_g = True
+                if l[8] != 0:
+                    has_adjust_g = True
+
+        return {
+            'periodes_a': periodes_a,
+            'periodes_r': periodes_r,
+            'periodes_c': periodes_c,
+            'periodes_g': periodes_g,
+            'lectures_a': lectures_a,
+            'lectures_r': lectures_r,
+            'lectures_c': lectures_c,
+            'lectures_g': lectures_g,
+            'lectures_real_a': lectures_real_a,
+            'lectures_real_r': lectures_real_r,
+            'lectures_real_c': lectures_real_c,
+            'lectures_real_g': lectures_real_g,
+            'total_lectures_a': total_lectures_a,
+            'total_lectures_r': total_lectures_r,
+            'total_lectures_c': total_lectures_c,
+            'total_lectures_g': total_lectures_g,
+            'has_adjust_a': has_adjust_a,
+            'has_adjust_g' : has_adjust_g,
+            'has_readings_g': has_readings_g,
+        }

--- a/giscedata_facturacio_comer_som/report/components/readings_table/__init__.py
+++ b/giscedata_facturacio_comer_som/report/components/readings_table/__init__.py
@@ -1,0 +1,1 @@
+import readings_table

--- a/giscedata_facturacio_comer_som/report/components/readings_table/readings_table.py
+++ b/giscedata_facturacio_comer_som/report/components/readings_table/readings_table.py
@@ -9,6 +9,7 @@ class ComponentReadingsTableData(base_component_data.BaseComponentData):
         return a dictionary with all readings table component needed data
         """
         readings = self.container.readings_data
+        global_data = self.container.global_data
 
         dies_factura = (datetime.strptime(self.fact.data_final, '%Y-%m-%d') - datetime.strptime(self.fact.data_inici, '%Y-%m-%d')).days + 1
         diari_factura_actual_eur = self.fact.total_energia / (dies_factura or 1.0)
@@ -21,6 +22,6 @@ class ComponentReadingsTableData(base_component_data.BaseComponentData):
         data['dies_factura'] = dies_factura
         data['diari_factura_actual_eur'] = diari_factura_actual_eur
         data['diari_factura_actual_kwh'] = diari_factura_actual_kwh
-        data['has_autoconsum'] = self.te_autoconsum()
+        data['has_autoconsum'] = global_data.te_autoconsum
 
         return data

--- a/giscedata_facturacio_comer_som/report/components/readings_table/readings_table.py
+++ b/giscedata_facturacio_comer_som/report/components/readings_table/readings_table.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+from .. import base_component_data
+
+class ComponentReadingsTableData(base_component_data.BaseComponentData):
+
+    def get_data(self):
+        """
+        return a dictionary with all readings table component needed data
+        """
+        readings = self.container.readings_data
+
+        dies_factura = (datetime.strptime(self.fact.data_final, '%Y-%m-%d') - datetime.strptime(self.fact.data_inici, '%Y-%m-%d')).days + 1
+        diari_factura_actual_eur = self.fact.total_energia / (dies_factura or 1.0)
+        diari_factura_actual_kwh = (self.fact.energia_kwh * 1.0) / (dies_factura or 1.0)
+
+        data = base_component_data.BaseComponentData.get_data(self)
+        data['periodes_a'] = readings.periodes_a
+        data['lectures_a'] = readings.lectures_a
+        data['total_lectures_a'] = readings.total_lectures_a
+        data['dies_factura'] = dies_factura
+        data['diari_factura_actual_eur'] = diari_factura_actual_eur
+        data['diari_factura_actual_kwh'] = diari_factura_actual_kwh
+        data['has_autoconsum'] = self.te_autoconsum()
+
+        return data

--- a/giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako
+++ b/giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako
@@ -34,7 +34,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
 <%include file="/giscedata_facturacio_comer_som/report/components/lateral_text/lateral_text.mako" args="lt=factura_data.lateral_text" />
 <div id="container">
 
-% if factura_data.globals.is_TD: # Factura 2.0TD 3.0TD 6.XTD
+% if factura_data.global_data.is_TD: # Factura 2.0TD 3.0TD 6.XTD
 
     <div class="company_address" style="font-size: .7em;">
         <%include file="/giscedata_facturacio_comer_som/report/components/logo/logo.mako" args="logo=factura_data.logo" />
@@ -52,7 +52,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
         <h1>${_(u"INFORMACIÓ DE L'ELECTRICITAT UTILITZADA")}</h1>
         <div>
             <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako" args="energy=factura_data.energy_consumption_graphic_td" />
-            % if factura_data.globals.is_indexed:
+            % if factura_data.global_data.is_indexed:
                 <%include file="/giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako" args="hc=factura_data.hourly_curve" />
             % endif
         </div>
@@ -97,7 +97,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
     <!-- LECTURES ACTIVA i GRÀFIC BARRES -->
     <div class="energy_info">
         <h1>${_(u"INFORMACIÓ DEL CONSUM ELÈCTRIC")}</h1>
-        % if factura_data.globals.is_6x:
+        % if factura_data.global_data.is_6x:
             <div class="" style="padding: 10px;">
                 <%include file="/giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako" args="readings_6x=factura_data.readings_6x" />
                 <div class="column">
@@ -105,7 +105,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
                 </div>
             </div>
         % else:
-            % if factura_data.globals.num_periodes < 3:
+            % if factura_data.global_data.num_periodes < 3:
                 <div class="energy_child_info">
             % else:
                 <div>
@@ -115,7 +115,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
                 <%include file="/giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako" args="readings=factura_data.readings_g_table" />
                 <%include file="/giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako" args="readings=factura_data.readings_text" />
             </div>
-            % if factura_data.globals.num_periodes < 3:
+            % if factura_data.global_data.num_periodes < 3:
                 <div class="energy_child_info">
             % else:
                 <div>
@@ -139,7 +139,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
     <!-- DETALL FACTURA -->
         <div class="invoice_detail">
             <h1>${_(u"DETALL DE LA FACTURA")}</h1>
-            % if factura_data.globals.is_6x:
+            % if factura_data.global_data.is_6x:
             <div class="row">
                 <div class="column">
             %endif
@@ -148,7 +148,7 @@ report_data = r_obj.get_report_data(cursor, uid, objects)
                     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako" args="id_energy=factura_data.invoice_details_energy" />
                     <hr/>
                     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako" args="id_generation=factura_data.invoice_details_generation" />
-            % if factura_data.globals.is_6x:
+            % if factura_data.global_data.is_6x:
                 </div>
             </div>
             <%include file="/giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako" args="hc=factura_data.hourly_curve" />

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -9,6 +9,8 @@ from yamlns import namespace as ns
 from yamlns.testutils import assertNsEqual
 from datetime import datetime
 from .. import giscedata_facturacio_report
+from ..invoice_data_container import SmartInvoiceDataContainer
+
 
 class Tests_FacturacioFacturaReport_base(testing.OOTestCase):
 
@@ -47,6 +49,11 @@ class Tests_FacturacioFacturaReport_base(testing.OOTestCase):
         fac = self.factura_obj.browse(self.cursor, self.uid, f_id)
         pol = self.polissa_obj.browse(self.cursor, self.uid, fac.polissa_id.id)
         return {'fact': fac,'pol': pol}
+
+    def get_smart_component(self, f_id):
+        fac = self.factura_obj.browse(self.cursor, self.uid, f_id)
+        pol = self.polissa_obj.browse(self.cursor, self.uid, fac.polissa_id.id)
+        return SmartInvoiceDataContainer(self.cursor, self.uid, {}, fac, pol, {})
 
     def setup_langs(self):
         lang_obj = self.model('res.lang')
@@ -226,15 +233,16 @@ class Tests_FacturacioFacturaReport_company_component(Tests_FacturacioFacturaRep
     def test__som_report_comp_company__base(self):
         f_id = self.get_fixture('giscedata_facturacio', 'factura_0001')
 
-        result = self.r_obj.get_component_company_data(**self.bfp(f_id))
+        result = dict(self.get_smart_component(f_id).company)
         self.assertYamlfy(result)
         self.assertEquals(result , {
-            'cif': u'A31896889',
-            'city': u'Gerompont',
+            'is_visible': True,
+            'cif': 'A31896889',
+            'city': 'Gerompont',
             'email': False,
-            'name': u'Tiny sprl',
-            'street': u'Chaussee de Namur 40',
-            'zip': u'1367'})
+            'name': 'Tiny sprl',
+            'street': 'Chaussee de Namur 40',
+            'zip': '1367'})
 
     def test__som_report_comp_company__som(self):
         f_id = self.get_fixture('giscedata_facturacio', 'factura_0001')
@@ -260,15 +268,16 @@ class Tests_FacturacioFacturaReport_company_component(Tests_FacturacioFacturaRep
             'email': 'info@somenergia.coop',
         })
 
-        result = self.r_obj.get_component_company_data(**self.bfp(f_id))
+        result = dict(self.get_smart_component(f_id).company)
         self.assertYamlfy(result)
         self.assertEquals(result , {
-            'cif': u'F55091367',
-            'city': u'Girona',
-            'email': u'info@somenergia.coop',
-            'name': u'Som Energia, SCCL',
-            'street': u'Pic de Peguera, 11 A 2 8',
-            'zip': u'17003'})
+            'is_visible': True,
+            'cif': 'F55091367',
+            'city': 'Girona',
+            'email': 'info@somenergia.coop',
+            'name': 'Som Energia, SCCL',
+            'street': 'Pic de Peguera, 11 A 2 8',
+            'zip': '17003'})
 
 
 class Tests_FacturacioFacturaReport_gdo_component(Tests_FacturacioFacturaReport_base):

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -53,7 +53,7 @@ class Tests_FacturacioFacturaReport_base(testing.OOTestCase):
     def get_smart_component(self, f_id):
         fac = self.factura_obj.browse(self.cursor, self.uid, f_id)
         pol = self.polissa_obj.browse(self.cursor, self.uid, fac.polissa_id.id)
-        return SmartInvoiceDataContainer(self.cursor, self.uid, {}, fac, pol, {})
+        return SmartInvoiceDataContainer(self.cursor, self.uid, self.openerp, fac, pol, {})
 
     def setup_langs(self):
         lang_obj = self.model('res.lang')
@@ -162,7 +162,7 @@ class Tests_FacturacioFacturaReport_logo_component(Tests_FacturacioFacturaReport
     def test__som_report_comp_logo__no_soci(self):
         f_id = self.get_fixture('giscedata_facturacio', 'factura_0001')
 
-        result = self.r_obj.get_component_logo_data(**self.bfp(f_id))
+        result = dict(self.get_smart_component(f_id).logo)
         self.assertYamlfy(result)
         self.assertEquals(result ,{
             'logo': 'logo_som.png',
@@ -203,12 +203,18 @@ class Tests_FacturacioFacturaReport_logo_component(Tests_FacturacioFacturaReport
         f = self.factura_obj.browse(self.cursor, self.uid, f_id)
 
         p_id = 23
-        self.partner_obj.write(self.cursor, self.uid, p_id, {'ref': 'S12345'})
+        self.setup_langs()
+        self.partner_obj.write(self.cursor, self.uid, p_id, {
+            'ref': 'S12345',
+            'lang': 'ca_ES',
+        })
         self.polissa_obj.write(self.cursor, self.uid, f.polissa_id.id, {'soci': p_id})
+        self.factura_obj.write(self.cursor, self.uid, f.id, {'partner_id': p_id})
 
-        result = self.r_obj.get_component_logo_data(**self.bfp(f_id))
+        result = dict(self.get_smart_component(f_id).logo)
         self.assertYamlfy(result)
         self.assertEquals(result , {
+            'is_visible': True,
             'logo': 'logo_som.png',
             'has_agreement_partner': False})
 


### PR DESCRIPTION
## Objectiu

Plantejar la fase inicial del refactor del generador de dades monolític de les dades de la factura en pdf ara que ja es troba dividida en components de manera que els components es pugin agrupar com a conjunts de .mako .css i .py aillats. 

L'objectiu d'aquest refactor es evitar dobles carregues o carregues innecessàries de dades que alenteixen el procés de renderitzar la factura en pdf i evitar errors relacionats amb dades no necessàries.

## Targeta on es demana o Incidència 

https://trello.com/c/9nHtdVg9/1279-refactor-del-generador-de-dades-del-pdf-de-factura

## Comportament antic

Càrrega lenta i  de vegades repetida.

## Comportament nou

Per demostrar

## Comprovacions
- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
    - giscedata_facturacio_comer_som
- [ ] Script de migració
- [ ] Modifica traduccions
