### PR TITLE
Fix path to screenshots

### DIFF
--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -110,11 +110,10 @@ class SomCrawlersTaskStep(osv.osv):
         return output
 
     def attach_files_screenshot(self, cursor, uid, config_obj, path, result_id, task_step_params, context=None):
+        name = config_obj.name
         if 'process' in task_step_params:
-            name = config_obj.name + '_' + task_step_params['process']
-            path_to_screenshot = os.path.join(path, name)
-        else:
-           path_to_screenshot = os.path.join(path, config_obj.name)
+            name += '_' + task_step_params['process']
+        path_to_screenshot = os.path.join(path, 'screenShots', name)
         if os.path.exists(path_to_screenshot):
             for file_name in os.listdir(path_to_screenshot):
                 self.attach_file(cursor, uid, path_to_screenshot, file_name, result_id, context)


### PR DESCRIPTION
## Objectiu
- Arreglar les _screenshots_, no s'estaven guardant.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2090253310/13855099?folderId=3063374

## Comportament antic
- Al repositori `massive_importer_crawlers` s'ha canviat el _path_ de la _screenshot_ i a `som_crawlers` no s'estava construint correctament.

## Comportament nou
- Busquem les _screenshots_ al _path_ correcte.

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
