### PR TITLE
Fix waiting for annex cancelled contracts

### DIFF
--- a/som_account_invoice_pending/update_pending_states.py
+++ b/som_account_invoice_pending/update_pending_states.py
@@ -775,6 +775,6 @@ class UpdatePendingStates(osv.osv_memory):
                         if 'Bo Social' in process_name:
                             self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id, traspas_advocats_bs, context)
                         self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id, traspas_advocats_dp, context)
-                    fact_obj.set_pending(cursor, uid, fact_id, waiting_notif_id)
+                    fact_obj.set_pending(cursor, uid, [fact_id], waiting_notif_id)
 
 UpdatePendingStates()

--- a/som_account_invoice_pending/update_pending_states.py
+++ b/som_account_invoice_pending/update_pending_states.py
@@ -769,8 +769,8 @@ class UpdatePendingStates(osv.osv_memory):
             if len(inv_list) >= 2:
                 for invoice_id in inv_list:
                     inv_number = inv_obj.browse(cursor, uid, invoice_id).number
-                    fact_id = fact_obj.search(cursor, uid, [('number', '=', inv_number)])
-                    polissa = fact_obj.browse(cursor, uid, fact_id[0]).polissa_id
+                    fact_id = fact_obj.search(cursor, uid, [('number', '=', inv_number)])[0]
+                    polissa = fact_obj.browse(cursor, uid, fact_id).polissa_id
                     if polissa.state == 'baixa':
                         if 'Bo Social' in process_name:
                             self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id, traspas_advocats_bs, context)

--- a/som_account_invoice_pending/update_pending_states.py
+++ b/som_account_invoice_pending/update_pending_states.py
@@ -768,13 +768,13 @@ class UpdatePendingStates(osv.osv_memory):
                                                     ('pending_state.weight', '>', correct_weight)])
             if len(inv_list) >= 2:
                 for invoice_id in inv_list:
-                    inv_number = inv_obj.browse(cursor, uid, invoice_id).number
-                    fact_id = fact_obj.search(cursor, uid, [('number', '=', inv_number)])[0]
-                    polissa = fact_obj.browse(cursor, uid, fact_id).polissa_id
+                    inv_number = inv_obj.browse(cursor, uid, invoice_id).number #quan es fan testos és False perquè les factures de destral no tene number
+                    fact_id = fact_obj.search(cursor, uid, [('number', '=', inv_number)])
+                    polissa = fact_obj.browse(cursor, uid, fact_id[0]).polissa_id
                     if polissa.state == 'baixa':
                         if 'Bo Social' in process_name:
-                            self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id, traspas_advocats_bs, context)
-                        self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id, traspas_advocats_dp, context)
-                    fact_obj.set_pending(cursor, uid, [fact_id], waiting_notif_id)
+                            self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id[0], traspas_advocats_bs, context)
+                        self.update_waiting_for_annex_cancelled_contracts(cursor, uid, fact_id[0], traspas_advocats_dp, context)
+                    fact_obj.set_pending(cursor, uid, fact_id, waiting_notif_id)
 
 UpdatePendingStates()


### PR DESCRIPTION
## Objectiu
Que es pugui executar el canvi d'estats pendents

## Targeta on es demana o Incidència 
https://sentry.somenergia.coop/organizations/som-energia/issues/127504/events/fb5a01201ec34c55808e17618de97b67/?project=11&query=is%3Aunresolved

## Comportament antic
Petava current_state_id = fact_obj.read(cursor, uid, factura_id, ['pending_state'])['pending_state'][0] perquè factura_id era una llista

## Comportament nou
No peta

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
