### PR TITLE
Prioritzar camps filtre en trees de factures II

### DIFF
--- a/som_account_invoice_pending/account_invoice_pending_view.xml
+++ b/som_account_invoice_pending/account_invoice_pending_view.xml
@@ -41,14 +41,14 @@
             <field name="name">account.invoice.pending.form</field>
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account_invoice_pending.view_invoice_pending_form"/>
-            <field name="type">tree</field>
+            <field name="type">form</field>
             <field name="arch" type="xml" >
-                <field name="pending_state" position="replace">
-                    <field name="pending_state" select="1" size="32"/>
-                </field>
-                <field name="pending_state_date" position="replace">
-                    <field name="pending_state_date" select="1"/>
-                </field>
+                <xpath expr="//field[@name='pending_state']" position="attributes">
+                    <attribute name="select">1</attribute>
+                </xpath>
+                <xpath expr="//field[@name='pending_state_date']" position="attributes">
+                    <attribute name="select">1</attribute>
+                </xpath>
             </field>
         </record>
     </data>

--- a/som_account_invoice_pending/account_invoice_pending_view.xml
+++ b/som_account_invoice_pending/account_invoice_pending_view.xml
@@ -43,10 +43,18 @@
             <field name="inherit_id" ref="account_invoice_pending.view_invoice_pending_form"/>
             <field name="type">form</field>
             <field name="arch" type="xml" >
-                <xpath expr="//field[@name='pending_state']" position="attributes">
+                <xpath expr="//field[@name='pending_state_date']" position="attributes">
                     <attribute name="select">1</attribute>
                 </xpath>
-                <xpath expr="//field[@name='pending_state_date']" position="attributes">
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_factura_pendent_signed_tree">
+            <field name="name">giscedata.facturacio.factura.pendent.signed.tree</field>
+            <field name="model">giscedata.facturacio.factura</field>
+            <field name="inherit_id" ref="giscedata_facturacio_impagat.view_factura_pendent_signed_tree"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml" >
+                <xpath expr="//field[@name='pending_state']" position="attributes">
                     <attribute name="select">1</attribute>
                 </xpath>
             </field>


### PR DESCRIPTION
## Objectiu
Menejar camps  'pending_state' i 'pending_state_date' a la part de filtres que apareixen a la part sense desplegar. En aquest cas utilitzant la modificació de attributes en volta de replace dels camps.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2215432371/14666504?folderId=7422776

## Comportament antic
Calia donar-li al '+' per a poder filtrar per eixos camps.

## Comportament nou
Apareix a la part sense desplegar.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
