### PR TITLE
Afegir consum mitjà per codi postal a la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -26,7 +26,7 @@ BOE17_2021_dates = {
 factors_kp_change_calculation_date = '2021-10-18'
 
 mean_zipcode_consumption_dates = {
-    'start': '2022-10-18',
+    'start': '2022-12-01',
     'end': '2050-12-31',
 }
 
@@ -1100,8 +1100,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         required_max_requested_powers, max_potencies_demandades = self.max_requested_powers(pol, fact)
 
-        today = datetime.today().strftime('%Y-%m-%d')
-        if pol.tipo_medida == '05' and mean_zipcode_consumption_dates['start'] <= today < mean_zipcode_consumption_dates['end']:
+        if pol.tipo_medida == '05' and mean_zipcode_consumption_dates['start'] <= fact.data_inici < mean_zipcode_consumption_dates['end']:
             show_mean_zipcode_consumption = True
             try:
                 mean_zipcode_consumption = fact.consum_cp_ids[0].consum

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -25,6 +25,11 @@ BOE17_2021_dates = {
 
 factors_kp_change_calculation_date = '2021-10-18'
 
+mean_zipcode_consumption_dates = {
+    'start': '2022-10-18',
+    'end': '2050-12-31',
+}
+
 # -----------------------------------
 # helper functions
 # -----------------------------------
@@ -1095,6 +1100,17 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         required_max_requested_powers, max_potencies_demandades = self.max_requested_powers(pol, fact)
 
+        today = datetime.today().strftime('%Y-%m-%d')
+        if pol.tipo_medida == '05' and mean_zipcode_consumption_dates['start'] <= today < mean_zipcode_consumption_dates['end']:
+            show_mean_zipcode_consumption = True
+            try:
+                mean_zipcode_consumption = fact.consum_cp_ids[0].consum
+            except Exception as e:
+                mean_zipcode_consumption = 0
+        else:
+            show_mean_zipcode_consumption = False
+            mean_zipcode_consumption = 0
+
         data = {
                 'fact_id': fact.id,
                 'total_historic_eur_dia': (total_historic_eur * 1.0) / historic_dies_or_1,
@@ -1107,6 +1123,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 'max_requested_powers': max_potencies_demandades,
                 'required_max_requested_powers': required_max_requested_powers,
                 'distri_name': pol.distribuidora.name,
+                'show_mean_zipcode_consumption': show_mean_zipcode_consumption,
+                'zipcode': fact.cups_id.dp,
+                'mean_zipcode_consumption': mean_zipcode_consumption,
                 }
 
         return data

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1100,15 +1100,13 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         required_max_requested_powers, max_potencies_demandades = self.max_requested_powers(pol, fact)
 
-        if pol.tipo_medida == '05' and mean_zipcode_consumption_dates['start'] <= fact.data_inici < mean_zipcode_consumption_dates['end']:
-            show_mean_zipcode_consumption = True
+        mean_zipcode_consumption = 0
+        show_mean_zipcode_consumption = pol.tipo_medida == '05' and mean_zipcode_consumption_dates['start'] <= fact.data_inici < mean_zipcode_consumption_dates['end']
+        if show_mean_zipcode_consumption:
             try:
                 mean_zipcode_consumption = fact.consum_cp_ids[0].consum
-            except Exception as e:
-                mean_zipcode_consumption = 0
-        else:
-            show_mean_zipcode_consumption = False
-            mean_zipcode_consumption = 0
+            except Exception as e:  # consum_cp_ids is in another module and may be not installed or empty
+                pass
 
         data = {
                 'fact_id': fact.id,

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -6,13 +6,13 @@
 #   <>, 2017, 2018, 2019, 2020.
 # Agustí Fita <afita@gisce.net>, 2018.
 # GISCE-TI, S.L. <devel@gisce.net>, 2014, 2017.
-# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022.
+# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022, 2023.
 msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2022-11-22 10:46+0000\n"
-"PO-Revision-Date: 2022-11-22 09:51+0000\n"
+"POT-Creation-Date: 2023-01-09 10:41+0000\n"
+"PO-Revision-Date: 2023-01-09 09:44+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2668
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -35,15 +35,15 @@ msgid "Signar Factures"
 msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:297
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1909
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1911
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1925
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1905
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1921
 msgid "estimada"
 msgstr "estimada"
 
@@ -54,14 +54,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2698
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1944
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1960
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -72,49 +72,49 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1755
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1771
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:300
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:290
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1907
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1923
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2580
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2596
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:768
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:773
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1700
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1716
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2610
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1753
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1769
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -124,18 +124,18 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2639
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2655
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1701
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1717
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:293
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:298
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr "calculada por Som Energía"
@@ -146,7 +146,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1757
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
 msgid "(real)"
 msgstr "(real)"
 
@@ -1045,6 +1045,20 @@ msgid ""
 "Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat "
 "aquestes dades)."
 msgstr "Potencia máxima demandada: (lo sentimos, %s aún no nos ha facilitado este dato)."
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:38
+#, python-format
+msgid ""
+"El consum mitjà de la teva zona (CP %s) durant l'últim mes ha estat de "
+"<b>%s</b> kWh."
+msgstr "El consumo medio de tu zona (CP %s) durante el último mes ha sido de <b>%s</b> kWh."
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:40
+#, python-format
+msgid ""
+"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s) de"
+" l’últim mes."
+msgstr "Lo sentimos, %s no nos ha facilitado el consumo medio de tu zona (CP %s) del último mes."
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:7
 msgid "IMPACTE AMBIENTAL"

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2022-11-22 10:46+0000\n"
-"PO-Revision-Date: 2022-11-22 10:46+0000\n"
+"POT-Creation-Date: 2023-01-09 10:41+0000\n"
+"PO-Revision-Date: 2023-01-09 10:41+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2668
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -28,15 +28,15 @@ msgid "Signar Factures"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:297
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1909
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1911
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1925
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1905
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1921
 msgid "estimada"
 msgstr ""
 
@@ -47,14 +47,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2698
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1944
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1960
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -65,49 +65,49 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1755
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1771
 msgid "(sense lectura)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:300
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:290
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1907
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1923
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2580
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2596
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:768
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:773
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1700
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1716
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2610
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1753
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1769
 msgid "(estimada)"
 msgstr ""
 
@@ -117,18 +117,18 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2639
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2655
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1701
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1717
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:293
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:298
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr ""
@@ -139,7 +139,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1757
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
 msgid "(real)"
 msgstr ""
 
@@ -1031,6 +1031,20 @@ msgstr ""
 msgid ""
 "Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat "
 "aquestes dades)."
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:38
+#, python-format
+msgid ""
+"El consum mitjà de la teva zona (CP %s) durant l'últim mes ha estat de "
+"<b>%s</b> kWh."
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:40
+#, python-format
+msgid ""
+"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s)"
+" de l’últim mes."
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:7

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako
@@ -35,9 +35,9 @@ var esgran = ${energy.is_big and 'true' or 'false'}
             % endif
             % if energy.show_mean_zipcode_consumption:
                 % if energy.mean_zipcode_consumption:
-                    ${(_(u"El consum mitjà de la teva zona (CP %s) durant l’últim mes ha estat de <b>%s</b> kWh.") % (energy.zipcode, formatLang(energy.mean_zipcode_consumption, digits=2)))} <br />
+                    ${(_(u"El consum mitjà de la teva zona (CP %s) durant l'últim mes ha estat de <b>%s</b> kWh.") % (energy.zipcode, formatLang(energy.mean_zipcode_consumption, digits=2)))} <br />
                 % else:
-                    ${(_(u"La teva empresa distribuïdora no ha facilitat el consum mitjà de la teva zona (CP %s) durant l’últim mes.") % (energy.zipcode))} <br />
+                    ${(_(u"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s) de l’últim mes.") % (energy.distri_name, energy.zipcode))} <br />
                 % endif
             % endif
         </p>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako
@@ -30,7 +30,14 @@ var esgran = ${energy.is_big and 'true' or 'false'}
                     ${(_(u"La potència màxima que has fet servir en el període que va del %s fins al %s és de: Punta: <b><i>%s</i></b> kW - Vall: <b><i>%s</i></b> kW (últimes dades rebudes per l’empresa distribuïdora)")
                     % (energy.max_requested_powers[0]['data_inici'], energy.max_requested_powers[0]['data_final'], pot_p1, pot_p2))}  <br />
                 % else:
-                    ${_("Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat aquestes dades).") % (energy.distri_name)}
+                    ${_("Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat aquestes dades).") % (energy.distri_name)} <br />
+                % endif
+            % endif
+            % if energy.show_mean_zipcode_consumption:
+                % if energy.mean_zipcode_consumption:
+                    ${(_(u"El consum mitjà de la teva zona (CP %s) durant l’últim mes ha estat de <b>%s</b> kWh.") % (energy.zipcode, formatLang(energy.mean_zipcode_consumption, digits=0)))} <br />
+                % else:
+                    ${(_(u"La teva empresa distribuïdora no ha facilitat el consum mitjà de la teva zona (CP %s) durant l’últim mes.") % (energy.zipcode))} <br />
                 % endif
             % endif
         </p>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako
@@ -35,7 +35,7 @@ var esgran = ${energy.is_big and 'true' or 'false'}
             % endif
             % if energy.show_mean_zipcode_consumption:
                 % if energy.mean_zipcode_consumption:
-                    ${(_(u"El consum mitjà de la teva zona (CP %s) durant l’últim mes ha estat de <b>%s</b> kWh.") % (energy.zipcode, formatLang(energy.mean_zipcode_consumption, digits=0)))} <br />
+                    ${(_(u"El consum mitjà de la teva zona (CP %s) durant l’últim mes ha estat de <b>%s</b> kWh.") % (energy.zipcode, formatLang(energy.mean_zipcode_consumption, digits=2)))} <br />
                 % else:
                     ${(_(u"La teva empresa distribuïdora no ha facilitat el consum mitjà de la teva zona (CP %s) durant l’últim mes.") % (energy.zipcode))} <br />
                 % endif


### PR DESCRIPTION
## Objectiu

Afegir el consum mitjà per codi postal a la factura en pdf segons RDL 18/2022

## Targeta on es demana o Incidència 

https://trello.com/c/VMD1un0k/5541-0-2-p16-testeig-i-posar-a-productiu-modificar-pdf-per-aplicaci%C3%B3-real-decreto-ley-18-2022-de-18-de-octubre-part-2-3

## Comportament antic

No es mostrava la informació

## Comportament nou

Es mostra el consum mitja si n'hi ha

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [x] Modifica traduccions
