### PR TITLE
Unlink R101 claim when no invoice related

### DIFF
--- a/som_switching/wizard/wizard_create_r1.py
+++ b/som_switching/wizard/wizard_create_r1.py
@@ -102,6 +102,17 @@ class WizardSubtypeR1(osv.osv_memory):
 
         pol_obj.write(cursor, uid, polissa_id, pol_vals)
 
+        # Borrar reclamacions associades al pas sense factura associada
+        sw_id = sw_obj.browse(cursor, uid, res[-1])
+        if len(sw_id.step_ids) > 0:
+            pas_id = sw_id.step_ids[0].pas_id
+            model, index = pas_id.split(",")
+            m_obj = self.pool.get(model)
+            reclamacio_ids = m_obj.browse(cursor, uid, int(index)).reclamacio_ids
+            for reclamacio_id in reclamacio_ids:
+                if not reclamacio_id.num_factura:
+                    reclamacio_id.unlink()
+
         return res
 
     def fields_view_get(self, cursor, uid, view_id=None, view_type='form',


### PR DESCRIPTION
## Objectiu

Evitar detalls de reclamacions buides (sense factura associada) en un R101.

## Targeta on es demana o Incidència

https://secure.helpscout.net/conversation/2177022947/14332289?folderId=3063374

## Comportament antic
Al crear CAC a partir de factures tipus R, es creaven detalls de reclamació buits, o sense factura, vinculats al pas de l'ATC resultant. Això provocava molta pèrdua de temps corregint-ho per poder comunicar-ho a la distribuïdora.

## Comportament nou

Evitem la creació de detalls de reclamació buits, o sense factura, vinculats al pas de l'ATC.

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions