### PR TITLE
Afegir les columnes d'excedents de generació per tipus al informe de factures desagregades

### DIFF
--- a/som_facturacio_comer/wizard/wizard_informe_factures_dades_desagregades.py
+++ b/som_facturacio_comer/wizard/wizard_informe_factures_dades_desagregades.py
@@ -62,7 +62,7 @@ class WizardInformeDadesDesagregades(osv.osv_memory):
         for pol_id in pol_ids:
             pol = pol_obj.browse(cursor, uid, pol_id)
             subitem = OrderedDict([('Contracte', pol.name), ('Tarifa Comercialitzadora', pol.llista_preu.name if pol.llista_preu else ''), ('Indexada', 'Indexada' if pol.llista_preu and 'indexada' in pol.llista_preu.name.lower(
-            ) else 'No'), ('Energia activa', 0), ('MAG', 0), ('Penalització reactiva', 0), ('Potència', 0), ('Excés potència', 0), ('Excedents', 0), ('Lloguer comptador', 0), ('IVA', 0), ('IGIC', 0), ('IESE', 0), ('Altres', 0), ('TOTAL', 0)])
+            ) else 'No'), ('Energia activa', 0), ('MAG', 0), ('Penalització reactiva', 0), ('Potència', 0), ('Excés potència', 0), ('Excedents', 0), ('Excedents generats totals', 0),('Excedents saldo compensació', 0), ('Lloguer comptador', 0), ('IVA', 0), ('IGIC', 0), ('IESE', 0), ('Altres', 0), ('TOTAL', 0)])
             items[pol_id] = subitem
 
         fact_ids = fact_obj.search(cursor, uid, [('polissa_id.id', 'in', pol_ids), ('data_inici', '>=', from_date), ('data_final', '<=', to_date),
@@ -82,6 +82,12 @@ class WizardInformeDadesDesagregades(osv.osv_memory):
             pol_item['Potència'] += fact.total_potencia * factor
             pol_item['Excés potència'] += fact.total_exces_potencia * factor
             pol_item['Excedents'] += fact.total_generacio * factor
+            for line in fact.linies_generacio:
+                if 'Saldo excedentes de autoconsumo' in line:
+                    pol_item['Excedents saldo compensació'] += line.price_subtotal * factor
+                else:
+                    pol_item['Excedents generats totals'] += line.price_subtotal * factor
+
             pol_item['Lloguer comptador'] += fact.total_lloguers * factor
             for tax_line in fact.tax_line:
                 if 'IVA' in tax_line.name:

--- a/som_facturacio_comer/wizard/wizard_informe_factures_dades_desagregades.py
+++ b/som_facturacio_comer/wizard/wizard_informe_factures_dades_desagregades.py
@@ -83,7 +83,7 @@ class WizardInformeDadesDesagregades(osv.osv_memory):
             pol_item['Excés potència'] += fact.total_exces_potencia * factor
             pol_item['Excedents'] += fact.total_generacio * factor
             for line in fact.linies_generacio:
-                if 'Saldo excedentes de autoconsumo' in line:
+                if 'Saldo excedentes de autoconsumo' in line.name:
                     pol_item['Excedents saldo compensació'] += line.price_subtotal * factor
                 else:
                     pol_item['Excedents generats totals'] += line.price_subtotal * factor


### PR DESCRIPTION
## Objectiu

Mostrar les columnes per excedents totals i compensats a l'informe de factures desagregades

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2098625739/13901223?folderId=3063374

## Comportament antic

No teniem les dades

## Comportament nou

tenim les dades

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
