### PR TITLE
Asignar grupo de pago por defecto cuando se modifica el titular de la póliza.

### DIFF
--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -342,6 +342,27 @@ class GiscedataPolissa(osv.osv):
 
         return res
 
+    def wkf_activa(self, cursor, uid, ids):
+        if not isinstance(ids, list):
+            ids = [ids]
+
+        payment_mode_o = self.pool.get('payment.mode')
+        payment_mode_id = payment_mode_o.search(cursor, uid, [('name', '=', 'ENGINYERS')])
+        self.write(cursor, uid, ids, {'payment_mode_id': payment_mode_id[0]})
+
+        return super(GiscedataPolissa, self).wkf_activa(cursor, uid, ids)
+
+    def copy_data(self, cursor, uid, id, default=None, context=None):
+        if context is None:
+            context = {}
+
+        if default is None:
+            default = {}
+
+        payment_mode_o = self.pool.get('payment.mode')
+        payment_mode_id = payment_mode_o.search(cursor, uid, [('name', '=', 'ENGINYERS')])
+        default.update({'payment_mode_id': payment_mode_id[0]})
+        return super(GiscedataPolissa, self).copy_data(cursor, uid, id, default, context=context)
 
     _columns = {
         'info_gestio_endarrerida': fields.text('Informació gestió endarrerida'),

--- a/som_switching/giscedata_switching_helpers.py
+++ b/som_switching/giscedata_switching_helpers.py
@@ -9,6 +9,19 @@ class GiscedataSwitchingHelpers(osv.osv):
     _name = 'giscedata.switching.helpers'
     _inherit = 'giscedata.switching.helpers'
 
+    def activar_polissa_from_m1_canvi_titular_subrogacio(self, cursor, uid, sw_id, context=None):
+        res = super(GiscedataSwitchingHelpers, self).activar_polissa_from_m1_canvi_titular_subrogacio(
+            cursor, uid, sw_id, context=context
+        )
+
+        sw_obj = self.pool.get('giscedata.switching')
+        payment_mode_o = self.pool.get('payment.mode')
+        payment_mode_id = payment_mode_o.search(cursor, uid, [('name', '=', 'ENGINYERS')])
+        sw = sw_obj.browse(cursor, uid, sw_id, context=context)
+        sw.cups_polissa_id.write({'payment_mode_id': payment_mode_id[0]})
+
+        return res
+
     def tancar_reclamacio_cac(self, cursor, uid, sw_id, context=None):
         """
         Quan  s'importa o activa un R1-05 que:


### PR DESCRIPTION
## Objectiu

Asignar por defecto el grupo de pago ENGINYERS al copiar una póliza o al cambiar de titular por subrogación.

## Targeta on es demana o Incidència 
https://trello.com/c/IspdKAn6/5594-0-0-p12-no-copiar-grup-de-pagament-en-canvis-de-titular

## Comportament nou
En copiar-se una pòlissa per traspàs o fer una modcon per subrogació es posa per defecte el grup de pagament a ENGINYERS

## Comprovacions

- [ ] Reiniciar serveis