### PR TITLE
Bug no poder eliminar un termini de pagament

### DIFF
--- a/account_account_som/account_payment_term.py
+++ b/account_account_som/account_payment_term.py
@@ -24,3 +24,18 @@ class AccountPaymentTerm(osv.osv):
         return True
 
 AccountPaymentTerm()
+
+
+class AccountPaymentTermLine(osv.osv):
+    _name = "account.payment.term.line"
+    _inherit = "account.payment.term.line"
+
+    _columns = {
+        'payment_id': fields.many2one('account.payment.term', 'Payment Term', required=True, select=True, ondelete='cascade'),
+    }
+
+    _defaults = {
+        'days': lambda *a: 0,
+    }
+ 
+AccountPaymentTermLine()

--- a/account_account_som/account_payment_term.py
+++ b/account_account_som/account_payment_term.py
@@ -13,11 +13,14 @@ class AccountPaymentTerm(osv.osv):
         result = self.browse(cr, uid, id)
         if not result.line_ids:
             raise osv.except_osv(_("Falta dia de pagament!"), _("Els terminis de pagament han de tenir almenys un dia definit."))
+        return id
 
     def write(self, cr, uid, ids, vals, context=None):
         super(AccountPaymentTerm, self).write(cr, uid, ids, vals, context=context)
-        result = self.browse(cr, uid, id)
-        if not result.line_ids:
-            raise osv.except_osv(_("Falta dia de pagament!"), _("Els terminis de pagament han de tenir almenys un dia definit."))
+        for _id in ids:
+            result = self.browse(cr, uid, _id)
+            if not result.line_ids:
+                raise osv.except_osv(_("Falta dia de pagament!"), _("Els terminis de pagament han de tenir almenys un dia definit."))
+        return True
 
 AccountPaymentTerm()


### PR DESCRIPTION
## Objectiu
Arrreglar el bug introduit en la PR https://github.com/Som-Energia/openerp_som_addons/pull/267 que evitava que es pogués eliminar un termini de pagament. També facilitar la creació de terminis de pagament amb el default de dia de pagament.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/1347799277/7100531/
https://sentry.somenergia.coop/organizations/som-energia/issues/127319/?project=11&query=is%3Aunresolved+%21logger%3Aopenerp.web-services

## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
