### PR TITLE
Canviar la formula de les condicions particulars de PA a PTD

### DIFF
--- a/som_polissa_condicions_generals/i18n/es_ES.po
+++ b/som_polissa_condicions_generals/i18n/es_ES.po
@@ -4,19 +4,19 @@
 # 
 # Translators:
 #   <>, 2019, 2020.
-# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022.
+# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022, 2023.
 msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2022-08-26 11:36+0000\n"
-"PO-Revision-Date: 2022-08-26 09:38+0000\n"
+"POT-Creation-Date: 2023-02-15 17:24+0000\n"
+"PO-Revision-Date: 2023-02-15 16:29+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.9.1\n"
 "Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -46,7 +46,7 @@ msgstr "Este módulo añade las siguientes funcionalidades:\n    * Condiciones g
 #. module: som_polissa_condicions_generals
 #: model:account.fiscal.position,name:som_polissa_condicions_generals.fp_iva_reduit
 msgid "IVA Reduït (IVA 5%)"
-msgstr ""
+msgstr "IVA Reducido (IVA 5%)"
 
 #: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:17
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:11
@@ -430,8 +430,8 @@ msgid "Tipus de contracte: "
 msgstr "Tipo de contrato: "
 
 #: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:251
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:386
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:451
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:403
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:468
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:379
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:463
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:527
@@ -439,8 +439,8 @@ msgid "Punta"
 msgstr "Punta"
 
 #: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:253
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:388
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:453
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:405
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:470
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:381
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:465
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:529
@@ -453,84 +453,81 @@ msgstr "Valle"
 msgid "Potència contractada (kW):"
 msgstr "Potencia contratada (kW):"
 
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:344
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:347
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:349
 msgid "(vigents fins al {})"
 msgstr "(vigentes hasta el {})"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:346
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:351
 msgid "(vigents a partir del {})"
 msgstr "(vigentes a partir del {})"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:349
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:351
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:366
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:368
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:451
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:431
 msgid "TARIFES D'ELECTRICITAT"
 msgstr "TARIFAS DE ELECTRICIDAD"
 
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:402
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:419
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:479
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:450
 msgid "Terme potència (€/kW i any)"
 msgstr "Término potencia (€/kW y año) "
 
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:452
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:469
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:528
 msgid "Pla"
 msgstr "Llano"
 
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:460
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:477
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:536
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:479
 msgid "Terme energia (€/kWh)"
 msgstr "Término energía (€/kWh)"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:466
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:470
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:483
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:487
 msgid "Tarifa indexada"
 msgstr "Tarifa indexada"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:473
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:490
 msgid " - el preu horari es calcula d'acord amb la fórmula:"
 msgstr " - el precio horario se calcula de acuerdo con la fórmula:"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:476
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:493
 msgid ""
 "PH = 1,015 * [(PHM + PHMA + Pc + SobrecostosREE + Interrump + POsOm) (1 + "
-"Perd) + FE + K] + PA + CA"
-msgstr "PH = 1,015 * [(PHM + PHMA + Pc + SobrecostesREE + Interrump + POsOm) (1 + Perd) + FE + K] + PA + CA"
+"Perd) + FE + K] + PTD + CA"
+msgstr "PH = 1,015 * [(PHM + PHMA + Pc + SobrecostesREE + Interrump + POsOm) (1 + Perd) + FE + K] + PTD + CA"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:478
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:495
 msgid "on el marge de comercialització"
 msgstr "donde el margen de comercialización"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:504
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:521
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:551
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:494
 msgid "(1) GenerationkWh (€/kWh)"
 msgstr "(1) GenerationkWh (€/kWh)"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:527
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:544
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:566
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:509
 msgid "(2) Autoconsum (€/kWh)"
 msgstr "(2) Autoconsumo (€/kWh) "
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:530
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:547
 msgid "Tarifa indexada - el preu es calcula d'acord amb la fórmula:"
 msgstr "Tarifa indexada - el precio se calcula de acuerdo a la fórmula:"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:532
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:549
 msgid ""
 "Import excedents = Suma horària (kWh excedentaris h <sub>i</sub> * PHM "
 "<sub>i</sub> )"
 msgstr "Importe excedentes = Suma horaria (kWh excedentarios h <sub>i</sub> * PHM <sub>i</sub> )"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:550
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:567
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:573
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:516
 msgid ""
@@ -538,47 +535,46 @@ msgid ""
 "GenerationkWh."
 msgstr "Termino de energía en caso de participar, según condiciones del contrato GenerationkWh."
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:553
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:570
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:574
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:517
 msgid "Preu de la compensació d'excedents, si és aplicable."
 msgstr "Precio de la compensación de excedentes, si es aplicable."
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:559
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:576
 msgid ""
 "A més del preu fix associat al cost de l'energia, establert per Som Energia "
 "i publicat a la nostra pàgina web, la factura inclourà un import variable "
 "associat al mecanisme d'ajust establert al"
 msgstr "Además del precio fijo asociado al coste de la energía, establecido por Som Energia y publicado en nuestra página web, la factura incluirá un importe variable asociado al mecanismo de ajuste establecido en el"
 
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:561
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
 msgid ""
 "Aquest import el calcularem per a cada període de facturació. Ponderarem el "
 "preu de cada hora del mecanisme d'ajust ("
 msgstr "Este importe lo calcularemos para cada periodo de facturación. Ponderaremos el precio de cada hora del mecanismo de ajuste ("
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:561
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
 msgid "publicat per OMIE"
 msgstr "publicado por OMIE"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:562
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:579
 msgid ") en funció del repartiment horari energètic d'un consumidor/a tipus ("
 msgstr ") en función del reparto horario energético de un consumidor/a tipo ("
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:562
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:579
 msgid "publicat per Red Eléctrica de"
 msgstr "publicado por Red Eléctrica de"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:564
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:581
 msgid "segons la"
 msgstr "según la"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:564
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:581
 msgid "Resolució de 23/12/2021"
 msgstr "Resolución de 23/12/2021"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:565
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:582
 msgid ""
 "). El preu obtingut el multiplicarem, en cada factura, per l'energia total "
 "consumida en el període de facturació. El mecanisme d’ajust al gas no aplica"
@@ -586,67 +582,41 @@ msgid ""
 "tarifa Generation kWh."
 msgstr "). El precio obtenido lo multiplicaremos, en cada factura, por la energía total consumida en el período de facturación. El mecanismo de ajuste del gas no aplica para los contratos de Baleares y Canarias, y tampoco aplica a la tarifa Generation kWh."
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:574
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:591
 msgid "Els preus del terme de potència"
 msgstr "Los precios del término de potencia"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:576
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:593
 msgid "Tots els preus que apareixen en aquest contracte"
 msgstr "Todos los precios que aparecen en este contrato"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:595
 msgid ""
 "inclouen l'impost elèctric i l'IVA (IGIC a Canàries), amb el tipus impositiu"
 " vigent en cada moment per a cada tipus de contracte."
-msgstr "incluyen el impuesto eléctrico y el IVA (IGIC en Canarias), con el tipo impositivo vigente en cada momento para cada tipo de contrato."
+msgstr "incluyen el impuesto eléctrico y el IVA (IGIC en Canarias), con el tipo impositivo vigente en cada momento para cada tipo de\ncontrato."
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
-msgid "Reial Decret-llei 11/2022"
-msgstr "Real decreto ley 11/2022"
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
-msgid "l’IVA aplicable serà del"
-msgstr "el IVA aplicable será del"
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:580
-msgid ""
-"5% (sempre que el preu mitjà del mercat majorista del mes anterior al de "
-"facturació hagi estat superior a 45€/MWh. En cas que hagi estat inferior, "
-"l’IVA que s’aplicarà serà del 21%)."
-msgstr "5% (siempre que el precio mediano del mercado mayorista del mes anterior al de facturación haya estado superior a 45€/MWh. En caso de que haya estado inferior, el IVA que se aplicará será del 21%)."
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:582
-msgid "21%."
-msgstr "21%."
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:584
-msgid ""
-"També, i seguint el Reial Decret-Llei 11/2022, els preus inclouen l’Impost "
-"Especial sobre l’Electricitat rebaixat al 0,5% (amb una quota mínima de 0,5 "
-"€/MWh o 1 €/MWh, segons correspongui)."
-msgstr "También, y siguiendo el Real decreto ley 11/2022, los precios incluyen el Impuesto Especial sobre la Electricidad rebajado al 0,5% (con una cuota mínima de 0,5 €/MWh o 1 €/MWh, según corresponda)."
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:602
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:613
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:600
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:543
 msgid "DADES DE PAGAMENT"
 msgstr "DATOS DE PAGO"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:606
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:617
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:547
 msgid "Persona titular del compte: "
 msgstr "Persona titular de la cuenta: "
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:607
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:618
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:548
 msgid "NIF: "
 msgstr "NIF: "
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:610
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:621
 msgid "Nº de compte bancari (IBAN): **** **** **** ****"
 msgstr "Nº de cuenta bancaria (IBAN): **** **** **** ****"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:615
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:626
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:596
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:539
 msgid ""
@@ -657,30 +627,30 @@ msgid ""
 "el que estigui previst en aquestes Condicions Particulars."
 msgstr "Al contratar aceptan estas Condiciones Particulares y las Condiciones Generales, que se pueden consultar en las páginas siguientes. Si necesitamos modificarlas, en la cláusula 9 de las Condiciones Generales se explica el procedimiento que seguiremos. En caso de que haya alguna discrepancia, prevalecerá lo que esté previsto en estas Condiciones Particulares."
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:627
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:635
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:618
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:561
 msgid "a {0}"
 msgstr "a {0}"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:630
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:638
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:621
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:564
 msgid "La persona clienta:"
 msgstr "La persona clienta:"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:632
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:640
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:566
 msgid "Acceptat digitalment via formulari web"
 msgstr "Aceptado digitalmente vía formulario web"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:637
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:645
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:628
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:571
 msgid "La comercialitzadora"
 msgstr "La comercializadora"
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:648
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:656
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:639
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:582
 msgid ""

--- a/som_polissa_condicions_generals/i18n/som_polissa_condicions_generals.pot
+++ b/som_polissa_condicions_generals/i18n/som_polissa_condicions_generals.pot
@@ -6,15 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2022-08-26 11:36+0000\n"
-"PO-Revision-Date: 2022-08-26 11:36+0000\n"
-
+"POT-Creation-Date: 2023-02-15 17:24+0000\n"
+"PO-Revision-Date: 2023-02-15 17:24+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: \n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.9.1\n"
 
 #. module: som_polissa_condicions_generals
 #: model:ir.actions.report.xml,name:som_polissa_condicions_generals.report_contracte_canvi_preus
@@ -426,8 +425,8 @@ msgid "Tipus de contracte: "
 msgstr ""
 
 #: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:251
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:386
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:451
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:403
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:468
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:379
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:463
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:527
@@ -435,8 +434,8 @@ msgid "Punta"
 msgstr ""
 
 #: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:253
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:388
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:453
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:405
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:470
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:381
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:465
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:529
@@ -449,81 +448,81 @@ msgstr ""
 msgid "Potència contractada (kW):"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:344
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:347
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:349
 msgid "(vigents fins al {})"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:346
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:351
 msgid "(vigents a partir del {})"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:349
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:351
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:366
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:368
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:451
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:431
 msgid "TARIFES D'ELECTRICITAT"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:402
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:419
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:479
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:450
 msgid "Terme potència (€/kW i any)"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:452
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:469
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:528
 msgid "Pla"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:460
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:477
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:536
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:479
 msgid "Terme energia (€/kWh)"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:466
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:470
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:483
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:487
 msgid "Tarifa indexada"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:473
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:490
 msgid " - el preu horari es calcula d'acord amb la fórmula:"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:476
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:493
 msgid ""
 "PH = 1,015 * [(PHM + PHMA + Pc + SobrecostosREE + Interrump + POsOm) (1 +"
-" Perd) + FE + K] + PA + CA"
+" Perd) + FE + K] + PTD + CA"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:478
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:495
 msgid "on el marge de comercialització"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:504
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:521
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:551
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:494
 msgid "(1) GenerationkWh (€/kWh)"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:527
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:544
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:566
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:509
 msgid "(2) Autoconsum (€/kWh)"
 msgstr ""
 
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:530
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:547
 msgid "Tarifa indexada - el preu es calcula d'acord amb la fórmula:"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:532
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:549
 msgid ""
 "Import excedents = Suma horària (kWh excedentaris h <sub>i</sub> * PHM "
 "<sub>i</sub> )"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:550
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:567
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:573
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:516
 msgid ""
@@ -531,46 +530,46 @@ msgid ""
 "GenerationkWh."
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:553
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:570
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:574
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:517
 msgid "Preu de la compensació d'excedents, si és aplicable."
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:559
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:576
 msgid ""
 "A més del preu fix associat al cost de l'energia, establert per Som "
 "Energia i publicat a la nostra pàgina web, la factura inclourà un import "
 "variable associat al mecanisme d'ajust establert al"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:561
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
 msgid ""
 "Aquest import el calcularem per a cada període de facturació. Ponderarem "
 "el preu de cada hora del mecanisme d'ajust ("
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:561
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
 msgid "publicat per OMIE"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:562
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:579
 msgid ") en funció del repartiment horari energètic d'un consumidor/a tipus ("
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:562
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:579
 msgid "publicat per Red Eléctrica de"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:564
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:581
 msgid "segons la"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:564
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:581
 msgid "Resolució de 23/12/2021"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:565
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:582
 msgid ""
 "). El preu obtingut el multiplicarem, en cada factura, per l'energia "
 "total consumida en el període de facturació. El mecanisme d’ajust al gas "
@@ -578,67 +577,41 @@ msgid ""
 "aplica a la tarifa Generation kWh."
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:574
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:591
 msgid "Els preus del terme de potència"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:576
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:593
 msgid "Tots els preus que apareixen en aquest contracte"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:595
 msgid ""
 "inclouen l'impost elèctric i l'IVA (IGIC a Canàries), amb el tipus "
 "impositiu vigent en cada moment per a cada tipus de contracte."
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
-msgid "Reial Decret-llei 11/2022"
-msgstr ""
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:578
-msgid "l’IVA aplicable serà del"
-msgstr ""
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:580
-msgid ""
-"5% (sempre que el preu mitjà del mercat majorista del mes anterior al de "
-"facturació hagi estat superior a 45€/MWh. En cas que hagi estat inferior,"
-" l’IVA que s’aplicarà serà del 21%)."
-msgstr ""
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:582
-msgid "21%."
-msgstr ""
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:584
-msgid ""
-"També, i seguint el Reial Decret-Llei 11/2022, els preus inclouen "
-"l’Impost Especial sobre l’Electricitat rebaixat al 0,5% (amb una quota "
-"mínima de 0,5 €/MWh o 1 €/MWh, segons correspongui)."
-msgstr ""
-
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:602
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:613
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:600
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:543
 msgid "DADES DE PAGAMENT"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:606
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:617
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:547
 msgid "Persona titular del compte: "
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:607
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:618
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:548
 msgid "NIF: "
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:610
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:621
 msgid "Nº de compte bancari (IBAN): **** **** **** ****"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:615
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:626
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:596
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:539
 msgid ""
@@ -649,30 +622,30 @@ msgid ""
 "prevaldrà el que estigui previst en aquestes Condicions Particulars."
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:627
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:635
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:618
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:561
 msgid "a {0}"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:630
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:638
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:621
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:564
 msgid "La persona clienta:"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:632
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:640
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:566
 msgid "Acceptat digitalment via formulari web"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:637
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:645
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:628
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:571
 msgid "La comercialitzadora"
 msgstr ""
 
-#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:648
+#: rml:som_polissa_condicions_generals/report/condicions_particulars.mako:656
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_canvi_preus.mako:639
 #: rml:som_polissa_condicions_generals/report/condicions_particulars_nous_peatges_temporal.mako:582
 msgid ""

--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -490,7 +490,7 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
                                     ${_(u" - el preu horari es calcula d'acord amb la fórmula:")}
                                 </span>
                                 <br/>
-                                <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + SobrecostosREE + Interrump + POsOm) (1 + Perd) + FE + K] + PA + CA")}</span>
+                                <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + SobrecostosREE + Interrump + POsOm) (1 + Perd) + FE + K] + PTD + CA")}</span>
                                 <br/>
                                 <span class="normal_font_weight">${_(u"on el marge de comercialització")}</span>
                                 <span>&nbsp;${("(K) = %s €/MWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d), digits=3)}</span>


### PR DESCRIPTION
## Objectiu

Canviar la formula que apareix a les condicions particulars dels contractes amb indexada de PA a PTD ja que a la documentació ja s'ha canviat.

![image](https://user-images.githubusercontent.com/26924515/219093701-e2463dcc-515d-49e0-b77e-88a22964503d.png)

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2156660271/14249074?folderId=3063374

## Comportament antic

surt PA

## Comportament nou

surt PTD

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
       - som_polissa_condicions_particulars
- [ ] Script de migració
- [ ] Modifica traduccions
