### PR TITLE
modificar SobrecostesREE per SC i Interrump per I a la formula d'indexada

### DIFF
--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -490,7 +490,7 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
                                     ${_(u" - el preu horari es calcula d'acord amb la fórmula:")}
                                 </span>
                                 <br/>
-                                <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + SobrecostosREE + Interrump + POsOm) (1 + Perd) + FE + K] + PTD + CA")}</span>
+                                <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + Sc + I + POsOm) (1 + Perd) + FE + K] + PTD + CA")}</span>
                                 <br/>
                                 <span class="normal_font_weight">${_(u"on el marge de comercialització")}</span>
                                 <span>&nbsp;${("(K) = %s €/MWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d), digits=3)}</span>

--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -493,7 +493,7 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
                                 <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + Sc + I + POsOm) (1 + Perd) + FE + K] + PTD + CA")}</span>
                                 <br/>
                                 <span class="normal_font_weight">${_(u"on el marge de comercialització")}</span>
-                                <span>&nbsp;${("(K) = %s €/kWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d) / 1000.0, digits=3)}</span>
+                                <span>&nbsp;${("(K) = %s €/kWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d) / 1000.0, digits=6)}</span>
                             </td>
                         %else:
                             %for p in periodes_energia:

--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -493,7 +493,7 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
                                 <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + Sc + I + POsOm) (1 + Perd) + FE + K] + PTD + CA")}</span>
                                 <br/>
                                 <span class="normal_font_weight">${_(u"on el marge de comercialització")}</span>
-                                <span>&nbsp;${("(K) = %s €/MWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d), digits=3)}</span>
+                                <span>&nbsp;${("(K) = %s €/kWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d) / 1000.0, digits=3)}</span>
                             </td>
                         %else:
                             %for p in periodes_energia:


### PR DESCRIPTION
## Objectiu

modificar SobrecostesREE per SC i Interrump per I a la formula d'indexada de les dades de contracte

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2156660271/14249074

## Comportament antic

es mostra la formula així:

![image](https://user-images.githubusercontent.com/26924515/226864377-ff4600ad-446d-489f-86ce-85f380fca62f.png)

![image](https://user-images.githubusercontent.com/26924515/226864507-879952c9-cc78-42ee-b73d-c401bb83d054.png)

## Comportament nou

la formula es mostra així:

![image](https://user-images.githubusercontent.com/26924515/226867577-4e7b00ef-df77-4fcf-86e8-8fa1503b22e5.png)

![image](https://user-images.githubusercontent.com/26924515/226867981-90716d55-511e-4123-990f-16a6f6a8f25a.png)

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
