### PR TITLE
arreglar el total d'energia de la factura en pdf al resum

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1672,7 +1672,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         total_altres += total_extra
 
-        total_energia = fact.total_energia - total_extra
+        total_energia = sum([l.price_subtotal for l in fact.linies_energia])
+        total_energia = total_energia - total_extra
 
         data = {
             'total_exces_consumida': total_exces_consumida,


### PR DESCRIPTION
## Objectiu

Mostrar la dada correcta de € per la part d'energia al resum de la factura al pdf de la factura quan es tracta de factures amb generation kwh i mag per l'error del camp calculat total_energia (stored) de la factura mentre no s'arregla via la pr https://github.com/gisce/erp/pull/15723

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2113034573/13992164?folderId=3063374

## Comportament antic

Es mostra una dada de total_energia incorrecta

## Comportament nou

Es calcula la dada en comptes de utilitzar el camp calculat stored

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
