### PR TITLE
Fix screenshots not being deleted and do not attach old files

### DIFF
--- a/som_crawlers/tests/wizard_executar_tasca_tests.py
+++ b/som_crawlers/tests/wizard_executar_tasca_tests.py
@@ -226,7 +226,7 @@ class WizardExecutarTascaTests(testing.OOTestCase):
 
             result = self.taskStep.attach_files_zip(cursor, uid, crawler_taskStep_id, result_id, crawler_config_obj, path_desti, taskStepParams, context=None)
 
-            self.assertEqual(result,'files succesfully attached')
+            self.assertEqual(result,'File anselmo_2022-07-26_15_11_GRCW_W4X151_20220726151137.zip succesfully attached\n')
 
 
     """  Create args for script test --> sortida string arguments


### PR DESCRIPTION
## Objectiu
- Evitar que s'adjuntin fitxers antics que no s'hagin eliminat per algun motiu
- Evitar que quedin _screenshots_ sense esborrar quan no s'han trobat resultats

## Targeta on es demana o Incidència 
https://trello.com/c/bTRtHbQO/5655-0-6-import-massiva-arreglar-2-zips-adjunts-ep259-m

## Comportament antic
- Si hi havia fitxers antics al directori d'un `crawler` es penjaven tots provocant importacions duplicades
- Quan no es trobaven resultats es feia una captura, però no s'ajuntava ni s'eliminava

## Comportament nou
- No adjuntem fitxers antics i donem informació sobre ells a la sortida
- S'esborren les captures generades per una excepció de sense resultats

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
