### PR TITLE
Ficar la columna 'additional information' al final del tree de facturas de cliente

### DIFF
--- a/som_extend_facturacio_comer/giscedata_facturacio_view.xml
+++ b/som_extend_facturacio_comer/giscedata_facturacio_view.xml
@@ -34,7 +34,7 @@
             <field name="model">giscedata.facturacio.factura</field>
             <field name="inherit_id" ref="giscedata_facturacio.view_factura_tree"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='origin']" position="after">
+                <xpath expr="//field[@name='origin_date_invoice']" position="after">
                     <field name="comment"/>
                 </xpath>
             </field>


### PR DESCRIPTION
## Objectiu
Que la columna 'additional information' aparega al final del tree, ja que al poder contindre molta info, obliga a fer scroll horitzontal per veure altres columnes més importants.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2212267401/14649801?folderId=3063379

## Comportament antic
Apareixia abans a meitat del tree.

## Comportament nou
Apareix al final del tree.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
