### PR TITLE
Add comment to invoice when email and SMS are sent

### DIFF
--- a/som_account_invoice_pending/tests/update_pending_states_tests.py
+++ b/som_account_invoice_pending/tests/update_pending_states_tests.py
@@ -830,4 +830,5 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
         factura = fact_obj.browse(cursor, uid, self.invoice_1_id)
         self.assertEqual(mock_mail.call_count, 1)
         self.assertEqual(mock_sms.call_count, 1)
+        self.assertIn("(auto.): Enviat correu previ advocats + SMS.", factura.comment)
         self.assertEqual(factura.pending_state.id, self.traspas_advocats_dp)

--- a/som_account_invoice_pending/update_pending_states.py
+++ b/som_account_invoice_pending/update_pending_states.py
@@ -592,6 +592,14 @@ class UpdatePendingStates(osv.osv_memory):
                     self.send_sms(cursor, uid, factura_id, sms_template_id, current_state_id, context)
                 except Exception as e:
                     raise SMSException(e)
+                else:
+                    factura = fact_obj.browse(cursor, uid, factura_id)
+                    old_comment = factura.comment if factura.comment else ''
+                    new_comment = '{} (auto.): Enviat correu previ advocats + SMS.\n'.format(
+                        datetime.now().strftime("%Y-%m-%d"))
+                    fact_obj.write(cursor, uid, factura_id, {
+                                   'comment': new_comment + old_comment})
+
 
                 fact_obj.set_pending(cursor, uid, [factura_id], next_state)
                 logger.info(


### PR DESCRIPTION
## Objectiu
Afegir una línia a la informació addicional de la factura quan s'enviï el correu i l'SMS "previ advocats". Facilita saber que s'ha fet aquest enviament.

## Targeta on es demana o Incidència
https://trello.com/c/MPvKgaDX/5577-0-1-p16-nota-other-info-correu-i-sms-previ-advocats

## Comportament antic
No hi havia una manera ràpida de saber si s'havia enviat l'SMS i el correu.

## Comportament nou
S'afegeix una línia a "Informació addicional" que ens permet veure-ho fàcilment.

## Comprovacions
- [X] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
