### PR TITLE
Extractor de cassos del ERP

### DIFF
--- a/som_data_extractor/__init__.py
+++ b/som_data_extractor/__init__.py
@@ -1,0 +1,1 @@
+import som_data_extractor

--- a/som_data_extractor/__terp__.py
+++ b/som_data_extractor/__terp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Som Data Extractor",
+    "description": """Aquest mòdul permet extreure dades i les seves dependències""",
+    "version": "0-dev",
+    "author": "Som Energia",
+    "category": "Master",
+    "depends":[
+        "base",
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml": [
+    ],
+    "active": False,
+    "installable": True
+}

--- a/som_data_extractor/security/ir.model.access.csv
+++ b/som_data_extractor/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"

--- a/som_data_extractor/som_data_extractor.py
+++ b/som_data_extractor/som_data_extractor.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from osv import osv
+from lxml import etree
+from slugify import slugify
+
+
+class SomDataExtractor(osv.osv_memory):
+
+    _name = 'som.data.extractor'
+
+    def model_exists(self, model):
+        obj = self.pool.get(model)
+        if obj is None:
+            raise Exception('Model {0} does not exist!'.format(model))
+        return obj
+
+    def get_semantic_id(self, cursor, uid, model_obj, res_id):
+        return '{0}_{1}_{2}'.format(
+                model_obj._table,
+                slugify(model_obj.name_get(cursor, uid, [res_id])[0][1]),
+                res_id
+            )
+
+    def extract_model(self, cursor, uid,
+                      model, res_id, max_depth,
+                      context=None):
+        if context is None:
+            context = {}
+        entity_dict = {}
+        depth = 1
+        self.extract_model_r(cursor, uid,
+                             model, res_id, depth, max_depth,
+                             entity_dict, context)
+        return entity_dict
+
+    def extract_model_r(self, cursor, uid,
+                        model, res_id, depth, max_depth,
+                        entity_dict, context):
+
+        if max_depth and depth > max_depth:
+            return {None: {}}
+
+        result = {}
+
+        model_obj = self.model_exists(model)
+
+        fields_def = model_obj.fields_get(cursor, uid)
+
+        name_id = self.get_semantic_id(cursor, uid, model_obj, res_id)
+        key = (name_id, model)
+        if key in entity_dict:
+            result[key] = entity_dict[key]
+        else:
+            extracted_data = {}
+            result[key] = extracted_data
+            entity_dict[key] = extracted_data
+            for field, value in model_obj.read(cursor, uid, res_id).items():
+                if field not in fields_def:
+                    continue
+
+                field_def = fields_def[field]
+                field_type = field_def['type']
+
+                if field_type == 'many2many':
+                    pass
+                elif field_type == 'one2many':
+                    pass
+                elif field_type == 'many2one':
+                    if value:
+                        inner = self.extract_model_r(cursor, uid,
+                                                     field_def['relation'],
+                                                     value[0],
+                                                     depth+1, max_depth,
+                                                     entity_dict, context)
+                        if inner.keys()[0] not in [None, False]:
+                            extracted_data[field] = inner.keys()[0]
+                else:
+                    if field_type == 'date' and value == False:
+                        value = ''
+                    extracted_data[field] = value
+        return result
+
+    def encode_as_xml(self, items):
+        root = etree.Element("openerp")
+        data = etree.SubElement(root, u'data')
+        for name, item in items.items():
+            record = etree.SubElement(data, u'record')
+            self._parse_extracted_item(record, name, item)
+
+        return etree.tostring(root,
+                              xml_declaration=True,
+                              encoding='UTF-8',
+                              pretty_print=True)
+
+    def _parse_extracted_item(self, record, name, item):
+        record.set(u'id',name[0])
+        record.set(u'model',name[1])
+
+        for name,value in item.items():
+            field = etree.SubElement(record, u'field')
+            field.set(u'name',name)
+            if type(value) == tuple:
+                model = value[1].replace('.','_')
+                s_id = value[0]
+                field.set(u'ref',model+u'.'+s_id)
+            elif type(value) not in (str,unicode):
+                field.text = str(value)
+            else:
+                field.text = value
+
+    def extract_model_as_xml(self, cursor, uid,
+                             model, res_id, max_depth,
+                             context=None):
+        model_data = self.extract_model(cursor, uid,
+                                        model, res_id, max_depth,
+                                        context)
+        return self.encode_as_xml(model_data)
+
+
+SomDataExtractor()

--- a/som_data_extractor/tests/__init__.py
+++ b/som_data_extractor/tests/__init__.py
@@ -1,0 +1,1 @@
+from test_som_data_extractor import *

--- a/som_data_extractor/tests/test_som_data_extractor.py
+++ b/som_data_extractor/tests/test_som_data_extractor.py
@@ -1,0 +1,518 @@
+# -*- coding: utf-8 -*-
+import base64
+import unittest
+
+from destral import testing
+from destral.transaction import Transaction
+from expects import expect, raise_error
+from osv.orm import except_orm
+from addons import get_module_resource
+import time
+from tools.misc import cache
+import mock
+from .. import som_data_extractor
+
+
+class FakeErpModel(object):
+    def __init__(self, fields_def, field_values, model):
+        self.model = model
+        self.fields_def = fields_def
+        self.field_values = field_values
+    
+    def fields_get(self, cursor, uid):
+        return self.fields_def[self.model]
+
+    def read(self, cursor, uid, res_id):
+        return self.field_values[self.model]
+
+class TestSomDataExtractor(testing.OOTestCase):
+
+    def model(self, model_name):
+        return self.openerp.pool.get(model_name)
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.maxDiff = None
+
+    def tearDown(self):
+        self.txn.stop()
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_simple_estructure(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "fakeerpmodel": {
+                    "camp_1": {'type': "char"},
+                    "camp_2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "fakeerpmodel": {
+                    "camp_1": "a",
+                    "camp_2": "b"
+                }
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'fakeerpmodel'
+        e_id = 1
+        recursion_depth = 200
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+
+        expected_result = {('fake-semantic-id', 'fakeerpmodel'): {'camp_1':"a", "camp_2":"b"}}
+        self.assertDictEqual(result, expected_result)
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_one_child_one_depth(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "model1": {
+                    "camp_1": {'type': "char"},
+                    "subobjecte": {"type": "many2one", "relation": "model2"}
+                },
+                "model2": {
+                    "subcamp1": {"type": "char"},
+                    "subcamp2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "model1": {
+                    "camp_1": "a",
+                    "subobjecte": (1, "model2")
+                },
+                "model2": {
+                    "subcamp1": "b",
+                    "subcamp2": "c"
+                }
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'model1'
+        e_id = 1
+        recursion_depth = 200
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+        expected_result = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte': ('fake-semantic-id', 'model2')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp2': 'c', 'subcamp1': 'b'
+            }
+        }
+
+        self.assertDictEqual(result, expected_result)
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_two_different_children_one_depth(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "model1": {
+                    "camp_1": {'type': "char"},
+                    "subobjecte_1": {"type": "many2one", "relation": "model2"},
+                    "subobjecte_2": {"type": "many2one", "relation": "model3"}
+                },
+                "model2": {
+                    "subcamp1_1": {"type": "char"},
+                    "subcamp1_2": {"type": "char"}
+                },
+                "model3": {
+                    "subcamp2_1": {"type": "char"},
+                    "subcamp2_2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "model1": {
+                    "camp_1": "a",
+                    "subobjecte_1": (1, "model2"),
+                    "subobjecte_2": (1, "model3")
+                },
+                "model2": {
+                    "subcamp1_1": "b",
+                    "subcamp1_2": "c"
+                },
+                "model3": {
+                    "subcamp2_1": "d",
+                    "subcamp2_2": "e"
+                }
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'model1'
+        e_id = 1
+        recursion_depth = 200
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+        expected_result = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte_1': ('fake-semantic-id', 'model2'), 'subobjecte_2': ('fake-semantic-id', 'model3')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp1_1': 'b', 'subcamp1_2': 'c'
+            },
+            ('fake-semantic-id', 'model3'): {
+                'subcamp2_1': 'd', 'subcamp2_2': 'e'
+            }
+        }
+
+        self.assertDictEqual(result, expected_result)
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_two_same_children_one_depth(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "model1": {
+                    "camp_1": {'type': "char"},
+                    "subobjecte_1": {"type": "many2one", "relation": "model2"},
+                    "subobjecte_2": {"type": "many2one", "relation": "model2"}
+                },
+                "model2": {
+                    "subcamp1_1": {"type": "char"},
+                    "subcamp1_2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "model1": {
+                    "camp_1": "a",
+                    "subobjecte_1": (1, "model2"),
+                    "subobjecte_2": (1, "model2")
+                },
+                "model2": {
+                    "subcamp1_1": "b",
+                    "subcamp1_2": "c"
+                }
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'model1'
+        e_id = 1
+        recursion_depth = 200
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+        expected_result = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte_1': ('fake-semantic-id', 'model2'), 'subobjecte_2': ('fake-semantic-id', 'model2')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp1_1': 'b', 'subcamp1_2': 'c'
+            }
+        }
+
+        self.assertDictEqual(result, expected_result)
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_one_children_two_depth(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "model1": {
+                    "camp_1": {'type': "char"},
+                    "subobjecte_1": {"type": "many2one", "relation": "model2"}
+                },
+                "model2": {
+                    "subcamp1_1": {"type": "char"},
+                    "subcamp1_2": {"type": "char"},
+                    "subobjecte_2": {"type": "many2one", "relation": "model3"}
+                },
+                "model3": {
+                    "subcamp2_1": {"type": "char"},
+                    "subcamp2_2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "model1": {
+                    "camp_1": "a",
+                    "subobjecte_1": (1, "model2"),
+                },
+                "model2": {
+                    "subcamp1_1": "b",
+                    "subcamp1_2": "c",
+                    "subobjecte_2": (1, "model3")
+                },
+                "model3": {
+                    "subcamp2_1": "d",
+                    "subcamp2_2": "e"
+                }
+
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'model1'
+        e_id = 1
+        recursion_depth = 200
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+        expected_result = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte_1': ('fake-semantic-id', 'model2')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp1_1': 'b', 'subcamp1_2': 'c', 'subobjecte_2': ('fake-semantic-id', 'model3')
+            },
+            ('fake-semantic-id', 'model3'): {
+                'subcamp2_1': 'd', 'subcamp2_2': 'e'
+            }
+        }
+
+        self.assertDictEqual(result, expected_result)
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_two_children_two_depth(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "model1": {
+                    "camp_1": {'type': "char"},
+                    "subobjecte_1": {"type": "many2one", "relation": "model2"},
+                    "subobjecte_2": {"type": "many2one", "relation": "model3"}
+                },
+                "model2": {
+                    "subcamp1_1": {"type": "char"},
+                    "subcamp1_2": {"type": "char"},
+                    "subobjecte_2": {"type": "many2one", "relation": "model3"}
+                },
+                "model3": {
+                    "subcamp2_1": {"type": "char"},
+                    "subcamp2_2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "model1": {
+                    "camp_1": "a",
+                    "subobjecte_1": (1, "model2"),
+                    "subobjecte_2": (1, "model3")
+                },
+                "model2": {
+                    "subcamp1_1": "b",
+                    "subcamp1_2": "c",
+                    "subobjecte_2": (1, "model3")
+                },
+                "model3": {
+                    "subcamp2_1": "d",
+                    "subcamp2_2": "e"
+                }
+
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'model1'
+        e_id = 1
+        recursion_depth = 200
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+        expected_result = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte_1': ('fake-semantic-id', 'model2'), 'subobjecte_2': ('fake-semantic-id', 'model3')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp1_1': 'b', 'subcamp1_2': 'c', 'subobjecte_2': ('fake-semantic-id', 'model3')
+            },
+            ('fake-semantic-id', 'model3'): {
+                'subcamp2_1': 'd', 'subcamp2_2': 'e'
+            }
+        }
+
+        self.assertDictEqual(result, expected_result)
+
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "model_exists")
+    @mock.patch.object(som_data_extractor.SomDataExtractor, "get_semantic_id")
+    def test__export_two_different_children_one_depth_limit(self, mock_get_semantic_id, mock_model_exists):
+        def model_exist_mock(model):
+            fields_def = {
+                "model1": {
+                    "camp_1": {'type': "char"},
+                    "subobjecte_1": {"type": "many2one", "relation": "model2"},
+                    "subobjecte_2": {"type": "many2one", "relation": "model3"}
+                },
+                "model2": {
+                    "subcamp1_1": {"type": "char"},
+                    "subcamp1_2": {"type": "char"}
+                },
+                "model3": {
+                    "subcamp2_1": {"type": "char"},
+                    "subcamp2_2": {"type": "char"}
+                }
+            }
+            field_values = {
+                "model1": {
+                    "camp_1": "a",
+                    "subobjecte_1": (1, "model2"),
+                    "subobjecte_2": (1, "model3")
+                },
+                "model2": {
+                    "subcamp1_1": "b",
+                    "subcamp1_2": "c"
+                },
+                "model3": {
+                    "subcamp2_1": "d",
+                    "subcamp2_2": "e"
+                }
+            }
+            return FakeErpModel(fields_def, field_values, model)
+
+        mock_model_exists.side_effect = model_exist_mock
+        mock_get_semantic_id.return_value = "fake-semantic-id"
+
+        e_model = 'model1'
+        e_id = 1
+        recursion_depth = 1
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.extract_model(self.cursor, self.uid,
+                                                    e_model, e_id,
+                                                    recursion_depth)
+        expected_result = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a'
+            }
+        }
+
+        self.assertDictEqual(result, expected_result)
+
+    def test__encode_simple_estructure(self):
+        items = {('fake-semantic-id', 'fakeerpmodel'): {'camp_1':"a", "camp_2":"b"}}
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.encode_as_xml(items)
+
+        expected_result = "<?xml version='1.0' encoding='UTF-8'?>\n"\
+        '<openerp>\n'\
+        '  <data>\n'\
+        '    <record id="fake-semantic-id" model="fakeerpmodel">\n'\
+        '      <field name="camp_1">a</field>\n'\
+        '      <field name="camp_2">b</field>\n'\
+        '    </record>\n'\
+        '  </data>\n'\
+        '</openerp>\n'
+        
+        self.assertEqual(result, expected_result)
+
+    def test__encode_one_child_one_depth(self):
+        items = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte': ('fake-semantic-id', 'model2')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp2': 'c', 'subcamp1': 'b'
+            }
+        }
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.encode_as_xml(items)
+
+        expected_result = "<?xml version='1.0' encoding='UTF-8'?>\n"\
+        '<openerp>\n'\
+        '  <data>\n'\
+        '    <record id="fake-semantic-id" model="model2">\n'\
+        '      <field name="subcamp2">c</field>\n'\
+        '      <field name="subcamp1">b</field>\n'\
+        '    </record>\n'\
+        '    <record id="fake-semantic-id" model="model1">\n'\
+        '      <field name="camp_1">a</field>\n'\
+        '      <field name="subobjecte" ref="model2.fake-semantic-id"/>\n'\
+        '    </record>\n'\
+        '  </data>\n'\
+        '</openerp>\n'
+
+        self.assertEqual(result, expected_result)
+
+    def test__encode_two_children_two_depth(self):
+        items = {
+            ('fake-semantic-id', 'model1'): {
+                'camp_1': 'a', 'subobjecte_1': ('fake-semantic-id', 'model2'), 'subobjecte_2': ('fake-semantic-id', 'model3')
+            },
+            ('fake-semantic-id', 'model2'): {
+                'subcamp1_1': 'b', 'subcamp1_2': 'c', 'subobjecte_2': ('fake-semantic-id', 'model3')
+            },
+            ('fake-semantic-id', 'model3'): {
+                'subcamp2_1': 'd', 'subcamp2_2': 'e'
+            }
+        }
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.encode_as_xml(items)
+
+        expected_result = "<?xml version='1.0' encoding='UTF-8'?>\n"\
+        '<openerp>\n'\
+        '  <data>\n'\
+        '    <record id="fake-semantic-id" model="model2">\n'\
+        '      <field name="subcamp1_1">b</field>\n'\
+        '      <field name="subcamp1_2">c</field>\n'\
+        '      <field name="subobjecte_2" ref="model3.fake-semantic-id"/>\n'\
+        '    </record>\n'\
+        '    <record id="fake-semantic-id" model="model1">\n'\
+        '      <field name="camp_1">a</field>\n'\
+        '      <field name="subobjecte_1" ref="model2.fake-semantic-id"/>\n'\
+        '      <field name="subobjecte_2" ref="model3.fake-semantic-id"/>\n'\
+        '    </record>\n'\
+        '    <record id="fake-semantic-id" model="model3">\n'\
+        '      <field name="subcamp2_2">e</field>\n'\
+        '      <field name="subcamp2_1">d</field>\n'\
+        '    </record>\n'\
+        '  </data>\n'\
+        '</openerp>\n'
+
+        self.assertEqual(result, expected_result)
+
+    def test__encode_simple_estructure_with_boolean(self):
+        items = {('fake-semantic-id', 'fakeerpmodel'): {'camp_1':"a", "camp_2":"b", "camp_3":True, "camp_4":False}}
+
+        data_extractor = self.model('som.data.extractor')
+        result = data_extractor.encode_as_xml(items)
+
+        expected_result = "<?xml version='1.0' encoding='UTF-8'?>\n"\
+        '<openerp>\n'\
+        '  <data>\n'\
+        '    <record id="fake-semantic-id" model="fakeerpmodel">\n'\
+        '      <field name="camp_1">a</field>\n'\
+        '      <field name="camp_2">b</field>\n'\
+        '      <field name="camp_3">True</field>\n'\
+        '      <field name="camp_4">False</field>\n'\
+        '    </record>\n'\
+        '  </data>\n'\
+        '</openerp>\n'
+
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
## Objectiu

Originalment desenvolupat a https://github.com/gisce/erp/pull/10927

Crear eina per poder extreure casos d'una bbdd activa i realitzar testing posterior amb eines com destral.
Cal que la sortida sigui compatible amb destral per tant en format xml.
Eina enfocada a desenvolupadors

## Comportament antic

no aplica

## Comportament nou

Executable des d'ipython/cmd.
Requereix com a entrada:

Un model de l'ORM,
Un identificador d'una instància del model
Un paràmetre de profunditat, és a dir, quants nivells de subjerarquia volem explorar
La sortida és un fitxer xml amb tots els objectes que pertanyen a la jerarquia.
L'exploració d'objectes relacionats es fa seguint les relacions many2one.
Exemples dexecució:

dext_obj = O.SomDataExtractor
dext_obj.extract_model_as_xml('res.comarca',77,1)
dext_obj.extract_model_as_xml('res.municipi',1,2)
dext_obj.extract_model_as_xml('res.partner',1,2)
dext_obj.extract_model_as_xml('giscedata.polissa',100,2)

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
