### PR TITLE
Add conditional to not schedule next execution in some cases

### DIFF
--- a/som_crawlers/models/som_crawlers_task.py
+++ b/som_crawlers/models/som_crawlers_task.py
@@ -128,7 +128,8 @@ class SomCrawlersTask(osv.osv):
                               'resultat_text': output
                           })
 
-        self.schedule_next_execution(cursor, uid, id, context)
+        if resultat_correcte or "[S'ha fet click a descarregar: True]" in output:
+            self.schedule_next_execution(cursor, uid, id, context)
 
     def schedule_next_execution(self, cursor, uid, id, context=None):
         ir_obj = self.pool.get('ir.model.data')


### PR DESCRIPTION
## Objectiu
No assignar data de pròxima execució quan un `crawlers` ha fallat i no s'ha apretat a descarregar. Això farà que el següent `cron` el torni a executar.

## Targeta on es demana o Incidència 
https://trello.com/c/6NrjZLRm/5623-0-6-import-massiva-avan%C3%A7ar-la-data-dexecuci%C3%B3-quan-sha-fet-click-a-desc%C3%A0rregar-ep259-m

## Comportament antic
Sempre s'assignava data de pròxima exeució.

## Comportament nou
No s'assigna data de pròxima execució quan un `crawlers` ha fallat i no s'ha apretat a descarregar.

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
