### PR TITLE
Fer visible el camp de cerca de data alta autoconsum a la vista de pòlissa

### DIFF
--- a/som_switching/giscedata_polissa_view.xml
+++ b/som_switching/giscedata_polissa_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="giscedata_polissa.view_polissa_autoconsum_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//page[@string='Autoconsum']/field[@name='is_autoconsum_collectiu']" position="after">
-                    <field name="data_alta_autoconsum" readonly="1"/>
+                    <field name="data_alta_autoconsum" readonly="1" select="2"/>
                 </xpath>
             </field>
         </record>
@@ -20,7 +20,7 @@
             <field name="inherit_id" ref="giscedata_facturacio.giscedata_polissa_facturacio_tree"/>
             <field name="arch" type="xml">
                 <field name="lectura_en_baja" position="after" >
-                    <field name="data_alta_autoconsum" select="2"/>
+                    <field name="data_alta_autoconsum"/>
                 </field>
                 <field name="data_ultima_lectura" position="after" >
                     <field name="data_ultima_lectura_f1" string="Última lectura de F1"/>


### PR DESCRIPTION
## Objectiu

Fer visible el camp de cerca de data alta autoconsum a la vista de polissa i dervades

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2162967619/14283917?folderId=3063374

## Comportament antic

no es veu el camp i desapareix en cada update de som_switching

## Comportament nou

el camp es veu i es pot filtrar

## Comprovacions

- [ ] Hi ha testos
- [] Reiniciar serveis
- [x] Actualitzar mòdul
         - som_switching (però no cal fet a mà a productiu)
- [ ] Script de migració
- [ ] Modifica traduccions
