### PR TITLE
Afegir Iberdrola T1 crawler i gestionar excepcions durant la importació

### DIFF
--- a/som_crawlers/__terp__.py
+++ b/som_crawlers/__terp__.py
@@ -2,7 +2,7 @@
     "name": "Mòdul per descarregar fitxers distribuidores electricitat",
     "description": """ """,
     "version": "0.1",
-    "author": "SomeEnergia",
+    "author": "SomEnergia",
     "category": "Master",
     "depends":[
         "base",

--- a/som_crawlers/data/som_crawlers_step_data.xml
+++ b/som_crawlers/data/som_crawlers_step_data.xml
@@ -187,6 +187,20 @@
             <field name="params">{}</field>
             <field name="task_id" ref="descargar_iberdrola_d1"/>
         </record>
+        <record model="som.crawlers.task.step" id="pas_descargar_iberdrola_t1">
+            <field name="name">Descarregar fitxers</field>
+            <field name="sequence">1</field>
+            <field name="function">download_files</field>
+            <field name="params">{"nom_fitxer":"script_run_crawler.py", "process":"t1"}</field>
+            <field name="task_id" ref="descargar_iberdrola_t1"/>
+        </record>
+        <record model="som.crawlers.task.step" id="pas_importar_iberdrola_t1">
+            <field name="name">Importar fitxers XML</field>
+            <field name="sequence">2</field>
+            <field name="function">import_xml_files</field>
+            <field name="params">{}</field>
+            <field name="task_id" ref="descargar_iberdrola_t1"/>
+        </record>
         <!--fenosa-->
         <record model="som.crawlers.task.step" id="pas_descarregar_fenosa">
             <field name="name">Descarregar fitxers</field>

--- a/som_crawlers/data/som_crawlers_task_data.xml
+++ b/som_crawlers/data/som_crawlers_task_data.xml
@@ -74,6 +74,11 @@
             <field name="active">True</field>
             <field name="configuracio_id" ref="iberdrola_conf"/>
         </record>
+        <record model="som.crawlers.task" id="descargar_iberdrola_t1">
+            <field name="name">Descargar Iberdrola T1</field>
+            <field name="active">True</field>
+            <field name="configuracio_id" ref="iberdrola_conf"/>
+        </record>
         <record model="som.crawlers.task" id="descargar_A3_endesa">
             <field name="name">Endesa descargar A3</field>
             <field name="active">True</field>

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -316,13 +316,12 @@ class SomCrawlersTaskStep(osv.osv):
             context = {'active_ids': [import_wizard.id],
                        'active_id': import_wizard.id}
 
-            try:
-                import_wizard.action_import_xmls(context)
-                if import_wizard.state == 'load':
-                    import_wizard.action_send_xmls(context=context)
-                return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
-            except Exception as e:
-                raise e
+            import_wizard.action_import_xmls(context)
+
+            if import_wizard.state == 'load':
+                import_wizard.action_send_xmls(context=context)
+
+            return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
         else:
             return False
 

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -323,7 +323,7 @@ class SomCrawlersTaskStep(osv.osv):
 
             return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
         else:
-            return False
+            raise Exception("El fitxer no té format ZIP")
 
     def readOutputFile(self, cursor, uid, path, file_name):
         try:

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -4,7 +4,6 @@ from osv import osv, fields
 from tools.translate import _
 import json
 import os
-import pooler
 import base64
 from time import sleep
 from . import som_sftp, som_ftp
@@ -14,6 +13,8 @@ import StringIO
 from gridfs.errors import CorruptGridFile, NoFile
 
 # Class Task Step that describes the module and the task step fields
+
+
 class SomCrawlersTaskStep(osv.osv):
 
     # Module name
@@ -58,12 +59,13 @@ class SomCrawlersTaskStep(osv.osv):
 
     def get_output_path(self, cursor, uid, context=None):
         cfg_obj = self.pool.get('res.config')
-        output_path = cfg_obj.get(cursor, uid, 'som_crawlers_output_tmp_path', '/tmp/outputFiles')
+        output_path = cfg_obj.get(
+            cursor, uid, 'som_crawlers_output_tmp_path', '/tmp/outputFiles')
         if not os.path.isdir(output_path):
             os.mkdir(output_path)
         return output_path
 
-    #execute steps of a general task
+    # execute steps of a general task
     def executar_steps(self, cursor, uid, id, result_id, context=None):
         taskStep = self.browse(cursor, uid, id)
         function = getattr(self, taskStep.function)
@@ -72,40 +74,43 @@ class SomCrawlersTaskStep(osv.osv):
 
     def attach_file(self, cursor, uid, path_to_file, file_name, result_id, context=None):
         with open(os.path.join(path_to_file, file_name), 'rb') as f:
-            content  = f.read()
+            content = f.read()
 
         attachment = {
-            'name':  file_name,
-            'datas':  base64.b64encode(content),
+            'name': file_name,
+            'datas': base64.b64encode(content),
             'datas_fname': file_name,
             'res_model': 'som.crawlers.result',
             'res_id': result_id,
         }
-        attachment_id =  self.pool.get('ir.attachment').create(cursor, uid, attachment, context=context)
+        attachment_id = self.pool.get('ir.attachment').create(
+            cursor, uid, attachment, context=context)
         full_path = os.path.join(path_to_file, file_name)
         cursor.commit()
         os.remove(full_path)
         return attachment_id
 
-    #attached files [zip]
+    # attached files [zip]
     def attach_files_zip(self, cursor, uid, id, result_id, config_obj, path, task_step_params, context=None):
         classresult = self.pool.get('som.crawlers.result')
-        task_step_obj = self.browse(cursor,uid,id,context = context)
+
         output = ''
         if 'process' in task_step_params:
             name = config_obj.name + '_' + task_step_params['process']
             path_to_zip = os.path.join(path, name)
         else:
-           path_to_zip = os.path.join(path, config_obj.name)
+            path_to_zip = os.path.join(path, config_obj.name)
         if not os.path.exists(path_to_zip):
             output = "zip directory doesn\'t exist"
         else:
             if len(os.listdir(path_to_zip)) == 0:
-                 output = "Directori doesn\'t contain any ZIP"
+                output = "Directori doesn\'t contain any ZIP"
             else:
                 for file_name in os.listdir(path_to_zip):
-                    attachment_id = self.attach_file(cursor, uid, path_to_zip, file_name, result_id, context)
-                    classresult.write(cursor,uid, result_id, {'zip_name': attachment_id})
+                    attachment_id = self.attach_file(
+                        cursor, uid, path_to_zip, file_name, result_id, context)
+                    classresult.write(cursor, uid, result_id, {
+                                      'zip_name': attachment_id})
                     output = "files succesfully attached"
         return output
 
@@ -114,81 +119,100 @@ class SomCrawlersTaskStep(osv.osv):
             name = config_obj.name + '_' + task_step_params['process']
             path_to_screenshot = os.path.join(path, name)
         else:
-           path_to_screenshot = os.path.join(path, config_obj.name)
+            path_to_screenshot = os.path.join(path, config_obj.name)
         if os.path.exists(path_to_screenshot):
             for file_name in os.listdir(path_to_screenshot):
-                self.attach_file(cursor, uid, path_to_screenshot, file_name, result_id, context)
+                self.attach_file(cursor, uid, path_to_screenshot,
+                                 file_name, result_id, context)
 
-    def download_files(self, cursor, uid,id, result_id, context=None):
+    def download_files(self, cursor, uid, id, result_id, context=None):
         classresult = self.pool.get('som.crawlers.result')
-        task_step_obj = self.browse(cursor,uid,id)
+        task_step_obj = self.browse(cursor, uid, id)
         task_step_params = json.loads(task_step_obj.params)
         path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../')
-        classresult.write(cursor,uid, result_id, {'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
+        classresult.write(cursor, uid, result_id, {
+                          'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
         output = ''
 
-        if task_step_params.has_key('nom_fitxer'):
-            config_obj=self.pool.get('som.crawlers.task').id_del_portal_config(cursor,uid,task_step_obj.task_id.id,context)
-            script_path = os.path.join(path, "scripts/" + task_step_params['nom_fitxer'])
+        if 'nom_fitxer' in task_step_params:
+            config_obj = self.pool.get('som.crawlers.task').id_del_portal_config(
+                cursor, uid, task_step_obj.task_id.id, context)
+            script_path = os.path.join(
+                path, "scripts/" + task_step_params['nom_fitxer'])
             if os.path.exists(script_path):
                 cfg_obj = self.pool.get('res.config')
-                path_python = cfg_obj.get(cursor, uid, 'som_crawlers_massive_importer_python_path', '/home/erp/.virtualenvs/massive/bin/python')
+                path_python = cfg_obj.get(
+                    cursor, uid, 'som_crawlers_massive_importer_python_path', '/home/erp/.virtualenvs/massive/bin/python')
                 if not os.path.exists(path_python):
                     raise Exception("Not virtualenv of massive importer found")
-                file_name = "output_" + config_obj.name + "_" + datetime.now().strftime("%Y-%m-%d_%H_%M_%S_%f") + ".txt"
-                args_str = self.create_script_args(config_obj, task_step_params, file_name)
-                ret_value = os.system("{} {} {}".format(path_python, script_path, args_str))
+                file_name = "output_" + config_obj.name + "_" + \
+                    datetime.now().strftime("%Y-%m-%d_%H_%M_%S_%f") + ".txt"
+                args_str = self.create_script_args(
+                    config_obj, task_step_params, file_name)
+                os.system("{} {} {}".format(
+                    path_python, script_path, args_str))
                 output_path = self.get_output_path(cursor, uid)
-                output = self.readOutputFile(cursor, uid, output_path, file_name)
+                output = self.readOutputFile(
+                    cursor, uid, output_path, file_name)
                 if output == 'Files have been successfully downloaded':
-                    output = self.attach_files_zip(cursor, uid, id, result_id, config_obj, output_path, task_step_params, context = context)
+                    output = self.attach_files_zip(
+                        cursor, uid, id, result_id, config_obj, output_path, task_step_params, context=context)
                 else:
-                    self.attach_files_screenshot(cursor, uid, config_obj, output_path, result_id, task_step_params, context)
+                    self.attach_files_screenshot(
+                        cursor, uid, config_obj, output_path, result_id, task_step_params, context)
                     raise Exception("%s" % output)
             else:
                 output = 'File or directory doesn\'t exist'
         else:
             output = 'Falta especificar nom fitxer'
-        task_step_obj.task_id.write({'ultima_tasca_executada': str(task_step_obj.name)+ ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
+        task_step_obj.task_id.write({'ultima_tasca_executada': str(
+            task_step_obj.name) + ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
         classresult.write(cursor, uid, result_id, {'resultat_bool': True})
 
         return output
 
     def import_xml_files(self, cursor, uid, id, result_id, nivell=10, context=None):
         if nivell < 0:
-            raise Exception("SomCrawlersTaskStep: No s'ha pogut adjuntar el zip")
-        task_step_obj = self.browse(cursor,uid,id)
+            raise Exception(
+                "SomCrawlersTaskStep: No s'ha pogut adjuntar el zip")
+        task_step_obj = self.browse(cursor, uid, id)
         classresult = self.pool.get('som.crawlers.result')
         attachment_obj = self.pool.get('ir.attachment')
         classresult.write(cursor, uid, result_id, {'resultat_bool': False})
-        classresult.write(cursor,uid, result_id, {'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
-        result_obj= classresult.browse(cursor, uid, result_id)
+        classresult.write(cursor, uid, result_id, {
+                          'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
+        result_obj = classresult.browse(cursor, uid, result_id)
         attachment_id = result_obj.zip_name.id
-        task_step_obj = self.browse(cursor,uid,id)
+        task_step_obj = self.browse(cursor, uid, id)
         task_step_params = json.loads(task_step_obj.params)
 
         if not attachment_id:
-            output = "don't exist id attachment"
-            raise Exception(output)
+            output = "Don't exist attachment ID"
+            raise Exception("IMPORTANT: {}".format(output))
         else:
             try:
-                if task_step_params.has_key('clean_zip'):
-                    content, file_name = self.get_clean_attachment(cursor, uid, id, attachment_id)
+                if 'clean_zip' in task_step_params:
+                    content, file_name = self.get_clean_attachment(
+                        cursor, uid, id, attachment_id)
                 else:
-                    att = attachment_obj.browse(cursor,uid,attachment_id)
+                    att = attachment_obj.browse(cursor, uid, attachment_id)
                     content = att.datas
                     file_name = att.name
                 output = self.import_wizard(cursor, uid, file_name, content)
             except (TypeError, CorruptGridFile, NoFile) as e:
                 sleep(100)
-                output = self.import_xml_files(cursor, uid, id, result_id, nivell-1, context)
+                output = self.import_xml_files(
+                    cursor, uid, id, result_id, nivell - 1, context)
                 return output
+            except Exception as e:
+                raise Exception("IMPORTANT: {}: {}".format(
+                    type(e).__name__, str(e)))
 
-        task_step_obj.task_id.write({'ultima_tasca_executada': str(task_step_obj.name)+ ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
+        task_step_obj.task_id.write({'ultima_tasca_executada': str(
+            task_step_obj.name) + ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
         classresult.write(cursor, uid, result_id, {'resultat_bool': True})
 
         return output
-
 
     def recursive_extract_zip(self, zip_path, destination_path):
         with zipfile.ZipFile(zip_path, 'r') as zip_file:
@@ -210,14 +234,14 @@ class SomCrawlersTaskStep(osv.osv):
                     file_path = os.path.join(root, filename)
                     os.remove(file_path)
 
-
     def get_clean_attachment(self, cursor, uid, id, attachment_id):
         attachment_obj = self.pool.get('ir.attachment')
-        att = attachment_obj.browse(cursor,uid,attachment_id)
+        att = attachment_obj.browse(cursor, uid, attachment_id)
         data = base64.b64decode(att.datas)
 
         # Guardem att a disc
-        working_path = self.get_output_path(cursor, uid) + '/som_crawlers_import_{}'.format(datetime.strftime(datetime.today(), '%Y%m%d%H%M%S'))
+        working_path = self.get_output_path(cursor, uid) + '/som_crawlers_import_{}'.format(
+            datetime.strftime(datetime.today(), '%Y%m%d%H%M%S'))
         os.makedirs(working_path)
         zip_path = working_path + '/' + att.name
         with open(zip_path, 'w') as zip_file:
@@ -235,33 +259,35 @@ class SomCrawlersTaskStep(osv.osv):
 
         # Llegim fitxer
         with open(zip_path, 'rb') as f:
-            content  = f.read()
+            content = f.read()
 
-        #Netejem
+        # Netejem
         os.remove(zip_path)
         shutil.rmtree(working_path)
         return base64.b64encode(content), att.name
 
-
     def import_ftp_xml_files(self, cursor, uid, id, result_id, context=None):
         try:
-            output =  self.import_xml_files(cursor, uid, id, result_id)
+            output = self.import_xml_files(cursor, uid, id, result_id)
         except Exception as e:
-            raise Exception("IMPORTANT: {}: {}".format(type(e).__name__, str(e)))
+            raise Exception("IMPORTANT: {}: {}".format(
+                type(e).__name__, str(e)))
         else:
-            task_step_obj = self.browse(cursor,uid,id)
-            server_data = self.pool.get('som.crawlers.task').id_del_portal_config(cursor, uid, task_step_obj.task_id.id, context)
+            task_step_obj = self.browse(cursor, uid, id)
+            server_data = self.pool.get('som.crawlers.task').id_del_portal_config(
+                cursor, uid, task_step_obj.task_id.id, context)
             classresult = self.pool.get('som.crawlers.result')
             attachment_obj = self.pool.get('ir.attachment')
             ftp_reg = self.pool.get('som.ftp.file.register')
 
-            result_obj= classresult.browse(cursor, uid, result_id)
+            result_obj = classresult.browse(cursor, uid, result_id)
             attachment_id = result_obj.zip_name.id
-            att = attachment_obj.browse(cursor,uid,attachment_id)
+            att = attachment_obj.browse(cursor, uid, attachment_id)
 
             input_file = att.datas
 
-            working_path = self.get_output_path(cursor, uid) + '/som_crawlers_import_{}'.format(datetime.strftime(datetime.today(), '%Y%m%d%H%M%S'))
+            working_path = self.get_output_path(cursor, uid) + '/som_crawlers_import_{}'.format(
+                datetime.strftime(datetime.today(), '%Y%m%d%H%M%S'))
             os.makedirs(working_path)
 
             data = base64.b64decode(input_file)
@@ -270,9 +296,11 @@ class SomCrawlersTaskStep(osv.osv):
             input_file = zipfile.ZipFile(file_handler)
 
             for filename in input_file.namelist():
-                file_id = ftp_reg.search(cursor, uid, [('name','=', filename), ('server_from', '=', server_data['url_portal'])])
+                file_id = ftp_reg.search(cursor, uid, [(
+                    'name', '=', filename), ('server_from', '=', server_data['url_portal'])])
                 if file_id:
-                    ftp_reg.write(cursor, uid, file_id, {'state': 'imported', 'date_imported': datetime.now()})
+                    ftp_reg.write(cursor, uid, file_id, {
+                                  'state': 'imported', 'date_imported': datetime.now()})
 
             shutil.rmtree(working_path)
 
@@ -282,9 +310,11 @@ class SomCrawlersTaskStep(osv.osv):
         if file_name.endswith('.zip'):
             values = {'filename': file_name, 'file': file_content}
             WizardImportAtrF1 = self.pool.get('wizard.import.atr.and.f1')
-            import_wizard_id = WizardImportAtrF1.create(cursor,uid,values)
-            import_wizard  = WizardImportAtrF1.browse(cursor, uid, import_wizard_id)
-            context = {'active_ids': [import_wizard.id], 'active_id': import_wizard.id}
+            import_wizard_id = WizardImportAtrF1.create(cursor, uid, values)
+            import_wizard = WizardImportAtrF1.browse(
+                cursor, uid, import_wizard_id)
+            context = {'active_ids': [import_wizard.id],
+                       'active_id': import_wizard.id}
 
             try:
                 import_wizard.action_import_xmls(context)
@@ -292,8 +322,7 @@ class SomCrawlersTaskStep(osv.osv):
                     import_wizard.action_send_xmls(context=context)
                 return WizardImportAtrF1.browse(cursor, uid, import_wizard_id).info
             except Exception as e:
-                msg = "An error ocurred importing {}:{}".format("asd", "asd")
-                return msg
+                raise e
         else:
             return False
 
@@ -309,98 +338,112 @@ class SomCrawlersTaskStep(osv.osv):
 
         return output
 
-    #test ok
+    # test ok
     def create_script_args(self, config_obj, task_step_params, execution_restult_file, file_path=None):
         args = {
-            '-n':str(config_obj.name),
-            '-u':str(config_obj.usuari),
-            '-p':str(config_obj.contrasenya),
-            '-c':str(config_obj.crawler),
-            '-f':str(execution_restult_file),
-            '-url':"'{}'".format(str(config_obj.url_portal)),
-            '-url-upload':"'{}'".format(str(config_obj.url_upload)),
-            '-fltr':"'{}'".format(str(config_obj.filtres)),
-            '-d':str(config_obj.days_of_margin),
-            '-nfp':str(config_obj.pending_files_only),
-            '-b':str(config_obj.browser),
+            '-n': str(config_obj.name),
+            '-u': str(config_obj.usuari),
+            '-p': str(config_obj.contrasenya),
+            '-c': str(config_obj.crawler),
+            '-f': str(execution_restult_file),
+            '-url': "'{}'".format(str(config_obj.url_portal)),
+            '-url-upload': "'{}'".format(str(config_obj.url_upload)),
+            '-fltr': "'{}'".format(str(config_obj.filtres)),
+            '-d': str(config_obj.days_of_margin),
+            '-nfp': str(config_obj.pending_files_only),
+            '-b': str(config_obj.browser),
             '-pr': 'None',
         }
         if file_path:
             args['-fp'] = file_path
 
-        if(task_step_params.has_key('process')):
-            args.update({'-pr':str(task_step_params['process'])})
+        if 'process' in task_step_params:
+            args.update({'-pr': str(task_step_params['process'])})
 
-        return " ".join(["{} {}".format(k,v) for k,v in args.iteritems()])
-
+        return " ".join(["{} {}".format(k, v) for k, v in args.iteritems()])
 
     def upload_files(self, cursor, uid, id, result_id, context=None):
         classresult = self.pool.get('som.crawlers.result')
-        task_step_obj = self.browse(cursor,uid,id)
+        task_step_obj = self.browse(cursor, uid, id)
         task_step_params = json.loads(task_step_obj.params)
-        config_obj=self.pool.get('som.crawlers.task').id_del_portal_config(cursor,uid,task_step_obj.task_id.id,context)
+        config_obj = self.pool.get('som.crawlers.task').id_del_portal_config(
+            cursor, uid, task_step_obj.task_id.id, context)
         path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../')
-        classresult.write(cursor,uid, result_id, {'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
-        #TODO: Que fem quan carreguem el segon fitxer
+        classresult.write(cursor, uid, result_id, {
+                          'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
+        # TODO: Que fem quan carreguem el segon fitxer
         path_to_zip = self.get_output_path(cursor, uid)
-        file_name = "output_" + config_obj.name + "_" + datetime.now().strftime("%Y-%m-%d_%H_%M") + ".zip"
+        file_name = "output_" + config_obj.name + "_" + \
+            datetime.now().strftime("%Y-%m-%d_%H_%M") + ".zip"
         file_path = os.path.join(path_to_zip, file_name)
-        attachment_id = int(classresult.read(cursor,uid, result_id, ['resultat_text'])['resultat_text'])
-        zip_file = self.pool.get('ir.attachment').browse(cursor, uid, attachment_id)
+        attachment_id = int(classresult.read(
+            cursor, uid, result_id, ['resultat_text'])['resultat_text'])
+        zip_file = self.pool.get('ir.attachment').browse(
+            cursor, uid, attachment_id)
         with open(file_path, 'w') as f:
             f.write(base64.b64decode(zip_file.datas))
 
         output = ''
 
-        if task_step_params.has_key('nom_fitxer'):
-            script_path = os.path.join(path, "scripts/" + task_step_params['nom_fitxer'])
+        if 'nom_fitxer' in task_step_params:
+            script_path = os.path.join(
+                path, "scripts/" + task_step_params['nom_fitxer'])
             if os.path.exists(script_path):
                 cfg_obj = self.pool.get('res.config')
-                path_python = cfg_obj.get(cursor, uid, 'som_crawlers_massive_importer_python_path', '/home/erp/.virtualenvs/massive/bin/python')
+                path_python = cfg_obj.get(
+                    cursor, uid, 'som_crawlers_massive_importer_python_path', '/home/erp/.virtualenvs/massive/bin/python')
                 if not os.path.exists(path_python):
                     raise Exception("Not virtualenv of massive importer found")
-                execution_restult_file = "output_" + config_obj.name + "_" + datetime.now().strftime("%Y-%m-%d_%H_%M") + ".txt"
-                args_str = self.create_script_args(config_obj, task_step_params, execution_restult_file, file_path)
-                ret_value = os.system("{} {} {}".format(path_python, script_path, args_str))
+                execution_restult_file = "output_" + config_obj.name + \
+                    "_" + datetime.now().strftime("%Y-%m-%d_%H_%M") + ".txt"
+                args_str = self.create_script_args(
+                    config_obj, task_step_params, execution_restult_file, file_path)
+                ret_value = os.system("{} {} {}".format(
+                    path_python, script_path, args_str))
                 if ret_value != 0:
                     output = "System call from download files failed"
                 else:
-                    output = self.readOutputFile(cursor, uid, path_to_zip, execution_restult_file)
+                    output = self.readOutputFile(
+                        cursor, uid, path_to_zip, execution_restult_file)
                 if output != 'Files have been successfully uploaded':
-                    self.attach_files_screenshot(cursor, uid, config_obj, path, result_id, task_step_params, context)
+                    self.attach_files_screenshot(
+                        cursor, uid, config_obj, path, result_id, task_step_params, context)
                     raise Exception("%s" % output)
             else:
                 output = 'File or directory doesn\'t exist'
         else:
             output = 'Falta especificar nom fitxer'
-        task_step_obj.task_id.write({'ultima_tasca_executada': str(task_step_obj.name)+ ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
+        task_step_obj.task_id.write({'ultima_tasca_executada': str(
+            task_step_obj.name) + ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
         classresult.write(cursor, uid, result_id, {'resultat_bool': True})
         os.remove(file_path)
         return output
 
     def export_xml_files(self, cursor, uid, id, result_id, context={}):
-        task_step_obj = self.browse(cursor,uid,id)
+        task_step_obj = self.browse(cursor, uid, id)
         sw_obj = self.pool.get('giscedata.switching')
         atr_wiz_obj = self.pool.get('giscedata.switching.wizard')
 
         task_obj = self.pool.get('som.crawlers.task')
-        distri_id = task_obj.read(cursor, uid, task_step_obj.task_id.id, ['distribuidora'])
+        distri_id = task_obj.read(
+            cursor, uid, task_step_obj.task_id.id, ['distribuidora'])
 
         task_step_params = json.loads(task_step_obj.params)
-        if task_step_params.has_key('process'):
+        if 'process' in task_step_params:
             process = task_step_params['process']
             if not isinstance(process, list):
                 process = [process]
 
-
-        search_params = [('proces_id.name', 'in', process), ('state', '=', 'open'), ('enviament_pendent', '=', True)]
+        search_params = [('proces_id.name', 'in', process),
+                         ('state', '=', 'open'), ('enviament_pendent', '=', True)]
         if distri_id['distribuidora']:
-            search_params.append(('partner_id', '=', distri_id['distribuidora'][0]))
+            search_params.append(
+                ('partner_id', '=', distri_id['distribuidora'][0]))
         active_ids = sw_obj.search(cursor, uid, search_params)
 
-
         if not len(active_ids):
-            raise Exception("SENSE RESULTATS: No hi ha fitxers pendents d'exportar")
+            raise Exception(
+                "SENSE RESULTATS: No hi ha fitxers pendents d'exportar")
 
         ctx = {
             'active_ids': active_ids,
@@ -412,17 +455,19 @@ class SomCrawlersTaskStep(osv.osv):
         wiz = atr_wiz_obj.browse(cursor, uid, wiz)
 
         attachment = {
-            'name':  wiz.name,
-            'datas':  wiz.file,
+            'name': wiz.name,
+            'datas': wiz.file,
             'datas_fname': wiz.name,
             'res_model': 'som.crawlers.result',
             'res_id': result_id,
         }
 
-        attachment_id =  self.pool.get('ir.attachment').create(cursor, uid, attachment, context=context)
+        attachment_id = self.pool.get('ir.attachment').create(
+            cursor, uid, attachment, context=context)
         classresult = self.pool.get('som.crawlers.result')
         classresult.write(cursor, uid, result_id, {'zip_name': attachment_id})
-        task_step_obj.task_id.write({'ultima_tasca_executada': str(task_step_obj.name)+ ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
+        task_step_obj.task_id.write({'ultima_tasca_executada': str(
+            task_step_obj.name) + ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
         classresult.write(cursor, uid, result_id, {'resultat_bool': True})
 
         return attachment_id
@@ -431,16 +476,19 @@ class SomCrawlersTaskStep(osv.osv):
         try:
             classresult = self.pool.get('som.crawlers.result')
             ftp_reg = self.pool.get('som.ftp.file.register')
-            task_step_obj = self.browse(cursor,uid,id)
+            task_step_obj = self.browse(cursor, uid, id)
             task_step_params = json.loads(task_step_obj.params)
-            classresult.write(cursor, uid, result_id, {'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
+            classresult.write(cursor, uid, result_id, {
+                              'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M:%S")})
             output = ''
 
-            if task_step_params.has_key('dir_list'):
-                server_data = self.pool.get('som.crawlers.task').id_del_portal_config(cursor, uid, task_step_obj.task_id.id, context)
+            if 'dir_list' in task_step_params:
+                server_data = self.pool.get('som.crawlers.task').id_del_portal_config(
+                    cursor, uid, task_step_obj.task_id.id, context)
 
                 base_path = self.get_output_path(cursor, uid)
-                temp_folder = server_data['name'] + "_" + datetime.now().strftime("%Y%m%d%H%M%S")
+                temp_folder = server_data['name'] + "_" + \
+                    datetime.now().strftime("%Y%m%d%H%M%S")
                 destination_path = base_path + '/' + temp_folder
 
                 os.mkdir(destination_path)
@@ -451,35 +499,41 @@ class SomCrawlersTaskStep(osv.osv):
                 else:
                     conn = som_sftp.SomSftp(server_data)
 
-                file_list, dir_list = conn.list_files('/', task_step_params['dir_list'])
+                file_list, dir_list = conn.list_files(
+                    '/', task_step_params['dir_list'])
 
                 # Comprovar fitxers nous
                 files_to_download = []
                 for remote_file_path in file_list:
                     if remote_file_path.endswith(".xml") or remote_file_path.endswith(".zip"):
                         remote_file_name = os.path.basename(remote_file_path)
-                        local_file = ftp_reg.search(cursor, uid, [('name','=', remote_file_name), ('server_from', '=', server_data['url_portal'])])
+                        local_file = ftp_reg.search(cursor, uid, [(
+                            'name', '=', remote_file_name), ('server_from', '=', server_data['url_portal'])])
                         if not local_file or ftp_reg.read(cursor, uid, local_file[0])['state'] != 'imported':
                             files_to_download.append(remote_file_path)
 
                 if len(files_to_download) == 0:
-                    raise Exception("SENSE RESULTATS: No hi ha fitxers a descarregar")
+                    raise Exception(
+                        "SENSE RESULTATS: No hi ha fitxers a descarregar")
 
                 # Descarregarels fitxers
                 files_to_import = []
                 for remote_file_path in files_to_download:
                     try:
                         remote_file_name = os.path.basename(remote_file_path)
-                        conn.download_file(remote_file_path, destination_path + '/' + remote_file_name)
+                        conn.download_file(
+                            remote_file_path, destination_path + '/' + remote_file_name)
                         files_to_import.append(remote_file_path)
                     except Exception as e:
                         output += str(e) + "\n"
-                        file_id = ftp_reg.search(cursor, uid, [('name','=', remote_file_name), ('server_from', '=', server_data['url_portal'])])
+                        file_id = ftp_reg.search(cursor, uid, [(
+                            'name', '=', remote_file_name), ('server_from', '=', server_data['url_portal'])])
                         if file_id:
-                            ftp_reg.write(cursor, uid, file_id, {'state': 'error'})
+                            ftp_reg.write(cursor, uid, file_id,
+                                          {'state': 'error'})
                         else:
                             ftp_reg.create(cursor, uid, {'name': remote_file_name, 'server_from': server_data['url_portal'],
-                                'state': 'error', 'date_download': datetime.now()})
+                                                         'state': 'error', 'date_download': datetime.now()})
 
                 conn.close()
 
@@ -488,23 +542,28 @@ class SomCrawlersTaskStep(osv.osv):
                 filenames = os.listdir(destination_path)
                 with zipfile.ZipFile(destination_path + '/' + zip_filename, 'w') as zipObj:
                     for filename in filenames:
-                        zipObj.write(destination_path + '/' + filename, filename)
+                        zipObj.write(destination_path
+                                     + '/' + filename, filename)
                     zipObj.close()
 
                 # Adjuntar la sortida
-                attachment_id = self.attach_file(cursor, uid, destination_path, zip_filename, result_id, context)
-                classresult.write(cursor, uid, result_id, {'zip_name': attachment_id})
+                attachment_id = self.attach_file(
+                    cursor, uid, destination_path, zip_filename, result_id, context)
+                classresult.write(cursor, uid, result_id, {
+                                  'zip_name': attachment_id})
                 output = "Fitxer ZIP adjuntat correctament"
 
                 # Marcar com a descarregats
                 for remote_file_path in files_to_import:
                     remote_file_name = os.path.basename(remote_file_path)
-                    file_id = ftp_reg.search(cursor, uid, [('name','=', remote_file_name), ('server_from', '=', server_data['url_portal'])])
+                    file_id = ftp_reg.search(cursor, uid, [(
+                        'name', '=', remote_file_name), ('server_from', '=', server_data['url_portal'])])
                     if file_id:
-                        ftp_reg.write(cursor, uid, file_id, {'state': 'downloaded', 'date_download': datetime.now()})
+                        ftp_reg.write(cursor, uid, file_id, {
+                                      'state': 'downloaded', 'date_download': datetime.now()})
                     else:
                         ftp_reg.create(cursor, uid, {'name': remote_file_name, 'server_from': server_data['url_portal'],
-                                'state': 'downloaded', 'date_download': datetime.now()})
+                                                     'state': 'downloaded', 'date_download': datetime.now()})
 
                 # Esborrar fitxers temporals
                 shutil.rmtree(destination_path)
@@ -512,7 +571,8 @@ class SomCrawlersTaskStep(osv.osv):
             else:
                 output = 'Falta la llista de directoris'
 
-            task_step_obj.task_id.write({'ultima_tasca_executada': str(task_step_obj.name)+ ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
+            task_step_obj.task_id.write({'ultima_tasca_executada': str(
+                task_step_obj.name) + ' - ' + str(datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))})
             classresult.write(cursor, uid, result_id, {'resultat_bool': True})
         except Exception as e:
             if 'SENSE RESULTATS' in str(e):


### PR DESCRIPTION
## Objectiu
- Afegir `data` pel nou _crawler_ d'Iberdrola T1 
- Gestionar correctament les excepcions que salten quan es crida el _wizard_ d'importació

## Targeta on es demana o Incidència 
https://trello.com/c/16qWOaCz/5544-0-0-p18-ep259-traca-final-somcrawlers

## Comportament antic
- No hi havia el nou _crawler_
- No es marcava com error quan fallava la importació

## Comportament nou
- Afegida la `data` del nou _crawler_
- Es marca com error quan salta una excepció durant la importació
- S'han substituït alguns `has_key()` (_deprecated_) per `in`

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
