### PR TITLE
Fix menu_autoconsum parent id model

### DIFF
--- a/som_switching/demo/som_switching_demo_data.xml
+++ b/som_switching/demo/som_switching_demo_data.xml
@@ -4,9 +4,9 @@
         <record  model="giscedata.atc" id="cas_atc_0001">
             <field name="name">ccc</field>
             <field name="provincia" ref="l10n_ES_toponyms.ES17"/>
-            <field name="section_id">1</field>
+            <field name="section_id" eval="1"/>
             <field name="sector">electric</field>
-            <field name="subtipus_id">1</field>
+            <field name="subtipus_id" eval="1"/>
             <field name="reclamante">06</field>
             <field name="agent_actual">06</field>
 		</record>

--- a/som_switching/wizard/wizard_validate_d101_view.xml
+++ b/som_switching/wizard/wizard_validate_d101_view.xml
@@ -49,6 +49,6 @@
             <field name="view_mode">form</field>
             <field name="target">new</field>
         </record>
-        <menuitem id="menu_wizard_validate_d101_form" name="Validar D101" action="action_wizard_validate_d101_form" parent="giscedata_polissa.menu_autoconsum"/>
+        <menuitem id="menu_wizard_validate_d101_form" name="Validar D101" action="action_wizard_validate_d101_form" parent="giscedata_cups.menu_autoconsum"/>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu

Permetre que els tests de `som_switching` s'executin.

## Comportament antic

Es feia servir un menú que ja no existeix a `developer` de GISCE. També hi havia errors en la _demo data_.

## Comportament nou

Es fa servir el menú `giscedata_cups.menu_autoconsum` i s'arreglen errors en la _demo data_.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
