### PR TITLE
(IMP) powersms

### DIFF
--- a/powersms/__init__.py
+++ b/powersms/__init__.py
@@ -1,3 +1,5 @@
+from . import powersms_provider
+from . import powersms_provider_lleidanet
 from . import powersms_core
 from . import powersms_templates
 from . import powersms_smsbox

--- a/powersms/__terp__.py
+++ b/powersms/__terp__.py
@@ -12,7 +12,7 @@
     "init_xml": [],
     "update_xml": [
         'security/powersms_security.xml',
-        'security/ir.model.access.csv',
+        'powersms_provider_data.xml',
         'powersms_core_view.xml',
         'powersms_template_view.xml',
         'powersms_smsbox_view.xml',
@@ -20,6 +20,7 @@
         'wizard/wizard_send_sms_view.xml',
         'powersms_data.xml',
         'powersms_scheduler_data.xml',
+        'security/ir.model.access.csv'
     ],
     "installable": True,
     "active": False,

--- a/powersms/migrations/5.0.23.1.0/post-0001-set_lleidanet_provider_for_existing_acc.py
+++ b/powersms/migrations/5.0.23.1.0/post-0001-set_lleidanet_provider_for_existing_acc.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+import logging
+from oopgrade.oopgrade import load_data_records, load_data, add_columns_fk
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    import pooler
+    logger = logging.getLogger('openerp.migration')
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Setting up powersms provider DB...")
+    pool.get('powersms.provider')._auto_init(cursor, context={'module': 'powersms'})
+    logger.info("TABLE powersms_provider CREATED success!")
+
+    logger.info("Adding FK provider_id on powersms_core_accounts...")
+    add_columns_fk(
+        cursor,
+        {
+            'powersms_core_accounts': [
+                ('provider_id', 'int', 'powersms_provider', 'id', 'SET NULL')
+            ]
+        }
+    )
+    logger.info("FK provider_id created!")
+
+    logger.info("Loading Providers from data...")
+    load_data_records(
+        cursor, 'powersms', 'powersms_provider_data.xml', ['powersms_provider_lleidanet']
+    )
+    logger.info('Provider data loaded!')
+
+    logger.info('Setting lleida as default for all existing accounts')
+    set_lleidanet_for_existing_accounts = """
+    UPDATE powersms_core_accounts set provider_id = (
+        SELECT id FROM powersms_provider WHERE function_pattern_code = 'lleida'
+    )
+    """
+    cursor.execute(set_lleidanet_for_existing_accounts)
+
+    logger.info("Loading Acces Rules...")
+    load_data(
+        cursor, 'powersms', 'security/ir.model.access.csv', mode='update'
+    )
+    logger.info('Access rules create success!')
+
+
+def down(cursor, installed_version):
+    if not installed_version:
+        return
+
+
+migrate = up

--- a/powersms/migrations/5.0.23.1.0/post-0001-set_lleidanet_provider_for_existing_acc.py
+++ b/powersms/migrations/5.0.23.1.0/post-0001-set_lleidanet_provider_for_existing_acc.py
@@ -30,6 +30,13 @@ def up(cursor, installed_version):
     load_data_records(
         cursor, 'powersms', 'powersms_provider_data.xml', ['powersms_provider_lleidanet']
     )
+    load_data_records(
+        cursor, 'powersms', 'powersms_core_view.xml', ['powersms_core_accounts_form']
+    )
+    load_data_records(
+        cursor, 'powersms', 'powersms_core_view.xml', ['powersms_core_accounts_tree']
+    )
+
     logger.info('Provider data loaded!')
 
     logger.info('Setting lleida as default for all existing accounts')

--- a/powersms/powersms_core.py
+++ b/powersms/powersms_core.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 from osv import osv, fields
 from tools.translate import _
 import netsvc
-import base64
 
 class PowersmsCoreAccounts(osv.osv):
     """
@@ -15,36 +14,6 @@ class PowersmsCoreAccounts(osv.osv):
         if box_obj.check_mobile(numbers):
             return True
         return False
-
-    def _get_json_body(self, number_to, message, from_name, context=None):
-        special_characters = [
-            u"€",
-        ]
-        dict_sms = {
-            "txt": message,
-        }
-        if any(special_char in message for special_char in special_characters):
-            dict_sms = {
-                "charset":"utf-16",
-                "data_coding":"unicode",
-                "txt": base64.b64encode(message.encode('utf-16')),
-            }
-        json_body = {"sms": dict(dst={"num": number_to}, src=from_name, **dict_sms)}
-        return json_body
-
-
-    def send_sms_lleida(self, cr, uid, ids, number_to, message, from_name, context=None):
-        if isinstance(ids, list):
-            ids = ids[0]
-        if not self.check_numbers(cr, uid, ids, number_to):
-            raise Exception("Incorrect cell number: " + number_to)
-
-        values = self.read(cr, uid, ids, ['api_uname', 'api_pass'])
-        c = Client(user=str(values['api_uname']), password=str(values['api_pass']))
-        headers = {'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json'}
-        json_body = self._get_json_body(number_to, message, from_name, context)
-        resposta = c.API.post(resource='', json=json_body, headers=headers)
-        return resposta.result['code'] == 200 and resposta.result['status'] == u'Success'
 
     def send_sms(self, cr, uid, ids, from_name, numbers_to, body='', payload=None, context=None):
         if context is None:

--- a/powersms/powersms_core.py
+++ b/powersms/powersms_core.py
@@ -84,10 +84,9 @@ class PowersmsCoreAccounts(osv.osv):
             account = self.browse(cr, uid, account_id, context)
 
             try:
-                account.provider_id.send_sms(
+                return bool(account.provider_id.send_sms(
                     account_id, from_name, numbers_to, body=body, files=payload_parser(payload), context=context
-                )
-                return True
+                ))
             except Exception as error:
                 logger.notifyChannel(
                     _("Power SMS"), netsvc.LOG_ERROR,

--- a/powersms/powersms_core.py
+++ b/powersms/powersms_core.py
@@ -125,7 +125,7 @@ class PowersmsCoreAccounts(osv.osv):
                         string="Allowed User Groups",
                         help="Only users from these groups will be " \
                         "allowed to send SMS from this ID."),
-        'provider_id': fields.many2one('powersms.provider', 'SMS Provide')
+        'provider_id': fields.many2one('powersms.provider', 'SMS Provider')
     }
 
     _defaults = {

--- a/powersms/powersms_core.py
+++ b/powersms/powersms_core.py
@@ -2,7 +2,6 @@
 from osv import osv, fields
 from tools.translate import _
 import netsvc
-from lleida_net.sms import Client
 import base64
 
 class PowersmsCoreAccounts(osv.osv):

--- a/powersms/powersms_core_view.xml
+++ b/powersms/powersms_core_view.xml
@@ -18,6 +18,7 @@
                                 <field name="user" select="2" colspan="2" />
                                 <field name="api_server" select="1" colspan="2" />
                                 <field name="tel_id" select="1" colspan="2" />
+                                <field name="provider_id" select="1" colspan="2" />
                             </group>
                             <group col="2" colspan="2">
                                 <field name="api_uname" select="1" colspan="2" />
@@ -46,6 +47,7 @@
             <field name="arch" type="xml">
                 <tree string="SMS Server">
                     <field name="name" select="1" />
+                    <field name="provider_id" select="1"/>
                     <field name="tel_id" select="1" />
                     <field name="api_uname" select="1" />
                     <field name="user" select="1" />

--- a/powersms/powersms_provider.py
+++ b/powersms/powersms_provider.py
@@ -37,7 +37,7 @@ class PowersmsProvider(osv.osv):
     }
     _sql_constraints = [
         ('name_uniq', 'unique (name)', 'Provider must be unique'),
-        ('code_uniq', 'unique (code)', 'Function pattern must be unique')
+        ('code_uniq', 'unique (function_pattern_code)', 'Function pattern must be unique')
     ]
 
 

--- a/powersms/powersms_provider.py
+++ b/powersms/powersms_provider.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, unicode_literals
+from osv import osv, fields
+from tools.translate import _
+
+
+class PowersmsProvider(osv.osv):
+    _name = 'powersms.provider'
+
+    def _get_provider_function(self, cursor, uid, _id, context=None):
+        function_pattern = self.read(
+            cursor, uid, _id, ['function_pattern_code'], context=context
+        )['function_pattern']
+        return 'send_sms_{function_pattern}'.format(function_pattern=function_pattern)
+
+    def send_sms_default(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):
+        function_name = self._get_provider_function(cursor, uid, _id, context=context)
+        raise osv.except_osv(_("Programing Error"), _("Method {} not defined".format(function_name)))
+
+    def send_sms(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):
+        if isinstance(_id, (tuple, list)):
+            if len(_id) != 1:
+                raise osv.except_osv(_("Programing Error"), _("Multiple providers to send same sms"))
+            _id = _id[0]
+
+        function_name = self._get_provider_function(cursor, uid, _id, context=context)
+
+        return getattr(self, function_name, 'send_sms_default')(
+            cursor, uid, _id, account_id, from_name, numbers_to, body, context=context
+        )
+
+    _columns = {
+        'name': fields.char('Provider', size=64, required=True),
+        'function_pattern_code': fields.char(
+            'Function pattern definition', size=16, required=True,
+            help=_('Function must be defined as def send_sms_{function_pattern_code}')
+        )
+    }
+    _sql_constraints = [
+        ('name_uniq', 'unique (name)', 'Provider must be unique'),
+        ('code_uniq', 'unique (code)', 'Function pattern must be unique')
+    ]
+
+
+PowersmsProvider()

--- a/powersms/powersms_provider.py
+++ b/powersms/powersms_provider.py
@@ -24,7 +24,7 @@ class PowersmsProvider(osv.osv):
 
         function_name = self._get_provider_function(cursor, uid, _id, context=context)
 
-        return getattr(self, function_name, 'send_sms_default')(
+        return getattr(self, function_name, self.send_sms_default)(
             cursor, uid, _id, account_id, from_name, numbers_to, body, context=context
         )
 

--- a/powersms/powersms_provider.py
+++ b/powersms/powersms_provider.py
@@ -9,7 +9,7 @@ class PowersmsProvider(osv.osv):
     def _get_provider_function(self, cursor, uid, _id, context=None):
         function_pattern = self.read(
             cursor, uid, _id, ['function_pattern_code'], context=context
-        )['function_pattern']
+        )['function_pattern_code']
         return 'send_sms_{function_pattern}'.format(function_pattern=function_pattern)
 
     def send_sms_default(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):

--- a/powersms/powersms_provider.py
+++ b/powersms/powersms_provider.py
@@ -12,11 +12,11 @@ class PowersmsProvider(osv.osv):
         )['function_pattern_code']
         return 'send_sms_{function_pattern}'.format(function_pattern=function_pattern)
 
-    def send_sms_default(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):
+    def send_sms_default(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', files=None, context=None):
         function_name = self._get_provider_function(cursor, uid, _id, context=context)
         raise osv.except_osv(_("Programing Error"), _("Method {} not defined".format(function_name)))
 
-    def send_sms(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):
+    def send_sms(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', files=None, context=None):
         if isinstance(_id, (tuple, list)):
             if len(_id) != 1:
                 raise osv.except_osv(_("Programing Error"), _("Multiple providers to send same sms"))
@@ -25,7 +25,7 @@ class PowersmsProvider(osv.osv):
         function_name = self._get_provider_function(cursor, uid, _id, context=context)
 
         return getattr(self, function_name, self.send_sms_default)(
-            cursor, uid, _id, account_id, from_name, numbers_to, body, context=context
+            cursor, uid, _id, account_id, from_name, numbers_to, body, files, context=context
         )
 
     _columns = {

--- a/powersms/powersms_provider_data.xml
+++ b/powersms/powersms_provider_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
-    <data noupdate="1">
+    <data>
         <record id="powersms_provider_lleidanet" model="powersms.provider">
             <field name="name">Lleida Net</field>
             <field name="function_pattern_code">lleida</field>

--- a/powersms/powersms_provider_data.xml
+++ b/powersms/powersms_provider_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="powersms_provider_lleidanet" model="powersms.provider">
+            <field name="name">Lleida Net</field>
+            <field name="function_pattern_code">lleida</field>
+        </record>
+    </data>
+</openerp>

--- a/powersms/powersms_provider_lleidanet.py
+++ b/powersms/powersms_provider_lleidanet.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import, unicode_literals
 import base64
 from osv import osv

--- a/powersms/powersms_provider_lleidanet.py
+++ b/powersms/powersms_provider_lleidanet.py
@@ -5,10 +5,10 @@ from osv import osv, fields
 class PowersmsProviderLleidaNet(osv.osv):
     _inherit = 'powersms.provider'
 
-    def send_sms_lleida(self, cr, uid, ids, number_to, message, from_name, context=None):
+    def send_sms_lleida(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):
         from lleida_net.sms import Client
         account_obj = self.pool.get('powersms.core_accounts')
-        values = account_obj.read(cr, uid, ids, ['api_uname', 'api_pass'])
+        values = account_obj.read(cursor, uid, account_id, ['api_uname', 'api_pass'])
         c = Client(user=str(values['api_uname']), password=str(values['api_pass']))
         headers = {'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json'}
         response = c.API.post(
@@ -16,9 +16,9 @@ class PowersmsProviderLleidaNet(osv.osv):
             resource='',
             json={
                 "sms": {
-                    "txt": message,
+                    "txt": body,
                     "dst": {
-                        "num": number_to,
+                        "num": numbers_to,
                     },
                     "src": from_name,
                 }

--- a/powersms/powersms_provider_lleidanet.py
+++ b/powersms/powersms_provider_lleidanet.py
@@ -1,9 +1,27 @@
 from __future__ import absolute_import, unicode_literals
-from osv import osv, fields
+import base64
+from osv import osv
 
 
 class PowersmsProviderLleidaNet(osv.osv):
     _inherit = 'powersms.provider'
+
+    def _get_json_body(self, number_to, message, from_name, context=None):
+        special_characters = [
+            u"€",
+        ]
+        dict_sms = {
+            "txt": message,
+        }
+        if any(special_char in message for special_char in special_characters):
+            dict_sms = {
+                "charset":"utf-16",
+                "data_coding":"unicode",
+                "txt": base64.b64encode(message.encode('utf-16')),
+            }
+        json_body = {"sms": dict(dst={"num": number_to}, src=from_name, **dict_sms)}
+        return json_body
+
 
     def send_sms_lleida(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', files=None, context=None):
         from lleida_net.sms import Client
@@ -11,19 +29,8 @@ class PowersmsProviderLleidaNet(osv.osv):
         values = account_obj.read(cursor, uid, account_id, ['api_uname', 'api_pass'])
         c = Client(user=str(values['api_uname']), password=str(values['api_pass']))
         headers = {'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json'}
-        response = c.API.post(
-            headers=headers,
-            resource='',
-            json={
-                "sms": {
-                    "txt": body,
-                    "dst": {
-                        "num": numbers_to,
-                    },
-                    "src": from_name,
-                }
-            },
-        )
+        json_body = self._get_json_body(numbers_to, body, from_name, context)
+        response = c.API.post(resource='', json=json_body, headers=headers)
         return response.result['code'] == 200 and response.result['status'] == 'Success'
 
 

--- a/powersms/powersms_provider_lleidanet.py
+++ b/powersms/powersms_provider_lleidanet.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, unicode_literals
+from osv import osv, fields
+
+
+class PowersmsProviderLleidaNet(osv.osv):
+    _inherit = 'powersms.provider'
+
+    def send_sms_lleida(self, cr, uid, ids, number_to, message, from_name, context=None):
+        from lleida_net.sms import Client
+        account_obj = self.pool.get('powersms.core_accounts')
+        values = account_obj.read(cr, uid, ids, ['api_uname', 'api_pass'])
+        c = Client(user=str(values['api_uname']), password=str(values['api_pass']))
+        headers = {'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json'}
+        response = c.API.post(
+            headers=headers,
+            resource='',
+            json={
+                "sms": {
+                    "txt": message,
+                    "dst": {
+                        "num": number_to,
+                    },
+                    "src": from_name,
+                }
+            },
+        )
+        return response.result['code'] == 200 and response.result['status'] == 'Success'
+
+
+PowersmsProviderLleidaNet()

--- a/powersms/powersms_provider_lleidanet.py
+++ b/powersms/powersms_provider_lleidanet.py
@@ -5,7 +5,7 @@ from osv import osv, fields
 class PowersmsProviderLleidaNet(osv.osv):
     _inherit = 'powersms.provider'
 
-    def send_sms_lleida(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', context=None):
+    def send_sms_lleida(self, cursor, uid, _id, account_id, from_name, numbers_to, body='', files=None, context=None):
         from lleida_net.sms import Client
         account_obj = self.pool.get('powersms.core_accounts')
         values = account_obj.read(cursor, uid, account_id, ['api_uname', 'api_pass'])

--- a/powersms/powersms_smsbox.py
+++ b/powersms/powersms_smsbox.py
@@ -226,6 +226,8 @@ class PowersmsSMSbox(osv.osv):
         core_obj = self.pool.get('powersms.core_accounts')
         for id in ids:
             try:
+                ctx = context.copy()
+                ctx['from_smsbox_id'] = id
                 values = self.read(cr, uid, id, [], context) #Values will be a dictionary of all entries in the record ref by id
                 # ids, from_name, numbers_to, body = '', payload = None, context = None
 
@@ -236,7 +238,7 @@ class PowersmsSMSbox(osv.osv):
                     values.get('psms_body_text', '') or '',
                     self._get_attatchment_payload(cr, uid, values.get('pem_attachments_ids'), context=context),
                     # todo payload pem_attachments_ids read
-                    context=context
+                    context=ctx
                 )
                 if result is True:
                     self.write(cr, uid, id, {'folder':'sent', 'state':'sent', 'date_sms':time.strftime("%Y-%m-%d %H:%M:%S")}, context)

--- a/powersms/powersms_smsbox.py
+++ b/powersms/powersms_smsbox.py
@@ -1,5 +1,6 @@
 import netsvc
 import os
+from six import string_types
 from osv import osv, fields
 import pooler
 import re
@@ -9,6 +10,7 @@ from tools.config import config
 import tools
 from oorq.decorators import job
 import six
+import json
 
 LOGGER = netsvc.Logger()
 
@@ -37,7 +39,7 @@ class PowersmsSMSbox(osv.osv):
         ctx['meta'] = {}
         if vals:
             init_meta = vals.get('meta', {}) or {}
-            if isinstance(init_meta, basestring):
+            if isinstance(init_meta, string_types):
                 init_meta = json.loads(init_meta)
         else:
             init_meta = {}
@@ -155,12 +157,11 @@ class PowersmsSMSbox(osv.osv):
         """
         try:
             self.send_all_sms(cursor, user, context=context)
-        except Exception, e:
+        except Exception as e:
             LOGGER.notifyChannel(
                                  _("Power SMS"),
                                  netsvc.LOG_ERROR,
                                  _("Error sending sms: %s") % str(e))
-
 
     def send_all_sms(self, cr, uid, ids=None, context=None):
         if ids is None:
@@ -219,7 +220,7 @@ class PowersmsSMSbox(osv.osv):
                     values.get('psms_body_text', u'') or u'',
                     context=context
                 )
-                if result == True:
+                if result is True:
                     self.write(cr, uid, id, {'folder':'sent', 'state':'sent', 'date_sms':time.strftime("%Y-%m-%d %H:%M:%S")}, context)
                     self.historise(cr, uid, [id], "SMS sent successfully", context)
                 else:

--- a/powersms/powersms_smsbox_view.xml
+++ b/powersms/powersms_smsbox_view.xml
@@ -34,6 +34,12 @@
                                 </group>
                             </group>
                         </page>
+                        <page string="Attachments">
+                            <group col="4">
+                                <separator colspan="4" string="Attachments" />
+                                <field name="pem_attachments_ids" colspan="4" nolabel="1" height="400"/>
+                            </group>
+                        </page>
                     </notebook>
                     <separator colspan="4" string="" />
                     <group col="4" colspan="4">

--- a/powersms/powersms_smsbox_view.xml
+++ b/powersms/powersms_smsbox_view.xml
@@ -37,7 +37,7 @@
                         <page string="Attachments">
                             <group col="4">
                                 <separator colspan="4" string="Attachments" />
-                                <field name="pem_attachments_ids" colspan="4" nolabel="1" height="400"/>
+                                <field name="pem_attachments_ids" colspan="4" nolabel="1" height="400" widget="one2many"/>
                             </group>
                         </page>
                     </notebook>

--- a/powersms/powersms_template_view.xml
+++ b/powersms/powersms_template_view.xml
@@ -63,6 +63,8 @@
                                         attrs="{'readonly':[('ref_ir_act_window', '!=', False), ('ref_ir_value', '!=', False)]}"/>
                                 <field name="ref_ir_value" colspan="2"/>
                             </group>
+                            <separator string="Attachments (Report to attach)" colspan="4" />
+                            <field name="report_template" colspan="4" nolabel="1"/>
                         </page>
                     </notebook>
                 </form>

--- a/powersms/powersms_templates.py
+++ b/powersms/powersms_templates.py
@@ -145,6 +145,19 @@ class PowersmsTemplates(osv.osv):
         else:
             return message
 
+    def create_report(self, cursor, user, template, record_ids, context=None):
+        import netsvc
+        if context is None:
+            context = {}
+        report_obj = self.pool.get('ir.actions.report.xml')
+        report_name = report_obj.read(
+            cursor, user, template.report_template.id, ['report_name'], context=context
+        )['report_name']
+        report_name = 'report.' + report_name
+        service = netsvc.LocalService(report_name)
+        data = {'model': template.model_int_name}
+        _result, _format = service.create(cursor, user, record_ids, data, context=context)
+        return _result, _format
 
     _columns = {
         'name': fields.char('Name of Template', size=100, required=True),
@@ -217,6 +230,8 @@ class PowersmsTemplates(osv.osv):
                     "result is True the SMS will be send if it false the SMS "
                     "won't be send.\n"
                     "Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "),
+        'report_template': fields.many2one('ir.actions.report.xml', 'Report to send'),
+
     }
 
     _defaults = {
@@ -226,5 +241,6 @@ class PowersmsTemplates(osv.osv):
     _sql_constraints = [
         ('name', 'unique (name)', _('The template name must be unique!'))
     ]
+
 
 PowersmsTemplates()

--- a/powersms/security/ir.model.access.csv
+++ b/powersms/security/ir.model.access.csv
@@ -11,3 +11,6 @@
 "access_wizard_send_settings_manager","powersms.send.wizard","model_powersms_send_wizard","res_groups_psmsmanager",1,1,1,1
 "access_wizard_send_external_users","powersms.send.wizard","model_powersms_send_wizard","res_groups_psmsuserse",1,1,1,1
 "access_wizard_send_internal_users","powersms.send.wizard","model_powersms_send_wizard","res_groups_psmsusersi",1,1,1,1
+"access_powersms_provider_use","powersms.provider","model_powersms_provider","powersms.res_groups_psmsuserse",1,1,1,0
+"access_powersms_provider_usi","powersms.provider","model_powersms_provider","powersms.res_groups_psmsusersi",1,1,1,0
+"access_powersms_provider_man","powersms.provider","model_powersms_provider","powersms.res_groups_psmsmanager",1,1,1,1

--- a/powersms/security/ir.model.access.csv
+++ b/powersms/security/ir.model.access.csv
@@ -5,9 +5,9 @@
 "access_psms_template_settings_manager","powersms.templates","model_powersms_templates","res_groups_psmsmanager",1,1,1,1
 "access_psms_template_external_users","powersms.templates","model_powersms_templates","res_groups_psmsuserse",1,1,0,0
 "access_psms_template_internal_users","powersms.templates","model_powersms_templates","res_groups_psmsusersi",1,1,0,0
-"access_psms_mailbox_settings_manager","powersms.mailbox","model_powersms_smsbox","res_groups_psmsmanager",1,1,1,1
-"access_psms_mailbox_external_users","powersms.mailbox","model_powersms_smsbox","res_groups_psmsuserse",1,1,1,1
-"access_psms_mailbox_internal_users","powersms.mailbox","model_powersms_smsbox","res_groups_psmsusersi",1,1,1,1
+"access_psms_mailbox_settings_manager","powersms.smsbox","model_powersms_smsbox","res_groups_psmsmanager",1,1,1,1
+"access_psms_mailbox_external_users","powersms.smsbox","model_powersms_smsbox","res_groups_psmsuserse",1,1,1,1
+"access_psms_mailbox_internal_users","powersms.smsbox","model_powersms_smsbox","res_groups_psmsusersi",1,1,1,1
 "access_wizard_send_settings_manager","powersms.send.wizard","model_powersms_send_wizard","res_groups_psmsmanager",1,1,1,1
 "access_wizard_send_external_users","powersms.send.wizard","model_powersms_send_wizard","res_groups_psmsuserse",1,1,1,1
 "access_wizard_send_internal_users","powersms.send.wizard","model_powersms_send_wizard","res_groups_psmsusersi",1,1,1,1

--- a/powersms/tests/__init__.py
+++ b/powersms/tests/__init__.py
@@ -1,1 +1,2 @@
 from powersms_tests import *
+from test_powersms_coding_validation import *

--- a/powersms/tests/test_powersms_coding_validation.py
+++ b/powersms/tests/test_powersms_coding_validation.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+from destral import testing
+from destral.transaction import Transaction
+
+
+class TestProviders(testing.OOTestCase):
+    def test_provider_code_implementation(self):
+        with Transaction().start(self.database) as txn:
+            cursor, uid, pool = txn.cursor, txn.user, txn.pool
+            provider_obj = pool.get('powersms.provider')
+            providers = provider_obj.search(
+                cursor, uid, [], context={'active_test': False}
+            )
+            self.assertTrue(providers)
+            for p_id in providers:
+                self.assertTrue(hasattr(provider_obj, provider_obj._get_provider_function(cursor, uid, p_id)))
+
+    def test_provider_code_implementation_reverse(self):
+        with Transaction().start(self.database) as txn:
+            cursor, uid, pool = txn.cursor, txn.user, txn.pool
+            provider_obj = pool.get('powersms.provider')
+            provider_pattern_methods = [
+                m for m in dir(provider_obj) if m.startswith('send_sms_') and m != 'send_sms_default'
+            ]
+            self.assertTrue(provider_pattern_methods)
+            for _method in provider_pattern_methods:
+                self.assertTrue(
+                    provider_obj.search(cursor, uid, [('function_pattern_code', '=', _method.replace('send_sms_', ''))])
+                )
+
+

--- a/powersms/tests/test_powersms_coding_validation.py
+++ b/powersms/tests/test_powersms_coding_validation.py
@@ -29,4 +29,39 @@ class TestProviders(testing.OOTestCase):
                     provider_obj.search(cursor, uid, [('function_pattern_code', '=', _method.replace('send_sms_', ''))])
                 )
 
-
+    def test_migration_post_0001_set_lleidanet_provider_for_existing_acc(self):
+        import six
+        if six.PY2:
+            import imp
+            from addons import get_module_resource
+            script = get_module_resource(
+                'powersms', 'migrations', '5.0.23.1.0',
+                'post-0001-set_lleidanet_provider_for_existing_acc.py'
+            )
+            mod = imp.load_source('powersms', script)
+            with Transaction().start(self.database) as txn:
+                cursor, uid, pool = txn.cursor, txn.user, txn.pool
+                imd_obj = pool.get('ir.model.data')
+                acc_obj = pool.get('powersms.core_accounts')
+                cursor.execute(
+                    "ALTER TABLE powersms_core_accounts DROP COLUMN provider_id"
+                )
+                cursor.execute(
+                    "DROP TABLE powersms_provider"
+                )
+                mod.up(cursor, True)
+                provider_obj = pool.get('powersms.provider')
+                providers = provider_obj.search(
+                    cursor, uid, [], context={'active_test': False}
+                )
+                self.assertTrue(providers)
+                for p_id in providers:
+                    self.assertTrue(hasattr(provider_obj, provider_obj._get_provider_function(cursor, uid, p_id)))
+                account_id = imd_obj.get_object_reference(cursor, uid, 'powersms', 'sms_account_som')[1]
+                lleidanet_prov_id = imd_obj.get_object_reference(
+                    cursor, uid, 'powersms', 'powersms_provider_lleidanet'
+                )[1]
+                provider_on_account = acc_obj.read(cursor, uid, account_id, ['provider_id'])['provider_id']
+                self.assertTrue(provider_on_account)
+                provider_on_account = provider_on_account[0]
+                self.assertEqual(provider_on_account, lleidanet_prov_id)

--- a/powersms/wizard/wizard_send_sms.py
+++ b/powersms/wizard/wizard_send_sms.py
@@ -131,7 +131,7 @@ class PowersmsSendWizard(osv.osv_memory):
                     ) or _('Report')
                 ) + "." + format,
                 'description': vals['psms_body_text'] or _("No Description"),
-                'res_model': 'powersms.mailbox',
+                'res_model': 'powersms.smsbox',
                 'res_id': sms_id
             }
             attachment_id = attach_obj.create(cr, uid, attach_vals, context=context)

--- a/powersms/wizard/wizard_send_sms.py
+++ b/powersms/wizard/wizard_send_sms.py
@@ -119,10 +119,7 @@ class PowersmsSendWizard(osv.osv_memory):
             service = netsvc.LocalService(reportname)
             if template.report_template.context:
                 context.update(eval(template.report_template.context))
-            # if screen_vals['single_email'] and len(report_record_ids) > 1:
-            #     # The optional attachment will be generated as a single file for all these records
-            #     (result, format) = service.create(cr, uid, report_record_ids, data, context=context)
-            # else:
+
             (result, format) = service.create(cr, uid, [src_rec_id], data, context=context)
 
             attach_vals = {

--- a/powersms/wizard/wizard_send_sms.py
+++ b/powersms/wizard/wizard_send_sms.py
@@ -1,5 +1,6 @@
 from osv import osv, fields
 import tools
+from tools.translate import _
 
 class PowersmsSendWizard(osv.osv_memory):
     _name = 'powersms.send.wizard'
@@ -90,6 +91,46 @@ class PowersmsSendWizard(osv.osv_memory):
 
         return {'type': 'ir.actions.act_window_close'}
 
+    def create_report_attachment(self, cr, uid, template, vals, screen_vals, sms_id, report_record_ids, src_rec_id, context=None):
+        import netsvc
+        import base64
+        if context is None:
+            context = {}
+
+        ir_act_rep_xml_obj = self.pool.get('ir.actions.report.xml')
+        ir_model_obj = self.pool.get('ir.model')
+        attach_obj = self.pool.get('ir.attachment')
+
+        if template.report_template:
+            reportname_read = ir_act_rep_xml_obj.read(
+                cr, uid, template.report_template.id, ['report_name'], context=context
+            )['report_name']
+            reportname = 'report.' + reportname_read
+            data = {}
+            data['model'] = ir_model_obj.browse(cr, uid, screen_vals['rel_model'], context=context).model
+            service = netsvc.LocalService(reportname)
+            if template.report_template.context:
+                context.update(eval(template.report_template.context))
+            if screen_vals['single_email'] and len(report_record_ids) > 1:
+                # The optional attachment will be generated as a single file for all these records
+                (result, format) = service.create(cr, uid, report_record_ids, data, context=context)
+            else:
+                (result, format) = service.create(cr, uid, [src_rec_id], data, context=context)
+            attach_vals = {
+                'name': _('%s (Email Attachment)') % tools.ustr(vals['pem_subject']),
+                'datas': base64.b64encode(result),
+                'datas_fname': tools.ustr(
+                    self.get_end_value(
+                        cr, uid, src_rec_id, screen_vals['report'], template, context=context
+                    ) or _('Report')
+                ) + "." + format,
+                'description': vals['pem_body_text'] or _("No Description"),
+                'res_model': 'powersms.mailbox',
+                'res_id': sms_id
+            }
+            attachment_id = attach_obj.create(cr, uid, attach_vals, context=context)
+            return attachment_id
+        return False
 
     def save_to_smsbox(self, cr, uid, ids, context=None):
         model_obj = self.pool.get('ir.model')
@@ -110,18 +151,20 @@ class PowersmsSendWizard(osv.osv_memory):
         report_record_ids = context['src_rec_ids'][:]
         create_empty_number = context.get('create_empty_number', True)
         pca_obj = self.pool.get('powersms.core_accounts')
+        sms_box_obj = self.pool.get('powersms.smsbox')
 
-        for id in report_record_ids:
+        for rec_id in report_record_ids:
+            attachment_ids = []
             accounts = pca_obj.read(cr, uid, screen_vals['account'], context=context)
             psms_to = []
-            phone_numbers = self.get_value(cr, uid, template, getattr(template, 'def_to'), context, id)
+            phone_numbers = self.get_value(cr, uid, template, getattr(template, 'def_to'), context, rec_id)
             for number in list(set(map(str.strip,str(phone_numbers).split(',')))):
-                if pca_obj.check_numbers(cr, uid, id, number):
+                if pca_obj.check_numbers(cr, uid, rec_id, number):
                     psms_to.append(number)
 
             vals = {
                 'psms_from': screen_vals['from'],
-                'psms_body_text': get_end_value(id, screen_vals['body_text']),
+                'psms_body_text': get_end_value(rec_id, screen_vals['body_text']),
                 'psms_account_id': screen_vals['account'],
                 'state':'na',
             }
@@ -135,22 +178,33 @@ class PowersmsSendWizard(osv.osv_memory):
                 vals.update({'psms_to': number})
                 #Create partly the mail and later update attachments
                 ctx = context.copy()
-                ctx.update({'src_rec_id': id})
-                sms_id = self.pool.get('powersms.smsbox').create(cr, uid, vals, ctx)
+                ctx.update({'src_rec_id': rec_id})
+                sms_id = sms_box_obj.create(cr, uid, vals, ctx)
                 sms_ids.append(sms_id)
 
                # Ensure report is rendered using template's language. If not found, user's launguage is used.
                 ctx = context.copy()
                 if template.lang:
-                    ctx['lang'] = self.get_value(cr, uid, template, template.lang, context, id)
-                    lang = self.get_value(cr, uid, template, template.lang, context, id)
+                    ctx['lang'] = self.get_value(cr, uid, template, template.lang, context, rec_id)
+                    lang = self.get_value(cr, uid, template, template.lang, context, rec_id)
                     if len(self.pool.get('res.lang').search(cr, uid, [('name','=',lang)], context = context)):
                         ctx['lang'] = lang
                 if not ctx.get('lang', False) or ctx['lang'] == 'False':
                     ctx['lang'] = self.pool.get('res.users').read(cr, uid, uid, ['context_lang'], context)['context_lang']
 
-        return sms_ids
+                attachment_id = self.create_report_attachment(
+                    cr, uid, template, vals, screen_vals, sms_id, report_record_ids, rec_id, context=ctx
+                )
+                if attachment_id:
+                    attachment_ids.append(attachment_id)
 
+                if attachment_ids:
+                    mailbox_vals = {
+                        'pem_attachments_ids': [[6, 0, attachment_ids]]
+                    }
+                    sms_box_obj.write(cr, uid, sms_id, mailbox_vals, context=context)
+
+        return sms_ids
 
     _columns = {
         'ref_template':fields.many2one('powersms.templates','Template',readonly=True),


### PR DESCRIPTION
## Objectiu

Afegir el camp proveïdor als comptes de powersms
Delegar la logica d'enviar sms al proveïdor per fer el codi més generic
Afegir suport per reports y adjunts

![image](https://user-images.githubusercontent.com/15796004/225882777-4d756dec-a038-444d-ba92-c1fa49b962fd.png)

![image](https://user-images.githubusercontent.com/15796004/225882835-9a8576a3-e727-4f7b-8f24-016e04e031a3.png)

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul powersms  (--run-scripts=powersms)
- [x] Script de migració post-0001-set_lleidanet_provider_for_existing_acc.py
