### PR TITLE
Fix Error de càlcul al pdf de factura a l'energia total consumida les últims 12 mesos

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -507,6 +507,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     f.data_inici >= date_trunc('month', date %(data_final)s) - interval '%(interval)s month'
                     AND (fl.isdiscount IS NULL OR NOT fl.isdiscount)
                     AND i.type IN ('out_invoice','out_refund')
+                    AND pt.name like 'P%%'
             GROUP BY
                     f.polissa_id, pt.name, f.data_inici
             ORDER BY f.data_inici DESC ) AS consums

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1962,7 +1962,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             lines_data[block]['data'] = data_desde
             lines_data[block]['days'] = (datetime.strptime(l.data_fins,'%Y-%m-%d') - datetime.strptime(l.data_desde,'%Y-%m-%d')).days + 1
             lines_data[block]['date_from'] = dateformat(l.data_desde)
-            lines_data[block]['date_to'] = dateformat(l.data_fins)
+            lines_data[block]['date_to_d'] = val(l.data_fins) if 'date_to_d' not in lines_data[block] or lines_data[block]['date_to_d'] < val(l.data_fins) else lines_data[block]['date_to_d']
+            lines_data[block]['date_to'] = dateformat(lines_data[block]['date_to_d'])
 
         lines_data = [lines_data[k] for k in sorted(lines_data.keys())]
         return lines_data

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -1634,6 +1634,7 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                 'days': 30,
                 'date_from': '01/06/2021',
                 'date_to': '30/06/2021',
+                'date_to_d': '2021-06-30',
             }])
 
     @mock.patch.object(giscedata_facturacio_report, 'is_2XTD')
@@ -1728,6 +1729,7 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         'days': 31,
                         'date_from': '01/05/2021',
                         'date_to': '31/05/2021',
+                        'date_to_d': '2021-05-31',
                     },{
                         'P1': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
                         'P2': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
@@ -1739,6 +1741,209 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         'days': 30,
                         'date_from': '01/06/2021',
                         'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
+                    },
+                ],
+            })
+
+    @mock.patch.object(giscedata_facturacio_report, 'is_2XTD')
+    @mock.patch.object(giscedata_facturacio_report.GiscedataFacturacioFacturaReport, 'get_atr_price')
+    def test__get_sub_component_invoice_details_td_data_4_power_lines_2_periods_2_blocks_incomplete(self, get_atr_price_mock_function, is_2XTD_mock_function):
+        get_atr_price_mock_function.return_value = 10.0
+        is_2XTD_mock_function.return_value = True
+
+        f_id = self.get_fixture('giscedata_facturacio', 'factura_0001')
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P1',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'extra': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 0,
+                'account_id': 1,
+                'data_desde': '2021-05-01',
+                'data_fins': '2021-05-31'
+            })
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P2',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'extra': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 0,
+                'account_id': 1,
+                'data_desde': '2021-05-01',
+                'data_fins': '2021-06-30'
+            })
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P1',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 1,
+                'account_id': 1,
+                'data_desde': '2021-06-01',
+                'data_fins': '2021-06-30'
+            })
+
+        result = self.r_obj.get_sub_component_invoice_details_td_power_data(**self.bfp(f_id))
+
+        self.assertYamlfy(result)
+        self.assertEquals(result, {
+            'header_multi': 6,
+            'showing_periods': ['P1', 'P2', 'P3'],
+            'power_lines_data': [
+                    {
+                        'P1': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'P2': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'multi': 1.0,
+                        'days_per_year': 365,
+                        'total': 2.0,
+                        'origin': 'sense lectura',
+                        'data': '2021-05-01',
+                        'days': 61,
+                        'date_from': '01/05/2021',
+                        'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
+                    },{
+                        'P1': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'multi': 1.0,
+                        'days_per_year': 365,
+                        'total': 1.0,
+                        'origin': 'sense lectura',
+                        'data': '2021-06-01',
+                        'days': 30,
+                        'date_from': '01/06/2021',
+                        'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
+                    },
+                ],
+            })
+
+    @mock.patch.object(giscedata_facturacio_report, 'is_2XTD')
+    @mock.patch.object(giscedata_facturacio_report.GiscedataFacturacioFacturaReport, 'get_atr_price')
+    def test__get_sub_component_invoice_details_td_data_4_power_lines_3_periods_2_blocks_incomplete(self, get_atr_price_mock_function, is_2XTD_mock_function):
+        get_atr_price_mock_function.return_value = 10.0
+        is_2XTD_mock_function.return_value = True
+
+        f_id = self.get_fixture('giscedata_facturacio', 'factura_0001')
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P1',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'extra': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 0,
+                'account_id': 1,
+                'data_desde': '2021-05-01',
+                'data_fins': '2021-05-31'
+            })
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P2',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'extra': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 0,
+                'account_id': 1,
+                'data_desde': '2021-05-01',
+                'data_fins': '2021-06-30'
+            })
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P3',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'extra': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 0,
+                'account_id': 1,
+                'data_desde': '2021-05-01',
+                'data_fins': '2021-06-30'
+            })
+
+        self.linia_f_obj.create(self.cursor, self.uid,
+            {
+                'name': 'P1',
+                'quantity': 1.0,
+                'price_subtotal': 10.0,
+                'price_unit_multi': 1,
+                'price_unit': 1,
+                'multi': 1,
+                'factura_id': f_id,
+                'tipus': 'potencia',
+                'product_id': 1,
+                'account_id': 1,
+                'data_desde': '2021-06-01',
+                'data_fins': '2021-06-30'
+            })
+
+        result = self.r_obj.get_sub_component_invoice_details_td_power_data(**self.bfp(f_id))
+
+        self.assertYamlfy(result)
+        self.assertEquals(result, {
+            'header_multi': 6,
+            'showing_periods': ['P1', 'P2', 'P3'],
+            'power_lines_data': [
+                    {
+                        'P1': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'P2': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'P3': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'multi': 1.0,
+                        'days_per_year': 365,
+                        'total': 3.0,
+                        'origin': 'sense lectura',
+                        'data': '2021-05-01',
+                        'days': 61,
+                        'date_from': '01/05/2021',
+                        'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
+                    },{
+                        'P1': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
+                        'multi': 1.0,
+                        'days_per_year': 365,
+                        'total': 1.0,
+                        'origin': 'sense lectura',
+                        'data': '2021-06-01',
+                        'days': 30,
+                        'date_from': '01/06/2021',
+                        'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
                     },
                 ],
             })
@@ -1869,6 +2074,7 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         'days': 30,
                         'date_from': '01/06/2021',
                         'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
                     },
                 ],
             })
@@ -2101,6 +2307,7 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         'days': 30,
                         'date_from': '01/05/2021',
                         'date_to': '30/05/2021',
+                        'date_to_d': '2021-05-30',
                     },{
                         'P1': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
                         'P2': {'extra': 1.0, 'price_unit': 1.0, 'price_subtotal': 1.0, 'price_unit_multi': 1.0, 'atr_price': 10.0, 'quantity': 1.0},
@@ -2116,6 +2323,7 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         'days': 30,
                         'date_from': '01/06/2021',
                         'date_to': '30/06/2021',
+                        'date_to_d': '2021-06-30',
                     },
                 ],
             })


### PR DESCRIPTION
## Objectiu

El càlcul de l'energia total consumida a l'any surt malament a la factura en pdf

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2134756504/14119771?folderId=3063409
https://secure.helpscout.net/conversation/2129795517/14097235?folderId=3063409

## Comportament antic

Barreja els consums de P1, P2, P3, P4, P5 i P6 amb els procedents de les línies d'ajust del Mag
 
## Comportament nou

Filtra les línies del mag deixant només P1, P2, P3, P4, P5 i P6

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
