### PR TITLE
WIP: Fix empowering token regeneration

### DIFF
--- a/som_empowering/res_partner.py
+++ b/som_empowering/res_partner.py
@@ -29,14 +29,16 @@ class ResPartner(osv.osv):
         """
         m = mdbpool.get_db()
         polissa_obj = self.pool.get('giscedata.polissa')
-        empowering_enabled_relations = [
+        # TODO: consider notifica and administradora
+        # TODO: move out as config if used elsewhere
+        allowed_relations = [
             'titular',
             'pagador',
         ]
         for partner in self.read(cursor, uid, ids, ['empowering_token']):
             token = partner['empowering_token']
             allowed_ids = self.related_contracts(
-                cursor, uid, partner['id'], empowering_enabled_relations
+                cursor, uid, partner['id'], allowed_relations
             )
             allowed = [
                 dict(

--- a/som_empowering/res_partner.py
+++ b/som_empowering/res_partner.py
@@ -12,10 +12,28 @@ class ResPartner(osv.osv):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
+
+    def related_contracts(self, cursor, uid, id, relations, context=None):
+        relation_map=dict(
+            notifica='direccio_notificacio.partner_id',
+        )
+        polissa_obj = self.pool.get('giscedata.polissa')
+        domain = (['|'] if len(relations)>1 else []) + [
+            (relation_map.get(relation,relation), '=', id)
+            for relation in relations
+        ]
+        return polissa_obj.search(cursor, uid, domain)
+
     def assign_token(self, cursor, uid, ids, context=None):
         """Assign a new token to the partner
         """
-        polissa_obj = self.pool.get('giscedata.polissa')
+        for id in ids:
+            token = generate_token()
+            self.write(cursor, uid, id, {
+                'empowering_token': token
+            })
+        return True
+
         m = mdbpool.get_db()
         for partner in self.read(cursor, uid, ids, ['empowering_token']):
             m.tokens.remove({'token': partner['empowering_token']})

--- a/som_empowering/res_partner.py
+++ b/som_empowering/res_partner.py
@@ -45,7 +45,12 @@ class ResPartner(osv.osv):
                 )
                 for x in polissa_obj.browse(cursor, uid, allowed_ids) or []
             ]
-            if not token:
+            if token:
+                m.tokens.update(
+                    dict(token=token),
+                    {'$set': dict(allowed_contracts=allowed)}
+                )
+            else:
                 token = generate_token()
                 self.write(cursor, uid, partner['id'], {
                     'empowering_token': token

--- a/som_empowering/res_partner.py
+++ b/som_empowering/res_partner.py
@@ -63,25 +63,15 @@ class ResPartner(osv.osv):
                 })
         return True
 
+    def clear_token(self, cursor, uid, ids, context=None):
+        """Clear the token for the partner including mongo
+        """
         m = mdbpool.get_db()
         for partner in self.read(cursor, uid, ids, ['empowering_token']):
             m.tokens.remove({'token': partner['empowering_token']})
-            token = generate_token()
             self.write(cursor, uid, [partner['id']], {
-                'empowering_token': token
+                'empowering_token': False
             })
-            allowed = polissa_obj.search(cursor, uid, [
-                '|',
-                    ('titular.id', '=', partner['id']),
-                    ('pagador.id', '=', partner['id'])
-            ])
-            if allowed:
-                allowed = [{'name': x.name, 'cups': x.cups.name}
-                           for x in polissa_obj.browse(cursor, uid, allowed)]
-                m.tokens.insert({
-                    'token': token,
-                    'allowed_contracts': allowed
-                })
         return True
 
     _columns = {

--- a/som_empowering/res_partner.py
+++ b/som_empowering/res_partner.py
@@ -27,11 +27,13 @@ class ResPartner(osv.osv):
     def assign_token(self, cursor, uid, ids, context=None):
         """Assign a new token to the partner
         """
-        for id in ids:
-            token = generate_token()
-            self.write(cursor, uid, id, {
-                'empowering_token': token
-            })
+        for partner in self.read(cursor, uid, ids, ['empowering_token']):
+            token = partner['empowering_token']
+            if not token:
+                token = generate_token()
+                self.write(cursor, uid, partner['id'], {
+                    'empowering_token': token
+                })
         return True
 
         m = mdbpool.get_db()

--- a/som_empowering/tests/__init__.py
+++ b/som_empowering/tests/__init__.py
@@ -1,0 +1,1 @@
+from test_res_partner import *

--- a/som_empowering/tests/test_res_partner.py
+++ b/som_empowering/tests/test_res_partner.py
@@ -180,7 +180,7 @@ class ResPartnerTest(testing.OOTestCase):
         token2 = self.get_token(self.owner2)
         self.assertNotEqual(token1, token2)
 
-    def _test_assign_token__twice_keepsSame(self):
+    def test_assign_token__twice_keepsSame(self):
         self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
         token = self.get_token(self.owner1)
         self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])

--- a/som_empowering/tests/test_res_partner.py
+++ b/som_empowering/tests/test_res_partner.py
@@ -1,0 +1,190 @@
+from destral import testing
+import unittest
+from mongodb_backend.mongodb2 import mdbpool
+import mock
+import pymongo
+from destral.transaction import Transaction
+from yamlns import ns
+
+class ResPartnerTest(testing.OOTestCase):
+
+
+    def get_reference(self, semantic_id):
+        return self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 
+            *semantic_id.split('.')
+        )[1]
+
+
+    from yamlns.testutils import assertNsEqual
+
+    def setUp(self):
+        self.maxDiff = None
+        self.databasename = 'som_empowering_test'
+        self.collection = 'tokens'
+        c = pymongo.MongoClient()
+        c.drop_database(self.databasename)
+        self.db = c[self.databasename]
+
+        patcher = mock.patch('mongodb_backend.mongodb2.mdbpool.get_db')
+        self.get_db_mock = patcher.start()
+        self.get_db_mock.return_value = self.db
+        self.addCleanup(patcher.stop)
+
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.addCleanup(self.txn.stop)
+        self.pool = self.openerp.pool
+        self.IrModelData = self.pool.get('ir.model.data')
+        self.ResPartner = self.pool.get('res.partner')
+        self.ResPartnerAddress = self.pool.get('res.partner.address')
+        self.GiscedataPolissa = self.pool.get('giscedata.polissa')
+
+        self.contract1 = self.get_reference('giscedata_polissa.polissa_gisce')
+        self.contract2 = self.get_reference('giscedata_polissa.polissa_0001')
+        # owner of contract1, no other roles on contract 1, unrelated to contract2
+        self.owner1 = self.get_reference('base.res_partner_gisce')
+        self.notified1 =  self.get_reference('base.res_partner_9')
+        # payer of contract2, no other roles on contract 2, unrelated to contract1
+        self.owner2 = self.get_reference('base.res_partner_c2c')
+        self.payer2 = self.get_reference('base.res_partner_agrolait')
+        # giscedata_polissa.polissa_0001
+
+    def tearDown(self):
+        c = pymongo.MongoClient()
+        c.drop_database(self.databasename)
+
+    def related_contracts(self, partner_id, relations):
+        return self.ResPartner.related_contracts(self.cursor, self.uid, partner_id, relations)
+
+    def set_role(self, contract1, partner_id, role):
+        self.GiscedataPolissa.write(self.cursor, self.uid, contract1, {
+            role: partner_id,
+        })
+
+    def assertRelated(self, contract1, partner_id, *relations):
+        # Comparing the full list of related contracts would be fragile
+        self.assertIn(contract1, self.related_contracts(partner_id, relations))
+
+    def assertUnrelated(self, contract1, partner_id, *relations):
+        # Comparing the full list of related contracts would be fragile
+        self.assertNotIn(contract1, self.related_contracts(partner_id, relations))
+
+    def getRoles(self, contract):
+        def getid(foreignkey):
+            if not foreignkey: return None
+            return foreignkey[0]
+
+        polissa = self.GiscedataPolissa.read(self.cursor, self.uid, contract)
+        result = ns(
+            owner=getid(polissa['titular']),
+            payer=getid(polissa['pagador']),
+            #admin=getid(polissa['administradora']),
+            notified=None
+        )
+        notify_address = getid(polissa['direccio_notificacio'])
+
+        if notify_address:
+            address = self.ResPartnerAddress.read(
+                self.cursor, self.uid, notify_address)
+            result.notified=getid(address['partner_id'])
+        return result
+
+    def test_fixtures(self):
+        "This tests checks assumptions the other tests do on the fixtures"
+        self.assertNsEqual(
+            ns(
+                contract1 = self.getRoles(self.contract1),
+                contract2 = self.getRoles(self.contract2),
+            ),
+            ns(
+                contract1 = ns(
+                    owner = self.owner1,
+                    payer = self.owner1,
+                    notified = self.notified1,
+                ),
+                contract2 = ns(
+                    owner = self.owner2,
+                    payer = self.payer2,
+                    notified = self.payer2,
+                ),
+            )
+        )
+
+    def test_related_contracts__titular(self):
+        # Contract is just in the related of the owner
+        self.assertRelated(self.contract1, self.owner1, 'titular')
+        self.assertUnrelated(self.contract1, self.owner2, 'titular')
+        self.assertRelated(self.contract2, self.owner2, 'titular')
+        self.assertUnrelated(self.contract2, self.payer2, 'titular')
+
+    def test_related_contracts__pagador(self):
+        # owner2 is not payer of contract 2
+        self.assertUnrelated(self.contract2, self.owner2, 'pagador')
+        # payer2 is
+        self.assertRelated(self.contract2, self.payer2, 'pagador')
+        # but if we set owner2 as the payer of contract2
+        self.set_role(self.contract2, self.owner2, 'pagador')
+        # The situation is inverted
+        self.assertRelated(self.contract2, self.owner2, 'pagador')
+        self.assertUnrelated(self.contract2, self.payer2, 'pagador')
+
+    def test_related_contracts__notifica(self):
+        # payer2 is both payer but also notifier of contract2
+        self.assertRelated(self.contract2, self.payer2, 'notifica')
+        # but has no relation with contract1
+        self.assertUnrelated(self.contract1, self.payer2, 'notifica')
+        # owner1 is not notified of contrac1
+        self.assertUnrelated(self.contract1, self.owner1, 'notifica')
+        # notified1 is
+        self.assertRelated(self.contract1, self.notified1, 'notifica')
+
+    @unittest.skip("Missing dependency")
+    def test_related_contracts__administrador(self):
+        self.assertUnrelated(self.contract1, self.payer2, 'administradora')
+        self.set_role(self.contract1, self.payer2, 'administradora')
+        self.assertRelated(self.contract1, self.payer2, 'administradora')
+
+
+    def get_token(self, partner):
+        return self.ResPartner.read(self.cursor, self.uid, partner, ['empowering_token'])['empowering_token']
+
+    def token_info(self, token):
+        return [
+            ns(x,_id=str(x['_id']))
+            for x in self.db.tokens.find({'token': token})
+        ]
+
+    def test_assign_token__beforeAssigningOne(self):
+        token = self.get_token(self.owner1)
+        self.assertEqual(token, False)
+
+    def test_assign_token__afterAssignment(self):
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        token = self.get_token(self.owner1)
+        self.assertTrue(token)
+
+    def test_assign_token__simultaneous_assign_different_tokens(self):
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1, self.owner2])
+        token1 = self.get_token(self.owner1)
+        token2 = self.get_token(self.owner2)
+        self.assertNotEqual(token1, token2)
+
+    def _test_assign_token__twice_keepsSame(self):
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        token = self.get_token(self.owner1)
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        new_token = self.get_token(self.owner1)
+        self.assertEqual(new_token, token)
+
+    def _test_assign_token__setsContractList(self):
+        self.assertNsEqual(self.token_info(token), """
+            hola: tu
+        """)
+
+
+
+
+
+

--- a/som_empowering/tests/test_res_partner.py
+++ b/som_empowering/tests/test_res_partner.py
@@ -146,6 +146,15 @@ class ResPartnerTest(testing.OOTestCase):
         self.set_role(self.contract1, self.payer2, 'administradora')
         self.assertRelated(self.contract1, self.payer2, 'administradora')
 
+    def test_related_contracts__multiple_roles(self):
+        # Both owner2 and payer2 are related to c2 with one of those roles
+        self.assertRelated(self.contract2, self.owner2, 'titular', 'pagador')
+        self.assertRelated(self.contract2, self.payer2, 'titular', 'pagador')
+        # Neither role is taken by owner1
+        self.assertUnrelated(self.contract2, self.owner1, 'titular', 'pagador')
+        # Neither role is taken by notified1 in c1
+        self.assertUnrelated(self.contract1, self.notified1, 'titular', 'pagador')
+
 
     def get_token(self, partner):
         return self.ResPartner.read(self.cursor, self.uid, partner, ['empowering_token'])['empowering_token']

--- a/som_empowering/tests/test_res_partner.py
+++ b/som_empowering/tests/test_res_partner.py
@@ -165,6 +165,13 @@ class ResPartnerTest(testing.OOTestCase):
             for x in self.db.tokens.find({'token': token})
         ]
 
+    def name_and_cups(self, contract_id):
+        contract = self.GiscedataPolissa.read(self.cursor, self.uid, contract_id, ['name', 'cups'])
+        return dict(
+            name=contract['name'],
+            cups=contract['cups'][1],
+        )
+
     def test_assign_token__beforeAssigningOne(self):
         token = self.get_token(self.owner1)
         self.assertEqual(token, False)
@@ -180,17 +187,20 @@ class ResPartnerTest(testing.OOTestCase):
         token2 = self.get_token(self.owner2)
         self.assertNotEqual(token1, token2)
 
-    def test_assign_token__twice_keepsSame(self):
+    def test_assign_token__twice_keepsSameToken(self):
         self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
         token = self.get_token(self.owner1)
         self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
         new_token = self.get_token(self.owner1)
         self.assertEqual(new_token, token)
 
-    def _test_assign_token__setsContractList(self):
-        self.assertNsEqual(self.token_info(token), """
-            hola: tu
-        """)
+    def test_assign_token__setsContractList(self):
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        token = self.get_token(self.owner1)
+        token_info = self.token_info(token)
+        mongo_contracts = token_info[0]['allowed_contracts']
+        self.assertIn(self.name_and_cups(self.contract1), mongo_contracts)
+        self.assertNotIn(self.name_and_cups(self.contract2), mongo_contracts)
 
 
 

--- a/som_empowering/tests/test_res_partner.py
+++ b/som_empowering/tests/test_res_partner.py
@@ -211,11 +211,28 @@ class ResPartnerTest(testing.OOTestCase):
         self.assertNotIn(self.name_and_cups(self.contract1), token_contracts)
 
         self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        token = self.get_token(self.owner1)
         token_contracts = self.token_contracts(token)
         self.assertIn(self.name_and_cups(self.contract1), token_contracts)
         self.assertNotIn(self.name_and_cups(self.contract2), token_contracts)
 
+    def test_clear_token(self):
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        token = self.get_token(self.owner1)
+        self.ResPartner.clear_token(self.cursor, self.uid, [self.owner1])
+        # Removed from mongo
+        with self.assertRaises(AssertionError):
+            # expected to raise because length is 0
+            self.token_contracts(token)
+        # Removed from partner
+        token2 = self.get_token(self.owner1)
+        self.assertFalse(token2)
 
-
+    def test_clear_token_twice(self):
+        self.ResPartner.assign_token(self.cursor, self.uid, [self.owner1])
+        token = self.get_token(self.owner1)
+        self.ResPartner.clear_token(self.cursor, self.uid, [self.owner1])
+        self.ResPartner.clear_token(self.cursor, self.uid, [self.owner1])
+        self.token_contracts(token)
 
 


### PR DESCRIPTION
## Objectiu

Fer que els tokens d'empowering no deixin de funcionar. Moltes usuaries reporten a l'ET que no poden veure la seccio d'infoenergia a la OV. Be les corbes, be els informes.  Fa temps que es va instruir a l'ET que calia regenerar el token amb el boto del client erp. Tot i aixi, son moltes les incidencies que es generen Usuaris -> ET -> Webapps, i tot i que moltes no escalen, i el primer nivell, els usuaris que troben que no els funciona, es l'important.

## Targeta on es demana o Incidència 

Els tres nivells:

- Usuaries -> ET: https://secure.helpscout.net/conversation/2165432486/14299717?folderId=5256417
- ET -> Webapps: https://secure.helpscout.net/conversation/2167389348/14303568?folderId=3063450
- WebApps -> ERP:  https://secure.helpscout.net/conversation/2167611630/14304014?folderId=3063374

## Comportament antic

- Quan es modifica un contracte, si ja existeix token, no es genera. Es va fer per evitar anar canviant el token si no cal, pero la consequencia es que tampoc no s'actualitza el llistat de contractes relacionats, fins que no premem el botó del client erp.
- Pel mateix motiu, suposem, les modificacions automatiques están molt capades:
   - Només es fa on write, no pas al create, unlink...
   - Només si el write modifica els attributs de relacio amb partner (titular, pagador). Si les relacions s'han setejat al create, i no al write, s'ignoraran.
   - Nomes en els partners entrants, els partners relacionats anteriorment s'ignoren i caldria actualitzar els seus llistats de contractes.
- Comprovem una relacio 'notificador' que no existeix, i despres no es té en compte
- El codi no té cap test

## Comportament nou

- [x] Actualitzar el token ja no suposa generar-ne un de nou, només actualitzar el llistat de contractes
- [ ] TODO: No evita actualitzar si ja existeix token pel partner
- [ ] TODO: Es dispara actualització pels partners de les relacions noves i les cesants
- [ ] TODO: Es dispara actualització en el create
- [x] Hi ha un llistat de relacions (titular, pagador) que podem modificar o ampliar (administradora, notifica)
- [x] Test driven developed
- [ ] TODO: Complementariament la OV actualitzarà el token quan sincronitzi la info del usuari (quan fa login)
- [ ] TODO: El boto crea un token nou com abans, pero ara eliminant el token i generant el nou. (No sabem si es necessari)

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
