### PR TITLE
mostrar els camps de cerca per autoconsum pòlissa i tarifa al al vista de llista de "fitxers F1 importats"

### DIFF
--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml
@@ -7,12 +7,12 @@
             <field name="inherit_id" ref="giscedata_facturacio_switching.view_importacio_linia_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='fecha_factura_hasta']" position="after">
-                    <field name="tarifa_atr"/>
-                    <field name="tipus_autoconsum"/>
+                    <field name="tarifa_atr" select="2" />
+                    <field name="tipus_autoconsum"  select="2"/>
                 </xpath>
                 <xpath expr="//field[@name='type_factura']" position="after">
                     <group attrs="{'invisible': [('type_factura', 'not in', ['R','A'])]}" colspan="4" col="4">
-                        <field name="codi_rectificada_anulada"/>
+                        <field name="codi_rectificada_anulada" select="2"/>
                     </group>
                     <group attrs="{'invisible': [('type_factura', 'not in', ['C'])]}" colspan="4" col="4">
                         <field name="num_expedient"/>
@@ -20,7 +20,7 @@
                     </group>
                 </xpath>
                 <xpath expr="//field[@name='liniafactura_id']" position="before">
-                    <field name="polissa_id"/>
+                    <field name="polissa_id" select="2"/>
                     <field name="data_ultima_lectura_polissa"/>
                 </xpath>
             </field>
@@ -31,11 +31,11 @@
             <field name="inherit_id" ref="giscedata_facturacio_switching.view_importacio_linia_general_tree"/>
             <field name="arch" type="xml">
                 <field name="tipo_factura_f1" position="after">
-                    <field name="codi_rectificada_anulada" select="2"/>
-                    <field name="tipus_autoconsum" select="2"/>
-                    <field name="tarifa_atr" select="2"/>
+                    <field name="codi_rectificada_anulada"/>
+                    <field name="tipus_autoconsum"/>
+                    <field name="tarifa_atr"/>
                     <field name="data_ultima_lectura_polissa"/>
-                    <field name="polissa_id" select="2"/>
+                    <field name="polissa_id"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
## Objectiu

Mostrar les camps de cerca de la vista de llista, nota, les select a la definició del tree sonignorats per l'erp, s'han de posar a la definició del form.

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2136758466/14136618?folderId=3063374

## Comportament antic

no es mostren els camps de cerca

## Comportament nou

es mostren els camps de cerca

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
         -som_facturacio_switching o carregar el xml de de l'assistent
- [ ] Script de migració
- [ ] Modifica traduccions
