### PR TITLE
Enviaments massius, fer requrit el camp raó al wizard de cancelar des de csv

### DIFF
--- a/som_infoenergia/wizard/wizard_cancel_from_csv.py
+++ b/som_infoenergia/wizard/wizard_cancel_from_csv.py
@@ -18,7 +18,7 @@ class WizardCancelFromCSV(osv.osv_memory):
         'name': fields.char('Filename', size=256),
         'csv_file': fields.binary('CSV File', required=True, help=_(u"Número de pòlissa de les pòlisses de les quals se'n vol cancel·lar l'enviament")),
         'state': fields.selection(STATES, _(u'Estat del wizard de cancelar enviaments des de CSV')),
-        'reason': fields.text(_('Comentari'), size=256),
+        'reason': fields.text(_('Comentari'), size=256, required=True),
     }
     _defaults = {
         'state': 'init',


### PR DESCRIPTION
## Objectiu

Protegir el wizard de cancel·lar des de csv per evitar que puguin cancel·lar sense raó i evitar que el codi (que dona per fet que raó te valor) doni error.

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2151086551/14202714?folderId=3063374

## Comportament antic

Al intentar cancel·lar sense posar una raó donava error

## Comportament nou

No permet continuar sense una raó

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
