### PR TITLE
Canvair active_test per domain

### DIFF
--- a/som_atc/views/giscedata_atc_view.xml
+++ b/som_atc/views/giscedata_atc_view.xml
@@ -42,5 +42,8 @@
                 </field>
             </field>
         </record>
+        <record id="giscedata_atc.all_atc_case-act" model="ir.actions.act_window">
+            <field name="context">{'active_test': False}</field>
+        </record>
     </data>
 </openerp>

--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -141,5 +141,9 @@
                 </field>
             </field>
         </record>
+        <record model="ir.actions.act_window" id="giscedata_polissa.action_polisses_all">
+            <field name="domain">[('active', '!=', None)]</field>
+            <field name="context">{}</field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu
Mostar llistat amb objectes no actius, per domain i no per contexte. D'aquesta manera no es propaga a les accions posteriors.

Necessita afegir al Client ERP el flag **allow_none**. En [parlen aqui](https://www.odoo.com/forum/help-1/typeerror-cannot-marshal-none-unless-allow-none-is-enabled-14108) i seria més o menys [per aqui](https://github.com/Som-Energia/erpclient/blob/master/bin/rpc.py#L102)

## Targeta on es demana o Incidència 


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
