### PR TITLE
Forçar dia de pagament al model terminis de pagament

### DIFF
--- a/account_account_som/__init__.py
+++ b/account_account_som/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 import account_account
 import wizard
+import account_payment_term

--- a/account_account_som/account_payment_term.py
+++ b/account_account_som/account_payment_term.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from osv import fields, osv
+from tools.translate import _
+
+
+class AccountPaymentTerm(osv.osv):
+    _name = "account.payment.term"
+    _inherit = "account.payment.term"
+
+    def create(self, cr, uid, vals, context={}):
+        id = super(AccountPaymentTerm, self).create(cr, uid, vals, context=context)
+        result = self.browse(cr, uid, id)
+        if not result.line_ids:
+            raise osv.except_osv(_("Falta dia de pagament!"), _("Els terminis de pagament han de tenir almenys un dia definit."))
+
+    def write(self, cr, uid, ids, vals, context=None):
+        super(AccountPaymentTerm, self).write(cr, uid, ids, vals, context=context)
+        result = self.browse(cr, uid, id)
+        if not result.line_ids:
+            raise osv.except_osv(_("Falta dia de pagament!"), _("Els terminis de pagament han de tenir almenys un dia definit."))
+
+AccountPaymentTerm()


### PR DESCRIPTION
## Objectiu
Forçar dia de pagament al model terminis de pagament ja que és necessari en el moment de crear una factura i definir la data de venciment.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1347799277/7100531/
https://sentry.somenergia.coop/organizations/som-energia/issues/127319/?project=11&query=is%3Aunresolved+%21logger%3Aopenerp.web-services

## Comportament antic
Es bloquejava la facturació si tenien un termini de pagament sense dia definit

## Comportament nou
No es poden crear nous terminis de pagament (o modificar els actuals) sense tenir-los definits

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
