### PR TITLE
Solucionar error en afegir partners amb Gkwh als enviaments massius

### DIFF
--- a/som_infoenergia/wizard/wizard_create_enviaments_from_partner.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_partner.py
@@ -31,26 +31,36 @@ class WizardAddPartnersLot(osv.osv_memory):
             'baixa': [('baixa', '=', wiz.baixa)],
             'init_date': [('data_baixa_soci', '>=', wiz.init_date)],
             'end_date': [('data_baixa_soci', '<=', wiz.end_date)],
-            'has_gkwh': [('has_gkwh', '=', wiz.has_gkwh)],
             'vat': [('vat', 'ilike', "%{}%".format(wiz.vat))],
         }
         for field in search_params_relation.keys():
             if getattr(wiz, field):
                 search_params += (search_params_relation[field])
 
+        partner_ids = []
+        soci_obj = self.pool.get('somenergia.soci')
+
         if wiz.te_aportacions:
             inv_obj = self.pool.get('generationkwh.investment')
             inv_ids = inv_obj.search(cursor, uid, [('emission_id.type', '=', 'apo')])
-            member_ids =  [x['member_id'][0] for x in inv_obj.read(cursor, uid, inv_ids, ['member_id']) ]
-            soci_obj = self.pool.get('somenergia.soci')
-            partner_ids = [ x['partner_id'][0] for x in soci_obj.read(cursor, uid, member_ids, ['partner_id']) ]
-            search_params += [('id', 'in', partner_ids)]
+            member_ids = [x['member_id'][0] for x in inv_obj.read(
+                cursor, uid, inv_ids,['member_id']) ]
+            partner_ids += [x['partner_id'][0] for x in soci_obj.read(
+                cursor, uid, member_ids, ['partner_id'])]
 
         if wiz.es_soci:
-            soci_obj = self.pool.get('somenergia.soci')
             soci_ids = soci_obj.search(cursor, uid, [('data_baixa_soci','=', False)])
-            partner_ids = [ x['partner_id'][0] for x in soci_obj.read(cursor, uid, soci_ids, ['partner_id']) ]
-            search_params += [('id', 'in', partner_ids)]
+            partner_ids += [x['partner_id'][0] for x in soci_obj.read(
+                cursor, uid, soci_ids, ['partner_id'])]
+
+        if wiz.has_gkwh:
+            soci_ids = soci_obj.search(
+                cursor, uid, [('data_baixa_soci','=', False), ('has_gkwh','=', True)])
+            partner_ids += [x['partner_id'][0] for x in soci_obj.read(
+                cursor, uid, soci_ids, ['partner_id'])]
+
+        partner_ids = list(set(partner_ids))
+        search_params += [('id', 'in', partner_ids)] if partner_ids else ""
 
         res_ids = partner_obj.search(cursor, uid, search_params)
 
@@ -59,7 +69,8 @@ class WizardAddPartnersLot(osv.osv_memory):
             'len_result': 'La cerca ha trobat {} resultats'.format(len(res_ids))
         })
         ctx = {'from_model': 'partner_id'}
-        lot_obj.create_enviaments_from_object_list(cursor, uid, context.get('active_id'), res_ids, ctx)
+        lot_obj.create_enviaments_from_object_list(
+            cursor, uid, context.get('active_id'), res_ids, ctx)
 
     _columns = {
         'category': fields.many2one('res.partner.category',


### PR DESCRIPTION
## Objectiu
Que es puguen filtrar i afegir partners amb generation als lots d'enviament massiu

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2196792245/14467740?folderId=3063374

## Comportament antic
Donava error i no deixava afegir partners amb aquest filtre.

## Comportament nou
Ja permet filtrar i afegir partners amb aquest filtre.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
