### PR TITLE
Script per reimportar resultats incorrectes dels crawlers que tinguin adjunts baixats

### DIFF
--- a/scripts/reimport_som_crawlers_zips.py
+++ b/scripts/reimport_som_crawlers_zips.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+import dbconfig
+from erppeek import Client
+
+"""_summary_
+Reimporta fitxers ZIPs trobats en Resultats de som_crawlers que han acabat amb Failed
+Aquest script s'ha d'executar després de la pimera onada de crawlers (7 hores)
+"""
+
+O = Client(**dbconfig.erppeek)
+
+
+# Obtenir la llista de resultats a tractar
+craw_ids = O.SomCrawlersTask.search([('resultat_bool','=',False)])
+
+total_crawlers = 0
+total_reintents = 0
+total_correctes = 0
+
+for craw_id in craw_ids:
+    attachment = []
+    craw = O.SomCrawlersTask.browse(craw_id)
+    if craw.run_ids:
+        last_result = craw.run_ids[0]
+        attachment_ids = O.IrAttachment.search([
+            ('res_id', '=', last_result.id),
+            ('name', 'ilike', '.zip'),
+        ])
+        if not attachment_ids:
+            continue
+        total_crawlers += 1
+        total_reintents += len(attachment_ids)
+        # Reimportar xml
+        result = True
+        output = "[{} REIMPORTACIONS]:\n\n".format(total_reintents)
+        for attachment_id in attachment_ids:
+            attachment = O.IrAttachment.browse(attachment_id)
+            try:
+                output += craw.task_step_ids[-1].import_wizard(attachment.name, attachment.datas)
+            except Exception as e:
+                output += "Error carregant el fitxer {}: {} \n".format(attachment.name, str(e))
+                result = False
+            else:
+                total_correctes += 1
+
+        output  += "\n{} reimportats correctament".format(total_correctes)
+        # Afegir nou resultat al crawler
+        O.SomCrawlersResult.create({'task_id': craw_id,
+            'data_i_hora_execucio': datetime.now().strftime("%Y-%m-%d_%H:%M"),
+            'resultat_bool': result,
+            'resultat_text': output,
+        })
+
+print """
+    Hem trobat {} crawlers per reimportar.
+     S'han intentat reimportat {} fitxers.
+     S'han reimportat correctament {} fitxers.""".format(total_crawlers, total_reintents, total_correctes)

--- a/scripts/run_all_som_crawlers_tasks.py
+++ b/scripts/run_all_som_crawlers_tasks.py
@@ -1,0 +1,14 @@
+from erppeek import Client
+import dbconfig;
+
+"""_summary_
+Executa tots les tasques actives de som_crawlers sobrescrivint el 'days_of_margin' (tasques d'importació)
+"""
+
+DAYS_OF_MARGIN = 15
+
+O = Client(**dbconfig.erppeek)
+
+active_ids = O.SomCrawlersTask.search() # TODO: Just imports, not exports
+wiz = O.WizardExecutarTasca.create({})
+wiz.executar_tasca(context={'active_ids': active_ids, 'days_of_margin': DAYS_OF_MARGIN})

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -201,7 +201,7 @@ class SomCrawlersTaskStep(osv.osv):
                     att = attachment_obj.browse(cursor, uid, attachment_id)
                     content = att.datas
                     file_name = att.name
-                output = self.import_wizard(cursor, uid, file_name, content)
+                output = self.import_wizard(cursor, uid, id, file_name, content)
             except (TypeError, CorruptGridFile, NoFile) as e:
                 sleep(100)
                 output = self.import_xml_files(
@@ -309,7 +309,7 @@ class SomCrawlersTaskStep(osv.osv):
 
         return output
 
-    def import_wizard(self, cursor, uid, file_name, file_content):
+    def import_wizard(self, cursor, uid, id, file_name, file_content):
         if file_name.endswith('.zip'):
             values = {'filename': file_name, 'file': file_content}
             WizardImportAtrF1 = self.pool.get('wizard.import.atr.and.f1')

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -148,6 +148,8 @@ class SomCrawlersTaskStep(osv.osv):
                     datetime.now().strftime("%Y-%m-%d_%H_%M_%S_%f") + ".txt"
                 args_str = self.create_script_args(
                     config_obj, task_step_params, file_name)
+                if 'days_of_margin' in context:
+                    args_str['-d'] = str(context['days_of_margin'])
                 os.system("{} {} {}".format(
                     path_python, script_path, args_str))
                 output_path = self.get_output_path(cursor, uid)

--- a/som_crawlers/tests/wizard_executar_tasca_tests.py
+++ b/som_crawlers/tests/wizard_executar_tasca_tests.py
@@ -90,12 +90,12 @@ class WizardExecutarTascaTests(testing.OOTestCase):
                 cursor = txn.cursor
                 uid = txn.user
                 crawler_task_step_id = self.Data.get_object_reference(cursor, uid, 'som_crawlers', 'demo_taskStep_6')[1]
-                #try test
                 result_id = self.Data.get_object_reference(cursor, uid, 'som_crawlers', 'demo_result_2')[1]
+                #try test
                 with self.assertRaises(Exception) as context:
                     self.taskStep.import_xml_files(cursor, uid, crawler_task_step_id, result_id)
                 #check result
-                self.assertTrue('don\'t exist id attachment' in context.exception)
+                self.assertTrue("Don't exist attachment ID" in context.exception.message)
 
 
     def no_test_import_xml_files_entrada_zip_prova_sortida_import_donee(self):


### PR DESCRIPTION
## Objectiu

Script per reimportar resultats incorrectes dels crawlers que tinguin adjunts baixats


## Targeta on es demana o Incidència 
https://trello.com/c/lsDWiIaG/5573-0-8-p15-ep259-get-somcrawlers-escombrada-df1s

## Comportament antic
S'havien de reimportar a mà

## Comportament nou
Es reimporten automàticament després de passar els crawlers

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
