### PR TITLE
Afegir llistat de tasques fallides sense els "SENSE RESULTATS"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Deploy files
 deploy/
+
+# Vim temporaly files
+*.swp

--- a/som_crawlers/models/exceptions.py
+++ b/som_crawlers/models/exceptions.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+class CrawlingProcessException(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.msg
+
+class NoResultsException(CrawlingProcessException):
+    def __init__(self, msg, download_was_clicked=False, add_msg_tag=True):
+        tag = ''
+        if add_msg_tag:
+            tag = 'SENSE RESULTATS: '
+        super(NoResultsException, self).__init__(tag + msg)
+
+    def __repr__(self):
+        return self.msg
+
+    def __str__(self):
+        return self.msg

--- a/som_crawlers/models/som_crawlers_task.py
+++ b/som_crawlers/models/som_crawlers_task.py
@@ -4,6 +4,7 @@ from osv import osv, fields
 from tools.translate import _
 from oorq.decorators import job
 from enerdata.calendars import REECalendar
+from . import exceptions
 
 
 ## Class Task that describes the module and the task fields
@@ -106,6 +107,9 @@ class SomCrawlersTask(osv.osv):
             try:
                 output = classTaskStep.executar_steps(cursor,uid,taskStep.id,result_id)
                 classresult.write(cursor,uid, result_id, {'resultat_bool': True, 'resultat_text': output})
+            except exceptions.NoResultsException as e:
+                classresult.write(cursor,uid, result_id, {'resultat_bool': True, 'resultat_text': str(e)})
+                break
             except Exception as e:
                 classresult.write(cursor,uid, result_id, {'resultat_bool': False, 'resultat_text': str(e)})
                 break

--- a/som_crawlers/views/som_crawlers_config_view.xml
+++ b/som_crawlers/views/som_crawlers_config_view.xml
@@ -65,6 +65,7 @@
         </record>
 
     <menuitem id="menu_som_crawlers_base" name="Som Crawlers" />
-    <menuitem action="action_configuracio_tree" id="menu_configuracio_tree" parent="som_crawlers.menu_som_crawlers_base"/>
+    <menuitem id="menu_som_crawlers_config" name="Configuracio" parent="som_crawlers.menu_som_crawlers_base"/>
+    <menuitem action="action_configuracio_tree" id="menu_configuracio_tree" parent="som_crawlers.menu_som_crawlers_config"/>
     </data>
 </openerp>

--- a/som_crawlers/views/som_crawlers_holiday_view.xml
+++ b/som_crawlers/views/som_crawlers_holiday_view.xml
@@ -31,7 +31,6 @@
             <field name="view_id" ref="view_som_crawlers_holiday_tree"/>
         </record>
 
-    <menuitem id="menu_som_crawlers_base" name="Som Crawlers" />
-    <menuitem action="action_som_crawlers_holiday_tree" id="menu_som_crawlers_holiday_tree" parent="som_crawlers.menu_som_crawlers_base"/>
+    <menuitem action="action_som_crawlers_holiday_tree" id="menu_som_crawlers_holiday_tree" parent="som_crawlers.menu_som_crawlers_config"/>
     </data>
 </openerp>

--- a/som_crawlers/views/som_crawlers_result_view.xml
+++ b/som_crawlers/views/som_crawlers_result_view.xml
@@ -46,7 +46,7 @@
             <field name="res_model">som.crawlers.result</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
-            <field name="domain">[('resultat_bool', '=', False),('resultat_text', 'not ilike', 'SENSE RESULTATS:%')]</field>
+            <field name="domain">[('resultat_bool', '=', False)]</field>
             <field name="view_id" ref="view_som_crawlers_result_tree"/>
         </record>
         <menuitem action='action_som_crawlers_result_fail_tree' id="menu_crawlers_fail_result"  parent="som_crawlers.menu_crawlers_folder_result"/>

--- a/som_crawlers/views/som_crawlers_result_view.xml
+++ b/som_crawlers/views/som_crawlers_result_view.xml
@@ -39,15 +39,16 @@
             <field name="view_id" ref="view_som_crawlers_result_tree" />
             <field name="context">{'active_test': False}</field>
         </record>
-        <menuitem id="menu_crawlers_result" action="action_som_crawlers_result_tree" parent="som_crawlers.menu_crawlers_task" />
+        <menuitem id="menu_crawlers_folder_result" name="Resultats" parent="som_crawlers.menu_som_crawlers_base"/>
+        <menuitem id="menu_crawlers_result" action="action_som_crawlers_result_tree" parent="som_crawlers.menu_crawlers_folder_result" />
         <record id="action_som_crawlers_result_fail_tree" model="ir.actions.act_window">
-            <field name="name">Tasques amb resultat incorrecte</field>
+            <field name="name">Resultats incorrectes</field>
             <field name="res_model">som.crawlers.result</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
             <field name="domain">[('resultat_bool', '=', False),('resultat_text', 'not ilike', 'SENSE RESULTATS:%')]</field>
             <field name="view_id" ref="view_som_crawlers_result_tree"/>
         </record>
-        <menuitem action='action_som_crawlers_result_fail_tree' id="menu_crawlers_fail_result"  parent="som_crawlers.menu_crawlers_task"/>
+        <menuitem action='action_som_crawlers_result_fail_tree' id="menu_crawlers_fail_result"  parent="som_crawlers.menu_crawlers_folder_result"/>
     </data>
 </openerp>

--- a/som_crawlers/views/som_crawlers_task_view.xml
+++ b/som_crawlers/views/som_crawlers_task_view.xml
@@ -82,7 +82,7 @@
             <field name="res_model">som.crawlers.task</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
-            <field name="domain">[('resultat_bool', '=', False),('resultat_curt', 'not ilike', 'SENSE RESULTATS:%')]</field>
+            <field name="domain">[('resultat_bool', '=', False)]</field>
             <field name="view_id" ref="view_som_crawlers_task_tree"/>
         </record>
         <menuitem action='action_som_crawlers_task_fail_tree' id="menu_crawlers_fail_task"  parent="som_crawlers.menu_crawlers_folder_task"/>

--- a/som_crawlers/views/som_crawlers_task_view.xml
+++ b/som_crawlers/views/som_crawlers_task_view.xml
@@ -52,7 +52,8 @@
             <field name="view_mode">tree,form</field>
             <field name="context">{'active_test': True}</field>
         </record>
-        <menuitem id="menu_crawlers_task" action="action_som_crawlers_task_tree" parent="som_crawlers.menu_som_crawlers_base"/>
+        <menuitem id="menu_crawlers_folder_task" name="Tasques" parent="som_crawlers.menu_som_crawlers_base"/>
+        <menuitem id="menu_crawlers_task" action="action_som_crawlers_task_tree" parent="som_crawlers.menu_crawlers_folder_task"/>
         <record id="action_som_crawlers_all_task_tree" model="ir.actions.act_window">
             <field name="name">Totes les tasques automàtiques</field>
             <field name="res_model">som.crawlers.task</field>
@@ -60,7 +61,7 @@
             <field name="view_mode">tree,form</field>
             <field name="context">{'active_test': False}</field>
         </record>
-        <menuitem id="menu_crawlers_all_task" action="action_som_crawlers_all_task_tree" parent="som_crawlers.menu_crawlers_task" />
+        <menuitem id="menu_crawlers_all_task" action="action_som_crawlers_all_task_tree" parent="som_crawlers.menu_crawlers_folder_task" />
         <act_window name="Resultats"
             domain="[('task_id', '=', active_id)]"
             res_model="som.crawlers.result"
@@ -76,5 +77,14 @@
             <field name="model">"som.crawlers.task</field>
             <field name="value" eval="'ir.actions.act_window,'+str(ref('act_resultats_tasca'))" />
         </record>
+        <record id="action_som_crawlers_task_fail_tree" model="ir.actions.act_window">
+            <field name="name">Tasques amb resultat incorrecte</field>
+            <field name="res_model">som.crawlers.task</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('resultat_bool', '=', False),('resultat_curt', 'not ilike', 'SENSE RESULTATS:%')]</field>
+            <field name="view_id" ref="view_som_crawlers_task_tree"/>
+        </record>
+        <menuitem action='action_som_crawlers_task_fail_tree' id="menu_crawlers_fail_task"  parent="som_crawlers.menu_crawlers_folder_task"/>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu
Afegir llistat de tasques fallides sense els "SENSE RESULTATS"

## Targeta on es demana o Incidència 
https://trello.com/c/16qWOaCz/5544-0-0-p18-ep259-traca-final-somcrawlers

## Comportament antic
Només hi havia un llistat de tasques fallides, tenint en compte també els que no tenien nous resultats.

## Comportament nou
S'afegeix un llistat nou "Tasques amb resultat incorrecte"
També es refà l'estructura del menú per fer-la més similar a la resta del menús de l'ERP
![image](https://user-images.githubusercontent.com/26488435/206252233-7af6da35-1569-4c78-b9bd-0002ed08fed8.png)



## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
- [x] Script de migració

> ```python                                                                      
> for result_id in O.SomCrawlersResult.search([('resultat_curt','like','SENSE RESULTATS: ')]):
>     result = O.SomCrawlersResult.browse(result_id)                                          
>     result.resultat_bool = True                                                             
> ```

- [ ] Modifica traduccions
