### PR TITLE
Prioritzar camps filtre en trees de factures

### DIFF
--- a/som_account_invoice_pending/account_invoice_pending_view.xml
+++ b/som_account_invoice_pending/account_invoice_pending_view.xml
@@ -37,5 +37,19 @@
                 </field>
             </field>
         </record>
+        <record model="ir.ui.view" id="view_invoice_pending_form">
+            <field name="name">account.invoice.pending.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account_invoice_pending.view_invoice_pending_form"/>
+            <field name="type">tree</field>
+            <field name="arch" type="xml" >
+                <field name="pending_state" position="replace">
+                    <field name="pending_state" select="1" size="32"/>
+                </field>
+                <field name="pending_state_date" position="replace">
+                    <field name="pending_state_date" select="1"/>
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu
Menejar camps  'pending_state' i 'pending_state_date' a la part de filtres que apareixen a la part sense desplegar.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2215432371/14666504?folderId=7422776

## Comportament antic
Calia donar-li al '+' per a poder filtrar per eixos camps.

## Comportament nou
Apareix a la part sense desplegar.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
