### PR TITLE
Afegir bo social 2023 a la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1352,7 +1352,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     'price_unit_multi': l.price_unit_multi,
                     'price_subtotal': l.price_subtotal,
                 })
-            if l.tipus in ('altres', 'cobrament') and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'DESC1721', 'DESC1721ENE', 'DESC1721POT'):
+            if l.tipus in ('altres', 'cobrament') and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'DESC1721', 'DESC1721ENE', 'DESC1721POT', 'RBS'):
                 altres_lines.append({
                     'name': l.name,
                     'price_subtotal': l.price_subtotal,
@@ -1658,7 +1658,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         donatiu_lines = [l for l in fact.linia_ids if l.tipus in 'altres'
                         and l.invoice_line_id.product_id.code == 'DN01']
         altres_lines = [l for l in fact.linia_ids if l.tipus in ('altres', 'cobrament')
-                        and l.invoice_line_id.product_id.code not in ('DN01', 'BS01')]
+                        and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'RBS')]
 
         extra_energy_lines = self.get_extra_energy_lines(fact, pol)
 
@@ -1705,6 +1705,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data['total_boe17_2021'] += self.get_sub_component_invoice_details_td_energy_discount_BOE17_2021_data(fact, pol)['total']
         total_altres = data['total_altres'] - data['total_boe17_2021']
         data['total_altres'] = total_altres if abs(total_altres) > 0.001 else 0
+        bosocial2023_lines = [l for l in fact.linia_ids if l.tipus in 'altres'
+                             and l.invoice_line_id.product_id.code == 'RBS']
+        data['total_bosocial2023'] = sum([l.price_subtotal for l in bosocial2023_lines])
         return data
 
     def get_component_partner_info_data(self, fact, pol):

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1905,6 +1905,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             'other_concepts': self.get_sub_component_invoice_details_td_other_concepts_data(fact, pol),
             'excess_power_maximeter': self.get_sub_component_invoice_details_td_excess_power_maximeter(fact, pol),
             'excess_power_quarterhours': self.get_sub_component_invoice_details_td_excess_power_quarterhours(fact, pol),
+            'bo_social_2023': self.get_sub_component_invoice_details_td_bo_social_2023_data(fact, pol),
             'generation': self.get_sub_component_invoice_details_td_generation_data(fact, pol),
             'inductive': self.get_sub_component_invoice_details_td_inductive_data(fact, pol),
             'capacitive': self.get_sub_component_invoice_details_td_capacitive_data(fact, pol),
@@ -2388,6 +2389,28 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             'excess_data': excess_data,
             'is_visible': True,
             'header_multi':4*(len(excess_data)),
+        }
+        return data
+
+    def get_sub_component_invoice_details_td_bo_social_2023_data(self, fact, pol):
+        days = 0.0
+        price_per_day = 0.0
+        subtotal = 0.0
+        visible = False
+
+        for l in fact.linia_ids:
+            if l.tipus in 'altres' and l.invoice_line_id.product_id.code == 'RBS':
+                days += l.quantity
+                price_per_day = l.price_unit
+                subtotal += l.price_subtotal
+                visible = True
+
+        data = {
+            'is_visible': visible,
+            'number_of_columns': len(self.get_matrix_show_periods(pol)) + 1,
+            'days':days,
+            'price_per_day': price_per_day,
+            'subtotal': subtotal,
         }
         return data
 

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-01-09 10:41+0000\n"
-"PO-Revision-Date: 2023-01-09 09:44+0000\n"
+"POT-Creation-Date: 2023-04-25 13:44+0000\n"
+"PO-Revision-Date: 2023-04-25 11:47+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2712
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -36,14 +36,14 @@ msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1925
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1930
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1932
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1921
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1926
 msgid "estimada"
 msgstr "estimada"
 
@@ -54,14 +54,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2742
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1960
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1965
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -72,7 +72,7 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1771
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1775
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
@@ -84,37 +84,37 @@ msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1923
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1928
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2596
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2624
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:773
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:774
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1716
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1722
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2654
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1769
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -124,13 +124,13 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2655
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2683
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1717
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
@@ -146,7 +146,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1777
 msgid "(real)"
 msgstr "(real)"
 
@@ -245,7 +245,7 @@ msgid "Costos regulats"
 msgstr "Costes regulados"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:27
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:35
 msgid "Impostos aplicats"
 msgstr "Impuestos aplicados"
 
@@ -254,12 +254,12 @@ msgid "Costos de producció electricitat"
 msgstr "Costes de producción de electricidad"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:36
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:48
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:46
 msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
 msgstr "DESTINO DEL IMPORTE DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:47
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
 msgstr "El destino del importe de tu factura, %s euros, es el siguiente:"
@@ -271,39 +271,35 @@ msgid ""
 "dels equips de mesura i control: %s €."
 msgstr "A los importes indicados en el diagrama debe añadirse, en su caso, el alquiler de los equipos de medida y control: %s €."
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
-msgid "RECORE: retribució a les renovables, cogeneració i residus"
-msgstr "RECORE: retribución a las renovables, cogeneración y residuos"
-
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:20
 msgid "Anualitat del dèficit"
 msgstr "Anualidad del déficit"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
 msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
 msgstr "Sobrecoste de generación en territorios no peninsulares (TNP)"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:24
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
 msgid "Altres costos regulats"
 msgstr "Otros costes regulados"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:85
 msgid "Lloguer de comptador"
 msgstr "Alquiler de contador"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
 msgid "Peatges de transport i distribució"
 msgstr "Peajes de transporte y distribución"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:4
 msgid "Càrrecs"
 msgstr "Cargos"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
 msgid "Energia"
 msgstr "Energía"
 
@@ -1254,7 +1250,8 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:53
@@ -1446,6 +1443,7 @@ msgstr "Bono social (RD 7/2016 23 diciembre)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:41
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:86
 #, python-format
 msgid "%s dies x %s €/dia"
@@ -1453,7 +1451,7 @@ msgstr "%s días x %s €/día"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:19
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:22
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:25
 msgid "Impost d'electricitat"
 msgstr "Impuesto de electricidad"
 
@@ -1492,7 +1490,7 @@ msgstr "Donativo voluntario (exento de IVA)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:30
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:39
 msgid "TOTAL IMPORT FACTURA"
 msgstr "TOTAL IMPORTE FACTURA"
 
@@ -1558,9 +1556,14 @@ msgstr "Detalle"
 msgid "Total conceptes"
 msgstr "Total conceptos"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:38
 msgid "TOTAL FACTURA"
 msgstr "TOTAL FACTURA"
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:7
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
+msgid "Bo social"
+msgstr "Bono social"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:9
 msgid "Penalització energia reactiva capacitiva"
@@ -1743,7 +1746,7 @@ msgstr "Precio energía reactiva inductiva [€/kVArh]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
 msgid "Altres conceptes"
 msgstr "Otros conceptos"
 
@@ -1923,12 +1926,12 @@ msgid "Penalització per energia reactiva"
 msgstr "Penalización por energía reactiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:20
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:26
 msgid "Lloguer del comptador"
 msgstr "Alquiler del contador"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:28
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:34
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
 msgid "Donatiu voluntari (0,01 &euro;/kWh) (exempt d'IVA)"
 msgstr "Donativo voluntario (0,01 &euro;/kWh) (exento de IVA)"
 
@@ -1948,7 +1951,7 @@ msgstr "Penalización por energía reactiva inductiva"
 msgid "Penalització per energia reactiva capacitiva"
 msgstr "Penalización por energía reactiva capacitiva"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:25
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:28
 msgid "Descompte sobre els càrrecs (RDL 17/2021)"
 msgstr "Descuento sobre los cargos (RDL 17/2021)"
 
@@ -1990,7 +1993,6 @@ msgid "Nom del / de la titular del contracte: "
 msgstr "Nombre del / de la titular del contrato: "
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:9
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:19
 msgid "NIF/CIF:"
 msgstr "NIF/CIF:"
 
@@ -2002,25 +2004,21 @@ msgstr "DATOS DE ABONO"
 msgid "DADES DE PAGAMENT"
 msgstr "DATOS DE PAGO"
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:18
-msgid "Titular compte bancari:"
-msgstr "Titular cuenta bancaria:"
-
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:19
 msgid "Entitat bancària:"
 msgstr "Entidad bancaria:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:21
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:20
 msgid "Núm. compte bancari:"
 msgstr "N.º cuenta bancaria:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:25
 msgid ""
 "L'import d'aquesta factura es carregarà al teu compte. El seu pagament queda"
 " justificat amb l'apunt bancari corresponent."
 msgstr "El importe de esta factura se cargará en tu cuenta. Su pago queda justificado con el correspondiente apunte bancario."
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:27
 msgid ""
 "L'import d'aquesta factura es pagarà mitjançant transferència bancària al "
 "compte indicat."

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-01-09 10:41+0000\n"
-"PO-Revision-Date: 2023-01-09 10:41+0000\n"
+"POT-Creation-Date: 2023-04-25 13:44+0000\n"
+"PO-Revision-Date: 2023-04-25 13:44+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2712
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -29,14 +29,14 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1925
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1930
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1932
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1921
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1926
 msgid "estimada"
 msgstr ""
 
@@ -47,14 +47,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2742
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1960
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1965
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -65,7 +65,7 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1771
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1775
 msgid "(sense lectura)"
 msgstr ""
 
@@ -77,37 +77,37 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1923
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1928
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2596
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2624
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:773
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:774
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1716
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1722
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2654
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1769
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
 msgid "(estimada)"
 msgstr ""
 
@@ -117,13 +117,13 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2655
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2683
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1717
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1777
 msgid "(real)"
 msgstr ""
 
@@ -238,7 +238,7 @@ msgid "Costos regulats"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:27
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:35
 msgid "Impostos aplicats"
 msgstr ""
 
@@ -247,12 +247,12 @@ msgid "Costos de producció electricitat"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:36
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:48
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:46
 msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:47
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
 msgstr ""
@@ -264,39 +264,35 @@ msgid ""
 " dels equips de mesura i control: %s €."
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
-msgid "RECORE: retribució a les renovables, cogeneració i residus"
-msgstr ""
-
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:20
 msgid "Anualitat del dèficit"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
 msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:24
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
 msgid "Altres costos regulats"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:85
 msgid "Lloguer de comptador"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
 msgid "Peatges de transport i distribució"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:4
 msgid "Càrrecs"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
 msgid "Energia"
 msgstr ""
 
@@ -1242,7 +1238,8 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:53
@@ -1436,6 +1433,7 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:41
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:86
 #, python-format
 msgid "%s dies x %s €/dia"
@@ -1443,7 +1441,7 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:19
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:22
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:25
 msgid "Impost d'electricitat"
 msgstr ""
 
@@ -1482,7 +1480,7 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:30
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:39
 msgid "TOTAL IMPORT FACTURA"
 msgstr ""
 
@@ -1548,8 +1546,13 @@ msgstr ""
 msgid "Total conceptes"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:38
 msgid "TOTAL FACTURA"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:7
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
+msgid "Bo social"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:9
@@ -1733,7 +1736,7 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
 msgid "Altres conceptes"
 msgstr ""
 
@@ -1913,12 +1916,12 @@ msgid "Penalització per energia reactiva"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:20
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:26
 msgid "Lloguer del comptador"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:28
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:34
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
 msgid "Donatiu voluntari (0,01 &euro;/kWh) (exempt d'IVA)"
 msgstr ""
 
@@ -1938,7 +1941,7 @@ msgstr ""
 msgid "Penalització per energia reactiva capacitiva"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:25
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:28
 msgid "Descompte sobre els càrrecs (RDL 17/2021)"
 msgstr ""
 
@@ -1980,7 +1983,6 @@ msgid "Nom del / de la titular del contracte: "
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:9
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:19
 msgid "NIF/CIF:"
 msgstr ""
 
@@ -1992,25 +1994,21 @@ msgstr ""
 msgid "DADES DE PAGAMENT"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:18
-msgid "Titular compte bancari:"
-msgstr ""
-
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:19
 msgid "Entitat bancària:"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:21
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:20
 msgid "Núm. compte bancari:"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:25
 msgid ""
 "L'import d'aquesta factura es carregarà al teu compte. El seu pagament "
 "queda justificat amb l'apunt bancari corresponent."
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:27
 msgid ""
 "L'import d'aquesta factura es pagarà mitjançant transferència bancària al"
 " compte indicat."

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
@@ -29,6 +29,7 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako" args="id=id.energy_tolls" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako" args="id=id.energy_charges" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako" args="id=id.energy_discount_BOE17_2021" />
+    <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako" args="bs=id.bo_social_2023" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako" args="id=id.generation" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako" args="id=id.inductive" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako" args="id=id.capacitive" />

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako
@@ -1,0 +1,11 @@
+<%page args="bs" />
+%if bs.is_visible:
+<%
+import locale
+%>
+<tr>
+    <td class="td_first concepte_td">${_(u"Bo social")}</td>
+    <td class="detall_td" colspan="${bs.number_of_columns}">${_(u"%s dies x %s €/dia") % (int(bs.days), locale.str(locale.atof(formatLang(bs.price_per_day, digits=6))))}</td>
+    <td class="subtotal">${_(u"%s €") % formatLang(bs.subtotal)}</td>
+</tr>
+%endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako
@@ -3,9 +3,9 @@
 <%
 import locale
 %>
-<tr>
-    <td class="td_first concepte_td">${_(u"Bo social")}</td>
-    <td class="detall_td" colspan="${bs.number_of_columns}">${_(u"%s dies x %s €/dia") % (int(bs.days), locale.str(locale.atof(formatLang(bs.price_per_day, digits=6))))}</td>
-    <td class="subtotal">${_(u"%s €") % formatLang(bs.subtotal)}</td>
-</tr>
+    <tr class="last_row">
+        <td class="td_first concepte_td">${_(u"Bo social")}</td>
+        <td class="detall_td" colspan="${bs.number_of_columns}">${_(u"%s dies x %s €/dia") % (int(bs.days), locale.str(locale.atof(formatLang(bs.price_per_day, digits=6))))}</td>
+        <td class="subtotal">${_(u"%s €") % formatLang(bs.subtotal)}</td>
+    </tr>
 %endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako
@@ -24,6 +24,9 @@
     % if invs.total_boe17_2021 != 0:
         <tr><td>${_(u"Descompte sobre els càrrecs (RDL 17/2021)")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_boe17_2021)}</td></tr>
     % endif
+    % if invs.total_bosocial2023 != 0:
+        <tr><td>${_(u"Bo social")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_bosocial2023)}</td></tr>
+    % endif
     % if (invs.total_altres + invs.total_bosocial) != 0:
         <tr><td>${_(u"Altres conceptes")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_altres + invs.total_bosocial)}</td></tr>
     % endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako
@@ -19,13 +19,13 @@
     % if invs.capacitive_is_visible:
         <tr><td>${_(u"Penalització per energia reactiva capacitiva")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_capacitive)}</td></tr>
     % endif
+    % if invs.total_bosocial2023 != 0:
+        <tr><td>${_(u"Bo social")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_bosocial2023)}</td></tr>
+    % endif
         <tr><td>${_(u"Impost d'electricitat")}</td><td class="e">${"%s &euro;" % formatLang(invs.iese)}</td></tr>
         <tr><td>${_(u"Lloguer del comptador")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_rent)}</td></tr>
     % if invs.total_boe17_2021 != 0:
         <tr><td>${_(u"Descompte sobre els càrrecs (RDL 17/2021)")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_boe17_2021)}</td></tr>
-    % endif
-    % if invs.total_bosocial2023 != 0:
-        <tr><td>${_(u"Bo social")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_bosocial2023)}</td></tr>
     % endif
     % if (invs.total_altres + invs.total_bosocial) != 0:
         <tr><td>${_(u"Altres conceptes")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_altres + invs.total_bosocial)}</td></tr>


### PR DESCRIPTION
## Objectiu

Afegir el bo social de 2023 a la factura en pdf mitjançant una entrada nova al bloc de línies de factura i al resum

## Targeta on es demana o Incidència 

https://trello.com/c/SyB5AVYW/4326-pintar-fila-bo-social-al-pdf-factura

## Comportament antic

No es mostrava i apareixia en secció altres conceptes

## Comportament nou

No es mostra en secció d'altres conceptes
Es mostra en un bloc específic
Es mostra al resum de la factura inicial separadament

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
     - giscedata_facturacio_comer_som
- [ ] Script de migració
- [x] Modifica traduccions
