### PR TITLE
Mostrar la k correcta a condicions particulars per polisses amb k definida per tarifa

### DIFF
--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -499,7 +499,7 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
                                         today = datetime.today().strftime("%Y-%m-%d")
                                         vlp = None
                                         for lp in polissa.llista_preu.version_id:
-                                            if lp.date_start <= today and (lp.date_end == False or lp.date_end >= today):
+                                            if lp.date_start.val <= today and (not lp.date_end or lp.date_end.val >= today):
                                                 vlp = lp
                                                 break
                                         if vlp:

--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -493,7 +493,22 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
                                 <span>${_(u"PH = 1,015 * [(PHM + PHMA + Pc + Sc + I + POsOm) (1 + Perd) + FE + K] + PTD + CA")}</span>
                                 <br/>
                                 <span class="normal_font_weight">${_(u"on el marge de comercialització")}</span>
-                                <span>&nbsp;${("(K) = %s €/kWh</B>") % formatLang((polissa.coeficient_k + polissa.coeficient_d) / 1000.0, digits=6)}</span>
+                                <%
+                                    coeficient_k = polissa.coeficient_k + polissa.coeficient_d
+                                    if coeficient_k == 0:
+                                        today = datetime.today().strftime("%Y-%m-%d")
+                                        vlp = None
+                                        for lp in polissa.llista_preu.version_id:
+                                            if lp.date_start <= today and (lp.date_end == False or lp.date_end >= today):
+                                                vlp = lp
+                                                break
+                                        if vlp:
+                                            for item in vlp.items_id:
+                                                if item.name == 'Coeficient K':
+                                                    coeficient_k = item.base_price
+                                                    break
+                                %>
+                                <span>&nbsp;${("(K) = %s €/kWh</B>") % formatLang((coeficient_k) / 1000.0, digits=6)}</span>
                             </td>
                         %else:
                             %for p in periodes_energia:


### PR DESCRIPTION
## Objectiu

Amb l'entrada de la tarifa indexada a contractes en general, cal mostrar la k al document de condicions particulars quan aquesta ve definida per tarifa i no directament a polissa.

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2193623551/14450458

## Comportament antic

es mostrava la k de la pòlissa que sol ser 0

## Comportament nou

es mostra la k de tarifa associada si a la pòlissa no esta definida o es 0

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
