### PR TITLE
Afegir la columna de polissa a la vista de comptadors

### DIFF
--- a/som_facturacio_comer/giscedata_lectures_view.xml
+++ b/som_facturacio_comer/giscedata_lectures_view.xml
@@ -12,5 +12,16 @@
                 </field>
             </field>
         </record>
+        <record model="ir.ui.view" id="view_giscedata_lectures_comptador_tree">
+            <field name="name">giscedata.lectures.comptador.tree</field>
+            <field name="model">giscedata.lectures.comptador</field>
+            <field name="inherit_id" ref="giscedata_lectures.view_giscedata_lectures_comptador_tree" />
+            <field name="type">tree</field>
+            <field name="arch" type="xml">
+                    <field name="meter_type" position="after">
+                        <field name="polissa"/>
+                    </field>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu

Afegir la pòlissa a la vista de comptadors de la pòlissa (redundant?) permet accedir a una sèrie de menus d'un sol click.

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2098591988/13901202?folderId=3063374

## Comportament antic

no es mostrava

## Comportament nou

es mostra

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
        som_facturacio_comer
- [ ] Script de migració
- [ ] Modifica traduccions
