### PR TITLE
Update distribution agreement som

### DIFF
--- a/som_switching/__terp__.py
+++ b/som_switching/__terp__.py
@@ -33,6 +33,7 @@
         'giscedata_switching_activation_data.xml',
         'giscedata_facturacio_switching_error_data.xml',
         'wizard/wizard_comment_to_F1_view.xml',
+        'wizard/wizard_validate_d101_view.xml',
         'security/ir.model.access.csv',
         'giscedata_switching_rebutjos_m.xml',
         'giscedata_switching_rebutjos_c.xml',

--- a/som_switching/security/ir.model.access.csv
+++ b/som_switching/security/ir.model.access.csv
@@ -2,3 +2,4 @@
 "access_wizard_comment_to_F1_rcwd","wizard.comment.to.F1","model_wizard_comment_to_F1","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
 "access_giscedata_atc_tag_w","giscedata.atc.tag","model_giscedata_atc_tag","crm.group_crm_manager",1,1,1,1
 "access_giscedata_atc_tag_u","giscedata.atc.tag","model_giscedata_atc_tag","crm.group_crm_user",1,1,1,0
+"access_wizard_validate_d101_rcwd","wizard.validate.d101","model_wizard_validate_d101","crm.group_crm_manager",1,1,1,1

--- a/som_switching/tests/__init__.py
+++ b/som_switching/tests/__init__.py
@@ -8,3 +8,4 @@ from tests_wizard_comment_to_F1 import *
 from tests_wizard_switching_b1 import *
 from tests_wizard_import_atr_and_f1 import *
 from tests_unlink_atc import *
+from tests_wizard_validate_d101 import *

--- a/som_switching/tests/tests_wizard_validate_d101.py
+++ b/som_switching/tests/tests_wizard_validate_d101.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from osv.osv import except_osv
+from destral.transaction import Transaction
+import mock
+from giscedata_switching.tests.common_tests import TestSwitchingImport
+
+from .. import wizard
+
+class TestWizardValidateD101(TestSwitchingImport):
+    def create_d1_case_at_step_01(self, txn):
+        self.switch(txn, 'distri')
+        uid = txn.user
+        cursor = txn.cursor
+
+        contract_id = self.get_contract_id(txn)
+
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        tarifa_id = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_polissa', 'tarifa_20TD'
+        )[1]
+        pol_obj = self.openerp.pool.get('giscedata.polissa')
+        pol_obj.write(cursor, uid, [contract_id], {'tarifa': tarifa_id})
+
+        self.change_polissa_comer(txn)
+        self.update_polissa_distri(txn)
+        self.activar_polissa_CUPS(txn)
+        context = {
+            'contract_id': contract_id,
+            'contract_ids': [contract_id],
+        }
+        d101_id = self.create_case_and_step(
+            cursor, uid, contract_id, 'D1', '01', {'whereiam': 'distri'}
+        )
+
+        d101_obj = self.openerp.pool.get('giscedata.switching.d1.01')
+        d101 = d101_obj.browse(cursor, uid, d101_id)
+        d1_id = d101.sw_id.id
+
+        autoconsum_id = self.crear_autoconsum(txn)
+
+        polissa_obj = self.openerp.pool.get('giscedata.polissa')
+        cups_obj = self.openerp.pool.get('giscedata.cups.ps')
+
+        cups_id = polissa_obj.read(cursor, uid, contract_id, ['cups'])['cups']
+        cups_obj.write(cursor, uid, cups_id[0], {'autoconsum_id': autoconsum_id})
+
+        # Button create case
+        context.update({'autoconsum_id': autoconsum_id})
+
+        sw_obj = self.openerp.pool.get('giscedata.switching')
+        self.switch(txn, 'comer')
+
+        cups_id = sw_obj.read(cursor, uid, d1_id, ['cups_id'])['cups_id']
+        sw_obj.write(cursor, uid, d1_id, {'cups_id': cups_id[0]})
+        return d1_id
+
+    def test__create_step_d1_02_autoconsum__reject(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            d102_obj = self.openerp.pool.get('giscedata.switching.d1.02')
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            rejection_comment = u"This is an example of a rejection comment"
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+            d102_id = wiz._create_step_d1_02_autoconsum(
+                sw_id=d1_id, is_rejected=True, rejection_comment=rejection_comment, set_pending=True
+            )
+
+            motiu_obj = self.openerp.pool.get('giscedata.switching.motiu.rebuig')
+            motiu_rebuig_id = motiu_obj.search(cursor, uid, [('name', '=', 'F1')])
+            motiu_rebuig_text = motiu_obj.read(cursor, uid, motiu_rebuig_id[0], ['text'])['text']
+
+            rejection_description = motiu_rebuig_text + ": {}".format(rejection_comment)
+
+            d1 = sw_obj.browse(cursor, uid, d1_id)
+            d102 = d102_obj.browse(cursor,uid, d102_id)
+
+            self.assertEqual(d102.sw_id.id, d1_id)
+            self.assertTrue(d102.rebuig)
+            self.assertTrue(d1.validacio_pendent)
+            self.assertTrue(d102.validacio_pendent)
+            self.assertEqual(d102.rebuig_ids[-1].desc_rebuig, rejection_description)
+
+            self.assertEqual(d102.motiu_rebuig, rejection_description)
+
+            self.assertEqual(
+                d102.sw_id.history_line[0].description.split(":")[-1].strip(),
+                rejection_comment
+            )
+
+    def test__create_step_d1_02_autoconsum__accept(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            d102_obj = self.openerp.pool.get('giscedata.switching.d1.02')
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+
+            d102_id = wiz._create_step_d1_02_autoconsum(d1_id, is_rejected=False, set_pending=True)
+
+            d1 = sw_obj.browse(cursor, uid, d1_id)
+            d102 = d102_obj.browse(cursor,uid, d102_id)
+
+            self.assertEqual(d102.sw_id.id, d1_id)
+            self.assertFalse(d102.rebuig)
+            self.assertFalse(d1.validacio_pendent)
+            self.assertFalse(d102.validacio_pendent)
+
+            expected_history_msg = u"D1-01 Acceptat des de l'assistent de validació de D1-01"
+            self.assertEqual(
+                d102.sw_id.history_line[0].description.split(":")[-1].strip(),
+                expected_history_msg
+            )
+
+    def test__create_case_m1_01_autoconsum(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            m101_obj = self.openerp.pool.get('giscedata.switching.m1.01')
+            wiz_step_obj = self.openerp.pool.get('wizard.create.step')
+
+            pol_id = self.get_contract_id(txn)
+
+            # create d101
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            # create d102 using previous existing wiz
+            params = {
+                'step': '02',
+                'option': "A",
+                'step_is_rejectable': True,
+                'check_repeated': True,
+            }
+            wiz_step_id = wiz_step_obj.create(cursor, uid, params, context={'active_ids': [d1_id]})
+            wiz_step = wiz_step_obj.browse(cursor, uid, wiz_step_id)
+            wiz_step.action_create_steps(context={'active_ids': [d1_id]})
+            wiz_step = wiz_step.browse()[0]
+            sw_obj.write(cursor, uid, [d1_id], {'additional_info': 'Autoconsum'})
+
+            #wizard to test
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+            m1_id = wiz._create_case_m1_01_autoconsum(pol_id)
+            m1 = sw_obj.browse(cursor, uid, m1_id)
+
+            self.assertEqual(m1.state, 'draft')
+            self.assertEqual(len(m1.step_ids), 1)
+            self.assertEqual(m1.polissa_ref_id.id, pol_id)
+
+            m101_id = int(m1.step_ids[-1].pas_id.split(",")[-1])
+            m101 = m101_obj.browse(cursor, uid, m101_id)
+
+            self.assertEqual(m101.sw_id.id, m1.id)
+            self.assertEqual(m101.tipus_autoconsum, u'31')
+
+    def test__create_case_m1_01_autoconsum__exception(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            m101_obj = self.openerp.pool.get('giscedata.switching.m1.01')
+            wiz_step_obj = self.openerp.pool.get('wizard.create.step')
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            pol_id = self.get_contract_id(txn)
+
+            # create d101
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+
+            with self.assertRaises(except_osv) as error:
+                wiz_validate_obj._create_case_m1_01_autoconsum(cursor, uid, wiz_id, pol_id)
+
+            self.assertIn(
+                u"Alerta, la modalitat d\'autoconsum no ha estat acceptada pel client, vols seguir?",
+                error.exception.message
+            )
+
+    def test__validate_d101__reject(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            d102_obj = self.openerp.pool.get('giscedata.switching.d1.02')
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            rejection_comment = u"This is an example of a rejection comment"
+
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            wiz_init = {
+                'sw_id': d1_id,
+                'is_rejected': True,
+                'rejection_comment': rejection_comment,
+                'set_pending': True
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+            wiz.validate_d101_autoconsum()
+
+            d102_id = wiz.read(['generated_d102'])[0]['generated_d102']
+            m1_id = wiz.read(['generated_m1'])[0]['generated_m1']
+
+            motiu_obj = self.openerp.pool.get('giscedata.switching.motiu.rebuig')
+            motiu_rebuig_id = motiu_obj.search(cursor, uid, [('name', '=', 'F1')])
+            motiu_rebuig_text = motiu_obj.read(cursor, uid, motiu_rebuig_id[0], ['text'])['text']
+
+            rejection_description = motiu_rebuig_text + ": {}".format(rejection_comment)
+
+            d102 = d102_obj.browse(cursor,uid, d102_id)
+
+            self.assertEqual(d102.sw_id.id, d1_id)
+            self.assertTrue(d102.rebuig)
+            self.assertEqual(d102.rebuig_ids[-1].desc_rebuig, rejection_description)
+
+            self.assertEqual(d102.motiu_rebuig, rejection_description)
+            self.assertFalse(m1_id)
+
+    @mock.patch.object(wizard.wizard_validate_d101.GiscedataSwitchingWizardValidateD101, "_create_case_m1_01_autoconsum")
+    def test__validate_d101__accept_m101_exception(self, mock_create_case_m1_01):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+
+            mock_create_case_m1_01.side_effect = except_osv(cursor, uid)
+
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            d102_obj = self.openerp.pool.get('giscedata.switching.d1.02')
+            m101_obj = self.openerp.pool.get('giscedata.switching.m1.01')
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+            with self.assertRaises(except_osv) as error:
+                wiz.validate_d101_autoconsum()
+
+            d1 = sw_obj.browse(cursor, uid, d1_id)
+            step_info = d1.step_ids[-1]
+            d102_id = int(step_info.pas_id.split(",")[-1])
+            d102 = d102_obj.browse(cursor, uid, d102_id)
+
+            self.assertEqual(step_info.step_id.name, "02")
+            self.assertEqual(d102.sw_id.id, d1_id)
+            self.assertFalse(d102.rebuig)
+            self.assertTrue(d1.validacio_pendent)
+            self.assertTrue(d102.validacio_pendent)
+
+            historize_msg = "Hi ha hagut un error al generar el cas M1 després d'acceptar " + \
+                    "el D1-01 mitjançant l'assistent de validació"
+            self.assertEqual(
+                d102.sw_id.history_line[0].description.split(":")[0].strip(),
+                historize_msg
+            )
+
+    def test__create_step_d1_02_motiu_06__accept_done(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            d101_obj = self.openerp.pool.get('giscedata.switching.d1.01')
+            d102_obj = self.openerp.pool.get('giscedata.switching.d1.02')
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            sw = sw_obj.browse(cursor, uid, d1_id)
+            pas_id = sw.step_ids[0].pas_id
+            id_pas = int(pas_id.split(',')[1])
+            d101_obj.write(cursor, uid, [id_pas], {'motiu_canvi': '06'})
+
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+
+            wiz.validate_d101_autoconsum()
+
+            d102_id = wiz.read(['generated_d102'])[0]['generated_d102']
+
+            sw_id = d102_obj.read(cursor, uid, d102_id, ['sw_id'])['sw_id'][0]
+            sw_obj.write(cursor, uid, sw_id, {"state": "done"})
+            
+            d102 = d102_obj.browse(cursor,uid, d102_id)
+
+            self.assertEqual(d102.sw_id.id, d1_id)
+            self.assertEqual(d102.sw_id.state, 'done')
+
+    def test__create_case_m1_01_motiu_06__S_R(self):
+        with Transaction().start(self.database) as txn:
+            uid = txn.user
+            cursor = txn.cursor
+
+            m101_obj = self.openerp.pool.get('giscedata.switching.m1.01')
+
+            pol_id = self.get_contract_id(txn)
+
+            #wizard to test
+            sw_obj = self.openerp.pool.get('giscedata.switching')
+            d101_obj = self.openerp.pool.get('giscedata.switching.d1.01')
+            d102_obj = self.openerp.pool.get('giscedata.switching.d1.02')
+            wiz_validate_obj = self.openerp.pool.get('wizard.validate.d101')
+
+            d1_id = self.create_d1_case_at_step_01(txn)
+
+            sw = sw_obj.browse(cursor, uid, d1_id)
+            pas_id = sw.step_ids[0].pas_id
+            id_pas = int(pas_id.split(',')[1])
+            d101_obj.write(cursor, uid, [id_pas], {'motiu_canvi': '06'})
+
+            wiz_init = {
+                'sw_id': d1_id
+            }
+            wiz_id = wiz_validate_obj.create(cursor, uid, wiz_init)
+            wiz = wiz_validate_obj.browse(cursor, uid, wiz_id)
+            
+            wiz.validate_d101_autoconsum()
+
+            m1_id = wiz.read(['generated_m1'])[0]['generated_m1']
+
+            m1 = sw_obj.browse(cursor, uid, m1_id)
+
+            self.assertEqual(m1.state, 'draft')
+            self.assertEqual(len(m1.step_ids), 1)
+            self.assertEqual(m1.polissa_ref_id.id, pol_id)
+            self.assertEqual(m1.additional_info[0:48], '(S)[R] Mod. Acord repartiment/fitxer coeficients')
+            id_pas = int(m1.step_ids[0].pas_id.split(',')[1])
+            pas = m101_obj.browse(cursor, uid, id_pas)
+            self.assertEqual(pas.sollicitudadm, 'S')
+            self.assertEqual(pas.canvi_titular, 'R')

--- a/som_switching/tests/tests_wizard_validate_d101.py
+++ b/som_switching/tests/tests_wizard_validate_d101.py
@@ -6,6 +6,7 @@ from osv.osv import except_osv
 from destral.transaction import Transaction
 import mock
 from giscedata_switching.tests.common_tests import TestSwitchingImport
+import unittest
 
 from .. import wizard
 
@@ -325,6 +326,7 @@ class TestWizardValidateD101(TestSwitchingImport):
             self.assertEqual(d102.sw_id.id, d1_id)
             self.assertEqual(d102.sw_id.state, 'done')
 
+    @unittest.skip("Waiting for ATR3.0")
     def test__create_case_m1_01_motiu_06__S_R(self):
         with Transaction().start(self.database) as txn:
             uid = txn.user

--- a/som_switching/wizard/__init__.py
+++ b/som_switching/wizard/__init__.py
@@ -10,3 +10,4 @@ import wizard_create_atc_from_polissa
 import giscedata_switching_wizard_b1
 import wizard_import_atr_and_f1
 import wizard_close_obsolete_cases
+import wizard_validate_d101

--- a/som_switching/wizard/wizard_validate_d101.py
+++ b/som_switching/wizard/wizard_validate_d101.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+
+from gestionatr.defs import TABLA_64, TABLA_17, TARIFES_SEMPRE_MAX
+
+
+class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
+
+    """Classe per gestionar el canvi de comercialitzador
+    """
+
+    _name = "wizard.validate.d101"
+
+    _change_reason = ''
+
+    def _get_change_reason(self, cursor, uid, ids):
+        sw_obj = self.pool.get("giscedata.switching")
+        wizard_vals = self.read(cursor, uid, ids)[0]
+        sw_id =  wizard_vals['sw_id']
+        sw = sw_obj.browse(cursor, uid, sw_id)
+
+        pas_id = sw.step_ids[0].pas_id
+        d101_obj = self.pool.get("giscedata.switching.d1.01")
+        id_pas = int(pas_id.split(',')[1])
+        self._change_reason = d101_obj.read(cursor, uid, id_pas, ['motiu_canvi'])['motiu_canvi']
+
+    def mod_con_wizard_default_values(self, cursor, uid, ids, context=None):
+        res = {"mod_autoconsum": True}
+
+        if self._change_reason == '06':
+            values = {
+                "generate_new_contract": 'exists',
+                "change_adm": 1,
+                "change_atr": 0,
+                "owner_change_type": 'R'
+            }
+            res.update(values)
+        return res
+        
+    def validate_d101_autoconsum(self, cursor, uid, ids, context=None):
+        """
+        Creates a step D102 from a D1 case (sw_id).
+        If it's not a rejections, a M1 case is created to change self-consumption for the related contract.
+        Returns a tuple with 2 values:
+            - If the D102 is a rejection step , returns (D102_ID, None)
+            - If the D102 is an accepted step, returns (D102_ID, M1_ID)
+        """
+        if not context:
+            context = {}
+
+        if isinstance(ids, list) or isinstance(ids, tuple):
+            ids = ids[0]
+
+        self._get_change_reason(cursor, uid, ids) 
+
+        sw_obj = self.pool.get("giscedata.switching")
+
+        wizard_vals = self.read(cursor, uid, ids,
+            ['sw_id', 'set_pending', 'is_rejected', 'rejection_comment'])[0]
+
+        sw_id =  wizard_vals['sw_id']
+
+        is_rejected = wizard_vals['is_rejected']
+        rejection_comment = wizard_vals['rejection_comment']
+        set_pending = wizard_vals['set_pending']
+
+        d102_id = self._create_step_d1_02_autoconsum(cursor, uid, ids, sw_id, is_rejected, rejection_comment, set_pending, context)
+        self.write(cursor, uid, [ids],{'generated_d102': d102_id})
+
+        cups_name = sw_obj.read(cursor, uid, sw_id, ['cups_id'])['cups_id'][1]
+
+        if not is_rejected:
+            pol_id = sw_obj.read(cursor, uid, sw_id, ["polissa_ref_id"])["polissa_ref_id"][0]
+            d102_obj = self.pool.get("giscedata.switching.d1.02")
+
+            try:
+                m1_id = self._create_case_m1_01_autoconsum(cursor, uid, ids, pol_id, context)
+                self.write(cursor, uid, [ids], {'generated_m1': m1_id})
+                d102_obj = self.pool.get("giscedata.switching.d1.02")
+                d102_sw_id = d102_obj.read(cursor, uid, d102_id, ['sw_id'])['sw_id'][0]
+                sw_obj.write(cursor, uid, d102_sw_id, {"state": "done"})
+
+            except Exception as e:
+                # set validacio_pendent to True
+                sw_obj.write(cursor, uid, sw_id, {'validacio_pendent':True})
+                d102_obj.write(cursor, uid, d102_id, {'validacio_pendent':True})
+
+                # historize error
+                d1 = sw_obj.browse(cursor, uid, sw_id)
+                error_msg = "Hi ha hagut un error al generar el cas M1 després d'acceptar " + \
+                    "el D1-01 mitjançant l'assistent de validació: {}".format(e.message)
+                d1.historize_msg(error_msg)
+
+                raise osv.except_osv(
+                    'Error',
+                    _(u"No s'ha pogut crear el cas M1 pel contracte {}: {}".format(
+                        pol_id, e.message
+                    ))
+                )
+
+            message = 'Passos D1-02 d\'acceptació i M1-01 creats per al CUPS {}'.format(cups_name)
+            self.write(cursor, uid, [ids], {'state': 'end', 'results': message})
+
+            return d102_id, m1_id
+
+        message = 'Pas D1-02 de rebuig creat per al CUPS {}'.format(cups_name)
+
+        self.write(cursor, uid, [ids], {'state': 'end', 'results': message})
+
+        return d102_id, False
+
+    def _create_step_d1_02_autoconsum(self, cursor, uid, ids, sw_id, is_rejected, rejection_comment='', set_pending=True, context=None):
+        """ Creates a step D102 (rejected or accepted, depending on is_rejection parameter)
+        from a D1 case (sw_id)"""
+        if not context:
+            context = {}
+        wiz_step_obj = self.pool.get('wizard.create.step')
+        sw_obj = self.pool.get("giscedata.switching")
+
+        context.update({'active_ids': [sw_id]})
+
+        params = {
+            'step': '02',
+            'option': "R" if is_rejected else "A",
+            'step_is_rejectable': True,
+            'check_repeated': True,
+        }
+
+        if is_rejected:
+            motiu_obj = self.pool.get('giscedata.switching.motiu.rebuig')
+            imd_obj = self.pool.get('ir.model.data')
+            motiu_rebuig_id = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_switching', 'sw_motiu_rebuig_F1'
+            )[1]
+            params['motiu_rebuig'] = motiu_rebuig_id
+
+        wiz_step_id = wiz_step_obj.create(cursor, uid, params, context=context)
+        wiz_step = wiz_step_obj.browse(cursor, uid, wiz_step_id)
+        wiz_step.action_create_steps(context=context)
+        wiz_step = wiz_step.browse()[0]
+
+        if len(eval(wiz_step.sw_ids)) == 0:
+            raise osv.except_osv(_('Error'), wiz_step.info)
+
+        d1 = sw_obj.browse(cursor, uid, sw_id)
+        d102 = sw_obj.get_pas(cursor, uid, d1)
+
+        if is_rejected:
+            rebuig_obj = self.pool.get('giscedata.switching.rebuig')
+            history_msg = "D1-01 Rebutjat des de l'assistent de validació de D1-01:\n" + rejection_comment
+            rebuig_obj.write(cursor, uid, [d102.rebuig_ids[-1].id], {
+                "desc_rebuig": d102.rebuig_ids[-1].desc_rebuig + ": {}".format(rejection_comment)
+            })
+            if set_pending:
+                d1.write({'validacio_pendent':True})
+                d102.write({'validacio_pendent':True})
+        else:
+            history_msg = "D1-01 Acceptat des de l'assistent de validació de D1-01"
+
+        d1.historize_msg(history_msg)
+        return d102.id
+
+    def add_tension_to_additional_info(self, cursor, uid, cas_id, tension):
+        sw_obj = self.pool.get("giscedata.switching")
+        sw_vals = sw_obj.read(cursor, uid, cas_id, ['additional_info'])
+
+        taula_cnmc = dict(TABLA_64)
+        tension_name = taula_cnmc.get(tension, False)
+
+        sw_obj.write(
+            cursor, uid, cas_id,
+            {'additional_info': '(N) Tensio: {tensio}; {old_info}'.format(
+                tensio='M -> T' if tension_name.lower().startswith('3x') else 'T -> M',
+                old_info=sw_vals['additional_info'][3:]
+            )}
+        )
+
+    def specify_lack_of_tension(self, cursor, uid, cas_id):
+        sw_obj = self.pool.get("giscedata.switching")
+        step_info_obj = self.pool.get("giscedata.switching.step.info")
+        m101_obj = self.pool.get("giscedata.switching.m1.01")
+
+        sw_vals = sw_obj.read(cursor, uid, cas_id, ['step_ids'])
+        step_info_vals = step_info_obj.read(cursor, uid, sw_vals['step_ids'][0])
+        m101_id = int(step_info_vals['pas_id'].split(',')[1])
+
+        m101_obj.write(cursor, uid, m101_id, {"solicitud_tensio": "N"})
+
+    def _create_case_m1_01_autoconsum(self, cursor, uid, ids, pol_id, context=None):
+        """ Creates case M1 to change self-consumption for the given contract """
+        if not context:
+            context = {}
+
+        sw_obj = self.pool.get('giscedata.switching')
+        wiz_obj = self.pool.get('giscedata.switching.mod.con.wizard')
+        pol_obj = self.pool.get('giscedata.polissa')
+
+        wiz_id = wiz_obj.create(
+            cursor, uid, {}, context={
+                'cas': 'M1',
+                'pol_id': pol_id
+            }
+        )
+        cups_name = pol_obj.read(cursor, uid, pol_id, ['cups'])['cups'][1]
+
+        # validate autoconsum data
+        res_auto = wiz_obj.onchange_mod_autoconsum(cursor, uid, wiz_id, True, cups_name, context=None)
+        if res_auto['warning']:
+            raise osv.except_osv(_('Error'), res_auto['warning'])
+
+        # validate tarpot changes
+        self_vals = self.read(cursor, uid, ids)[0]
+        wiz_obj_vals = wiz_obj.read(cursor, uid, wiz_id)[0]
+        wiz_modcon_args = {
+            'tariff': self_vals['tariff'] if self_vals.get('tariff', False) else wiz_obj_vals['tariff'],
+            'power_p1': self_vals['power_p1'] if self_vals.get('power_p1', False) else wiz_obj_vals['power_p1'],
+            'power_p2': self_vals['power_p2'] if self_vals.get('power_p2', False) else wiz_obj_vals['power_p2'],
+            'power_p3': self_vals['power_p3'] if self_vals.get('power_p3', False) else wiz_obj_vals['power_p3'],
+            'power_p4': self_vals['power_p4'] if self_vals.get('power_p4', False) else wiz_obj_vals['power_p4'],
+            'power_p5': self_vals['power_p5'] if self_vals.get('power_p5', False) else wiz_obj_vals['power_p5'],
+            'power_p6': self_vals['power_p6'] if self_vals.get('power_p6', False) else wiz_obj_vals['power_p6'],
+        }
+        useMaximeter = wiz_obj_vals['power_invoicing'] == '2' or (
+            wiz_modcon_args['tariff'] in TARIFES_SEMPRE_MAX)
+        wiz_modcon_args['power_invoicing'] = '2' if useMaximeter else '1'
+        res_tarpot = wiz_obj.onchange_atr(cursor, uid, wiz_id,
+            contract_id=pol_id, context={'pol_id': pol_id}, **wiz_modcon_args)
+        if res_tarpot['warning'] and res_tarpot['warning']['title'] != u'Potència incorrecte':
+            raise osv.except_osv(_('Error'), res_tarpot['warning'])
+
+        # include tension, if requested
+        tension = self_vals.get('solicitud_tensio', False)
+        if tension:
+            wiz_modcon_args['solicitud_tensio'] = self_vals['solicitud_tensio']
+
+        # update wizard and create cases
+        wiz_modcon_args.update({
+            "autoconsum": res_auto['value']['autoconsum'],
+            "retail_tariff": res_tarpot['value'].get('retail_tariff', False)
+        })
+
+        wiz_default_values = self.mod_con_wizard_default_values(cursor, uid, ids)
+        wiz_modcon_args.update(wiz_default_values)
+
+        for field_name in ['con_name', 'con_sur1', 'con_sur2', 'phone_num', 'phone_pre']:
+            if field_name in self_vals and self_vals[field_name]:
+                wiz_modcon_args[field_name] = self_vals[field_name]
+        wiz_obj.write(cursor, uid, [wiz_id], wiz_modcon_args)
+
+        wiz_obj.genera_casos_atr(cursor, uid, [wiz_id], context={'pol_id': pol_id})
+
+        casos_generats = wiz_obj.read(cursor, uid, wiz_id, ['casos_generats'])[0]['casos_generats']
+        cas_ids = eval(casos_generats)
+        if not cas_ids:
+            raise osv.except_osv(
+                'Error',
+                _(u"No s'ha pogut crear el cas M1 per la pòlissa {}".format(pol_id))
+            )
+
+        if tension:
+            self.add_tension_to_additional_info(cursor, uid, cas_ids[0], tension)
+        else:
+            self.specify_lack_of_tension(cursor, uid, cas_ids[0])
+
+        sw_obj.write(cursor, uid, cas_ids, {"state": "draft", "validacio_pendent": False})
+
+        return cas_ids[0]
+
+    def open_generated_cases(self, cursor, uid, ids, context=None):
+        if not context:
+            context = {}
+
+        if isinstance(ids, list) or isinstance(ids, tuple):
+            ids = ids[0]
+
+        casos_ids = []
+
+
+        d102_id = self.read(cursor, uid, ids, ['generated_d102'])['generated_d102']
+        if d102_id:
+            d102_obj = self.pool.get('giscedata.switching.d1.02')
+            d1_id = d102_obj.read(cursor, uid, d102_id, ['sw_id'])['sw_id'][0]
+            casos_ids.append(d1_id)
+
+
+        m1_id = self.read(cursor, uid, ids, ['generated_m1'])['generated_m1']
+        if m1_id:
+            casos_ids.append(m1_id)
+
+        return {
+            'domain': "[('id','in', %s)]" % str(casos_ids),
+            'name': _('Casos Creats'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'giscedata.switching',
+            'type': 'ir.actions.act_window'
+        }
+
+    _columns = {
+        'is_rejected': fields.boolean('Rebutjar', help='Si s\'activa, el D1-02 serà de rebuig, si no serà d\'acceptació'),
+        'rejection_comment': fields.text('Motiu de rebuig', help='Comentari de rebuig del pas D1-02'),
+        'set_pending': fields.boolean('D1-02 de rebuig pendent de validar', help='Si s\'activa, es crearà el D1-02 marcat com a pendent de validar'),
+        'sw_id': fields.many2one('giscedata.switching', 'Pas D1 a validar', required=True,
+            domain=[
+                ('proces_id.name','=','D1'),
+                ('step_id.name','=','01'),
+                '|', ('additional_info', 'ilike', '(04)%'), ('additional_info', 'ilike', '(05)%')
+            ]
+        ),
+        'generated_d102': fields.integer(string='ID del pas D102 generat per l\'assitent'),
+        'generated_m1': fields.integer(string='ID del cas M1 generat per l\'assitent'),
+        'state': fields.selection(selection=[('init', 'Init'), ('end', 'End')], string='Estat', required=True),
+        'results': fields.text('Resultats', read_only=True),
+        'solicitud_tensio': fields.selection([('', '')]+TABLA_64, u"Tensió Sol.licitada"),
+        'power_p1': fields.integer('P1'),
+        'power_p2': fields.integer('P2'),
+        'power_p3': fields.integer('P3'),
+        'power_p4': fields.integer('P4'),
+        'power_p5': fields.integer('P5'),
+        'power_p6': fields.integer('P6'),
+        'tariff': fields.selection(sorted(TABLA_17, key=lambda t: t[1]),
+                                   string="Tarifa ATR"),
+        'con_name': fields.char('Nom', size=256),
+        'con_sur1': fields.char('Cognom 1', size=256),
+        'con_sur2': fields.char('Cognom 2', size=256),
+        'phone_num': fields.char('Telèfon', size=9),
+        'phone_pre': fields.char('Prefix', size=2),
+    }
+
+    _defaults = {
+        'state': lambda *a: 'init',
+        'is_rejected': lambda *a: False,
+        'set_pending': lambda *a: True
+    }
+
+GiscedataSwitchingWizardValidateD101()

--- a/som_switching/wizard/wizard_validate_d101.py
+++ b/som_switching/wizard/wizard_validate_d101.py
@@ -25,10 +25,21 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
         id_pas = int(pas_id.split(',')[1])
         self._change_reason = d101_obj.read(cursor, uid, id_pas, ['motiu_canvi'])['motiu_canvi']
 
+    def isAutoconsum(self, cursor, uid):
+        """
+        Pending CNMC
+        """
+        return False
+
     def mod_con_wizard_default_values(self, cursor, uid, ids, context=None):
+        """
+        Method prepared to add default values
+        """
         res = {"mod_autoconsum": True}
 
-        if self._change_reason == '06':
+        isAutoconsum = self.isAutoconsum(cursor, uid)
+
+        if isAutoconsum and self._change_reason == '06':
             values = {
                 "generate_new_contract": 'exists',
                 "change_adm": 1,

--- a/som_switching/wizard/wizard_validate_d101.py
+++ b/som_switching/wizard/wizard_validate_d101.py
@@ -163,6 +163,9 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
             rebuig_obj.write(cursor, uid, [d102.rebuig_ids[-1].id], {
                 "desc_rebuig": d102.rebuig_ids[-1].desc_rebuig + ": {}".format(rejection_comment)
             })
+
+            d1.write({'state': 'draft'})
+
             if set_pending:
                 d1.write({'validacio_pendent':True})
                 d102.write({'validacio_pendent':True})

--- a/som_switching/wizard/wizard_validate_d101_view.xml
+++ b/som_switching/wizard/wizard_validate_d101_view.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="wizard_validate_d101_form" model="ir.ui.view">
+            <field name="name">wizard.validate.d101.form</field>
+            <field name="model">wizard.validate.d101</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Validar D1-01">
+                    <field name="state" invisible="1"/>
+                    <group attrs="{'invisible': [('state', '!=', 'init')]}">
+                        <group colspan="4">
+                            <field name="sw_id"/>
+                            <field name="is_rejected"/>
+                        </group>
+                        <group colspan="4" attrs="{'invisible': [('is_rejected', '!=', True)]}">
+                            <field name="rejection_comment" colspan="4"/>
+                        </group>
+                        <group colspan="4" attrs="{'invisible': [('is_rejected', '!=', True)]}">
+                            <field name="set_pending" colspan="4"/>
+                        </group>
+                        <group colspan="4" attrs="{'invisible':[('is_rejected','=', True)]}">
+                            <label colspan="4" string=""/>
+                            <label colspan="4" string=""/>
+                            <label colspan="4" string=""/>
+                            <label colspan="4" string=""/>
+                            <label colspan="4" string=""/>
+                        </group>
+                        <button name="validate_d101_autoconsum" type="object" icon="gtk-execute"
+                                string="D'acord" colspan="4"/>
+                        <button special="cancel" string="Cancel·lar" icon="gtk-cancel" colspan="4"/>
+                    </group>
+                    <group attrs="{'invisible': [('state', '!=', 'end')]}">
+                        <label string="Resultats:" colspan="4"/>
+                        <field name="results" colspan="4" nolabel="1"/>
+                        <button name="open_generated_cases" type="object" icon="gtk-execute"
+                                string="Obrir casos generats" colspan="4"/>
+                        <button special="cancel" string="Sortir" icon="gtk-cancel" colspan="4"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_wizard_validate_d101_form" model="ir.actions.act_window">
+            <field name="name">Validació D1</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.validate.d101</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+        <menuitem id="menu_wizard_validate_d101_form" name="Validar D101" action="action_wizard_validate_d101_form" parent="giscedata_cups.menu_autoconsum"/>
+    </data>
+</openerp>

--- a/som_switching/wizard/wizard_validate_d101_view.xml
+++ b/som_switching/wizard/wizard_validate_d101_view.xml
@@ -49,6 +49,6 @@
             <field name="view_mode">form</field>
             <field name="target">new</field>
         </record>
-        <menuitem id="menu_wizard_validate_d101_form" name="Validar D101" action="action_wizard_validate_d101_form" parent="giscedata_cups.menu_autoconsum"/>
+        <menuitem id="menu_wizard_validate_d101_form" name="Validar D101" action="action_wizard_validate_d101_form" parent="giscedata_polissa.menu_autoconsum"/>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu
Moure wizard_validate_d101 a som_switching.
Afegir funcionalitat necessaria per a tractar D1 01 amb motiu 06 (ATR 3.0)

Amb el canvi de formats V.3.0 la distribuïdora ens pot enviar un D1 01 motiu 06. En aquest cas s'ha de crear:

D1 02 Acceptat/Tancat (si no ha estat rebutjat)
Si el contracte ja té auto col·lectiu (42 i 43): li demanem al titular que hi ha un canvi en l'acord de repartiment i cal fer una M (s)(R)

## Targeta on es demana o Incidència 
https://trello.com/c/QK6qXM8F/5543-p3-ep287-wizard-generaci%C3%B3-m-tipus-s-acord-repartiment-i-pantalles-ov-per-la-d1-01-motiu-06

## Comportament antic
El wizard estava al repositori de GISCE.
No tractava el motiu 06

## Comportament nou
Wizard mogut a som_switching
Tracta el motiu 06

## Comprovacions

- [X] Hi ha testos
- [ ] Reiniciar serveis
- [X] Actualitzar mòdul
   som_switching
- [ ] Script de migració
- [ ] Modifica traduccions
