### PR TITLE
Estandarizar error importación XML

### DIFF
--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -286,16 +286,12 @@ class SomCrawlersTaskStep(osv.osv):
             import_wizard  = WizardImportAtrF1.browse(cursor, uid, import_wizard_id)
             context = {'active_ids': [import_wizard.id], 'active_id': import_wizard.id}
 
-            try:
-                import_wizard.action_import_xmls(context)
-                if import_wizard.state == 'load':
-                    import_wizard.action_send_xmls(context=context)
-                return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
-            except Exception as e:
-                msg = "An error ocurred importing {}:{}".format("asd", "asd")
-                return msg
+            import_wizard.action_import_xmls(context)
+            if import_wizard.state == 'load':
+                import_wizard.action_send_xmls(context=context)
+            return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
         else:
-            return False
+            raise Exception("Error intentem importar un fitxer no ZIP")
 
     def readOutputFile(self, cursor, uid, path, file_name):
         try:


### PR DESCRIPTION
## Objectiu
Fer que l'error d'importació XML sigui igual que els altres

## Targeta on es demana o Incidència 
https://trello.com/c/16qWOaCz/258-ep259-traca-final-somcrawlers

## Comportament antic
L'error d'importació no es marcava com error perquè es capturava l'excepció.

## Comportament nou
Ara es propaga cap a dalt i es marcada pel som_crawlers com a error.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
