### PR TITLE
Afegir adjunt pel certificat de l'IRPF de les aportacions i títols

### DIFF
--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
@@ -35,13 +35,14 @@ class WizardCancelFromCSV(osv.osv_memory):
         if context is None:
             context = {}
 
-        model_name = 'res.partner' if self.model_name == 'partner' else 'giscedata.polissa'
-        model_id = 'partner_id' if self.model_name == 'partner' else 'polissa_id'
-        field_search = 'ref' if self.model_name == 'partner' else 'name'
-
         lot_obj = self.pool.get('som.infoenergia.lot.enviament')
         model_obj = self.pool.get(model_name)
         wiz = self.browse(cursor, uid, ids[0], context=context)
+
+        model_name = 'res.partner' if wiz.model_name == 'partner' else 'giscedata.polissa'
+        model_id = 'partner_id' if wiz.model_name == 'partner' else 'polissa_id'
+        field_search = 'ref' if wiz.model_name == 'partner' else 'name'
+
         vals = {'from_model': model_id}
         csv_file = StringIO(base64.b64decode(wiz.csv_file))
         reader = csv.reader(csv_file)

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
@@ -39,6 +39,7 @@ class WizardCancelFromCSV(osv.osv_memory):
         wiz = self.browse(cursor, uid, ids[0], context=context)
 
         model_name = 'res.partner' if wiz.model_name == 'partner' else 'giscedata.polissa'
+        model_desc = 'partners' if wiz.model_name == 'partner' else 'pòlisses'
         model_id = 'partner_id' if wiz.model_name == 'partner' else 'polissa_id'
         field_search = 'ref' if wiz.model_name == 'partner' else 'name'
         model_obj = self.pool.get(model_name)
@@ -78,7 +79,7 @@ class WizardCancelFromCSV(osv.osv_memory):
         lot_id = context.get('active_id', [])
         item_ids = model_obj.search(cursor, uid, [(field_search, 'in', item_list)])
         lot_obj.create_enviaments_from_object_list(cursor, uid, lot_id, item_ids, vals)
-        msg = _(u"Es crearan els enviaments de {} pòlisses en segon pla".format(len(item_ids)))
+        msg = _(u"Es crearan els enviaments de {} {} en segon pla".format(len(item_ids), model_desc))
         wiz.write({'state': "finished", 'info': msg})
         return True
 

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
@@ -24,7 +24,7 @@ class WizardCancelFromCSV(osv.osv_memory):
         'csv_file': fields.binary(_(u'Fitxer CSV'), required=True, help=_(u"Número de pòlissa de les pòlisses o número de partners dels quals se'n vol crear un enviament")),
         'state': fields.selection(STATES, _(u'Estat del wizard de crear enviaments des de CSV')),
         'info': fields.text(_(u'Informació'), help=_(u"Només es creen enviaments de pòlisses Activa=Si"), size=256, readonly=True),
-        'model_name': fields.selection(STATES, _(u'Tipus de model a importar')),
+        'model_name': fields.selection(FROM_MODEL, _(u'Tipus de model a importar')),
     }
     _defaults = {
         'state': 'init',

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
@@ -36,12 +36,12 @@ class WizardCancelFromCSV(osv.osv_memory):
             context = {}
 
         lot_obj = self.pool.get('som.infoenergia.lot.enviament')
-        model_obj = self.pool.get(model_name)
         wiz = self.browse(cursor, uid, ids[0], context=context)
 
         model_name = 'res.partner' if wiz.model_name == 'partner' else 'giscedata.polissa'
         model_id = 'partner_id' if wiz.model_name == 'partner' else 'polissa_id'
         field_search = 'ref' if wiz.model_name == 'partner' else 'name'
+        model_obj = self.pool.get(model_name)
 
         vals = {'from_model': model_id}
         csv_file = StringIO(base64.b64decode(wiz.csv_file))

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv.py
@@ -35,9 +35,9 @@ class WizardCancelFromCSV(osv.osv_memory):
         if context is None:
             context = {}
 
-        model_name = 'res.partner' if self.model_id == 'partner' else 'giscedata.polissa'
-        model_id = 'partner_id' if self.model_id == 'partner' else 'polissa_id'
-        field_search = 'ref' if self.model_id == 'partner' else 'name'
+        model_name = 'res.partner' if self.model_name == 'partner' else 'giscedata.polissa'
+        model_id = 'partner_id' if self.model_name == 'partner' else 'polissa_id'
+        field_search = 'ref' if self.model_name == 'partner' else 'name'
 
         lot_obj = self.pool.get('som.infoenergia.lot.enviament')
         model_obj = self.pool.get(model_name)

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv_view.xml
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv_view.xml
@@ -9,7 +9,7 @@
                 <form string="Crea enviaments des de CSV">
                     <field name="state" invisible="1"/>
                     <group attrs="{'invisible': [('state', '!=', 'init')]}">
-                        <label string="Crear enviaments de les pòlisses indicades al CSV" colspan="4"/>
+                        <label string="Crear enviaments de les entitats indicades al CSV" colspan="4"/>
                         <label string="Format del CSV: a la primera columna hi ha d'haver els números dels contractes o dels partners, un a cada fila. Les següents columnes que hi hagi, les guardarà en un diccionari de dades al camp 'Informació Extra'" colspan="4"/>
                         <field name="csv_file" colspan="4" filename="name" string="Arxiu CSV"/>
                         <field name="model_name" colspan="4"/>

--- a/som_infoenergia/wizard/wizard_create_enviaments_from_csv_view.xml
+++ b/som_infoenergia/wizard/wizard_create_enviaments_from_csv_view.xml
@@ -10,10 +10,11 @@
                     <field name="state" invisible="1"/>
                     <group attrs="{'invisible': [('state', '!=', 'init')]}">
                         <label string="Crear enviaments de les pòlisses indicades al CSV" colspan="4"/>
-                        <label string="Format del CSV: a la primera columna hi ha d'haver els números dels contractes, un contracte a cada fila. Les següents columnes que hi hagi, les guardarà en un diccionari de dades al camp 'Informació Extra'" colspan="4"/>
+                        <label string="Format del CSV: a la primera columna hi ha d'haver els números dels contractes o dels partners, un a cada fila. Les següents columnes que hi hagi, les guardarà en un diccionari de dades al camp 'Informació Extra'" colspan="4"/>
                         <field name="csv_file" colspan="4" filename="name" string="Arxiu CSV"/>
-                            <button special="cancel" string="Sortir" icon="gtk-cancel"/>
-                            <button name="create_from_file" type="object" string="Crear enviaments" icon="gtk-execute"/>
+                        <field name="model_name" colspan="4"/>
+                        <button special="cancel" string="Sortir" icon="gtk-cancel"/>
+                        <button name="create_from_file" type="object" string="Crear enviaments" icon="gtk-execute"/>
                     </group>
                     <group attrs="{'invisible': [('state', '!=', 'finished')]}">
                             <field name="info" colspan="4"/>

--- a/som_inversions/report/__init__.py
+++ b/som_inversions/report/__init__.py
@@ -1,3 +1,4 @@
 import report_liquidacions
 import report_liquidacions_unificat
 import report_retencions_interessos
+import report_retencions_interessos_titols

--- a/som_inversions/report/__init__.py
+++ b/som_inversions/report/__init__.py
@@ -2,3 +2,4 @@ import report_liquidacions
 import report_liquidacions_unificat
 import report_retencions_interessos
 import report_retencions_interessos_titols
+import report_retencions_interessos_apo

--- a/som_inversions/report/report_retencions_interessos_apo.mako
+++ b/som_inversions/report/report_retencions_interessos_apo.mako
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+
+<%
+    import logging
+    logger = logging.getLogger('openerp')
+    report = objects[0]
+    data = report.report_retencions_data()
+    setLang(data.lang)
+%>
+
+<html>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700;900&display=swap" rel="stylesheet">
+<head>
+    <style type="text/css">
+    body {
+      margin: 5% 5% 5% 5%;
+    }
+    h1, h2, h3, p, ol, ul {
+      font-family: Roboto;
+      margin: 0px;
+    }
+    .capsalera{
+      width: 100%;
+      display: inline-block;
+    }
+    .fila {
+      display: table-row;
+    }
+    .LogoPpal {
+      display: table-cell;
+      width: 20%;
+      vertical-align: top;
+      font-size: 0.9em;
+      text-align: left;
+    }
+    .LogoPpal img {
+      display: block;
+      margin-left: 19px;
+      margin-top: -10px;
+    }
+    .sotalogo {
+      display: block;
+      margin-top: -35px;
+      padding: 0px 28px;
+      font-size: 0.85em;
+      line-height: 1.5em;
+      max-width: 50%;
+    }
+    .TitolHeader {
+      display: table-cell;
+      vertical-align: top;
+      max-width: 50%;
+      float: right;
+      margin-top: -175px;
+    }
+    h1.titol {
+      text-align: right;
+      font-size: 1.3em;
+      margin-top:8px;
+    }
+    h2.titol {
+      text-align: center;
+      font-size: 1.1em;
+      margin-bottom: 30px;
+    }
+    .caixaHeader {
+      display: table-cell;
+      background: #EDEEF0;
+      border-bottom: 10px solid #BFC74D;
+      width: 100%;
+      padding-bottom: 15px;
+      float: right;
+    }
+    .dreta, .esquerra {
+      display: table-cell;
+      width: 50%;
+      height: 90px;
+      margin: 0;
+      padding: 0;
+    }
+    .caixaHeader .ContingutDades  {
+      text-align: left;
+      line-height: 1.4em;
+      font-size: 0.85em;
+    }
+    .caixaHeader .doblecaixa {
+      margin-bottom: -15px;
+      padding-bottom: 0px;
+    }
+    .DataDoc {
+      margin: 35px 0;
+      text-align: right;
+      font-size: 1em;
+    }
+    .TitolCaixa {
+      background: #4D4D4D;
+    }
+    .TitolCaixa h2, .CaixaTitTitular h3,.CaixaTitAportacio h3, .InfoAddTitol h3 {
+      font-weight: 900;
+      font-size: 1em;
+      color: white;
+      padding: 8px 27px;
+    }
+    .CaixaFons {
+      background: #EDEEF0;
+    }
+    .doblecaixa{
+      width: 100%;
+      display: table;
+      /*margin-left: 0 auto;*/
+      padding: 20px;
+    }
+    .CaixaTitTitular, .CaixaTitAportacio {
+      display: table-cell;
+      background: #BFC74D;
+      color:white;
+      width:48.5%;
+      margin-top:0px;
+    }
+    .CaixaDadesTitular, .CaixaDadesAportacio {
+      display: table-cell;
+      background: white;
+      padding: 30px 30px;
+      line-height: 2.2em;
+      font-size: 0.85em;
+      text-align: justify;
+      padding-bottom: 54px;
+    }
+    .footer {
+      position: fixed;
+      bottom: 3%;
+      background: white;
+      padding: 0px 30px;
+      text-align: center;
+      font-size: 0.85em;
+      height: 2%;
+
+    }
+    @media print {
+      footer {
+        position:relative;
+        top:-20px;
+      }
+    }
+    </style>
+</head>
+<body>
+<div class="capsalera">
+  <div class="fila">
+    <div class="LogoPpal">
+      <a href="https://www.somenergia.coop" target="_blank">
+        <img src="${addons_path}/som_inversions/report/logo.jpg" width="150" height="150"/ alt="Logo Som Energia"></a><br>
+      <p class="sotalogo"><b>${data.somenergia.partner_name}</b><br>${_(u"CIF:")} ${data.somenergia.partner_vat.replace('ES','')}<br>${_(u"Domicili:")} ${data.somenergia.address_street} ${data.somenergia.address_zip} - ${data.somenergia.address_city}<br>
+        ${_(u"Adreça electrònica:")} aporta@somenergia.coop
+    </div>
+  </div>
+  <div class="TitolHeader">
+    <h2 class="titol">${_(u"Comunicat de rendiments per a la")}<br/>${_(u"declaració de la RENDA ")}${data.year}</h2>
+    <div class="caixaHeader">
+      <div class="doblecaixa">
+         <div class="fila">
+            <div class="dreta">
+               <p class="ContingutDades">
+                  ${_(u"<b>Data:</b>")}<br/>
+                  ${_(u"<b>Exercici:</b>")}<br/>
+                  ${_(u"<b>Tipus d'aportació:</b>")}<br/>
+               </p>
+            </div>
+            <div class="esquerra">
+              <p class="ContingutDades">
+                ${formatLang(time.strftime('%Y-%m-%d'), date=True)}<br/>
+                ${data.year}<br>
+                ${_("Aportacions voluntàries al capital social")}
+              </p>
+            </div>
+        </div>
+    </div>
+  </div>
+</div>
+
+</div>
+<div class="DataDoc">
+
+</div>
+<div class="TitolCaixa">
+  <h2></h2>
+</div>
+
+<div class="CaixaFons">
+  <div class="doblecaixa">
+    <div class="fila">
+      <div class="CaixaTitTitular">
+       <h3>${_(u"DADES DEL TITULAR")}</h3>
+      </div>
+      <div class="CaixaEspai">
+      </div>
+      <div class="CaixaTitAportacio">
+       <h3>${_(u"INFORMACIÓ FISCAL")}</h3>
+      </div>
+    </div>
+    <div class="fila">
+      <div class="CaixaDadesTitular">
+        <p class="ContingutDades"><b>${_(u"Nom:")}</b> ${data.partner_name}<br><b>${_(u"NIF/NIE:")}</b> ${data.partner_vat}
+        </p>
+      </div>
+      <div class="CaixaEspai">
+      </div>
+      <div class="CaixaDadesAportacio">
+        <p class="ContingutDades"><b>${_(u"Rendiments bruts:")}</b> ${formatLang(data.amount_untaxed, monetary=True)} €<br>
+        <b>${_(u"19% Retenció sobre l'estalvi:")}</b> ${formatLang(data.amount_tax, monetary=True)} €<br>
+        <b>${_(u"Tipus percepció:")}</b> ${_(u"Dinerària")}</p>
+      </div>
+    </div>
+    <p style="padding-top:15px;"><b>${_(u"Saldo a ")}${formatLang(data.date_last_date_previous_year, date=True)}:</b> ${formatLang(data.balance, monetary=True)} €</p>
+  </div>
+</div>
+<div>
+  <div class="footer">
+    <p class="TextPeu">${_(u"Som Energia, SCCL, CIF F55091367 | Domicili Pic de Peguera, 11 A 28 - 17003 - Girona | aporta@somenergia.coop | www.somenergia.coop")}</p>
+  </div>
+</div>
+</body>
+</html>

--- a/som_inversions/report/report_retencions_interessos_apo.mako
+++ b/som_inversions/report/report_retencions_interessos_apo.mako
@@ -4,7 +4,7 @@
     import logging
     logger = logging.getLogger('openerp')
     report = objects[0]
-    data = report.report_retencions_data()
+    data = report.report_retencions_data_apo()
     setLang(data.lang)
 %>
 

--- a/som_inversions/report/report_retencions_interessos_apo.py
+++ b/som_inversions/report/report_retencions_interessos_apo.py
@@ -1,0 +1,78 @@
+from osv import osv
+from yamlns import namespace as ns
+import pooler
+import datetime
+
+
+class ResPartner(osv.osv):
+    _name = 'res.partner'
+    _inherit = 'res.partner'
+
+    def report_retencions_data(self, cursor, uid, ids):
+        aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
+        investment_obj = self.pool.get('generationkwh.investment')
+        partner = self.browse(cursor, uid, ids[0])
+
+        data = ns()
+        data.year = str(datetime.date.today().year - 1)
+        search_params = [
+            ('partner_id', '=', ids[0]),
+            ('report_id.company_name', '=', 'APORTACIONS VOLUNTARIES'),
+            ('fiscal_year_id.name', '=', data.year),
+        ]
+        aeat193_record_ids = aeat193_record_obj.search(
+            cursor,
+            uid,
+            search_params,
+            limit=1,
+        )
+        aeat193_record = aeat193_record_obj.browse(
+            cursor,
+            uid,
+            aeat193_record_ids,
+        )
+        data.lang = partner.lang
+        data.somenergia = get_somenergia_partner_info(cursor, uid)
+        data.partner_name = partner.name
+        data.partner_vat = partner.vat[2:]
+        data.amount_untaxed = aeat193_record[0].amount_base if aeat193_record else 0
+        data.amount_tax = abs(aeat193_record[0].amount_tax) if aeat193_record else 0
+        data.date_last_date_previous_year = '{}-12-31'.format(data.year)
+        data.balance = 0
+
+        search_params = [
+            ('emission_id.type', '=', 'apo'),
+            ('member_id.partner_id.id', '=', ids[0]),
+            ('purchase_date', '<=', data.date_last_date_previous_year),
+            '|',
+            ('last_effective_date', '>', data.date_last_date_previous_year),
+            ('last_effective_date', '=', False)
+        ]
+        aportacions_member_ids = investment_obj.search(cursor, uid, search_params)
+        aportacions_member = investment_obj.browse(
+            cursor, uid, aportacions_member_ids)
+        total_member_nshares = sum([item.nshares for item in aportacions_member])
+        data.balance = total_member_nshares * gkwh.shareValue
+
+        return data
+
+
+ResPartner()
+
+
+def get_somenergia_partner_info(cursor, uid):
+    pool = pooler.get_pool(cursor.dbname)
+    ResPartner = pool.get('res.partner')
+    ResPartnerAdress = pool.get('res.partner.address')
+    som_partner_id = 1
+    som_partner = ResPartner.read(
+        cursor, uid, som_partner_id, ['name', 'vat', 'address'])
+    som_address = ResPartnerAdress.read(
+        cursor, uid, som_partner['address'][0], ['street', 'zip', 'city'])
+    data = ns()
+    data.address_city = som_address['city']
+    data.address_zip = som_address['zip']
+    data.address_street = som_address['street']
+    data.partner_name = som_partner['name']
+    data.partner_vat = som_partner['vat']
+    return data

--- a/som_inversions/report/report_retencions_interessos_apo.py
+++ b/som_inversions/report/report_retencions_interessos_apo.py
@@ -2,6 +2,7 @@ from osv import osv
 from yamlns import namespace as ns
 import pooler
 import datetime
+import generationkwh.investmentmodel as gkwh
 
 
 class ResPartner(osv.osv):

--- a/som_inversions/report/report_retencions_interessos_apo.py
+++ b/som_inversions/report/report_retencions_interessos_apo.py
@@ -8,7 +8,7 @@ class ResPartner(osv.osv):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
-    def report_retencions_data(self, cursor, uid, ids):
+    def report_retencions_data_apo(self, cursor, uid, ids):
         aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
         investment_obj = self.pool.get('generationkwh.investment')
         partner = self.browse(cursor, uid, ids[0])

--- a/som_inversions/report/report_retencions_interessos_titols.mako
+++ b/som_inversions/report/report_retencions_interessos_titols.mako
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+
+<%
+    import logging
+    logger = logging.getLogger('openerp')
+    report = objects[0]
+    data = report.report_retencions_data()
+%>
+
+<html>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700;900&display=swap" rel="stylesheet">
+<head>
+    <style type="text/css">
+    body {
+      margin: 5% 5% 5% 5%;
+    }
+    h1, h2, h3, p, ol, ul {
+      font-family: Roboto;
+      margin: 0px;
+    }
+    .capsalera{
+      width: 100%;
+      display: inline-block;
+    }
+    .fila {
+      display: table-row;
+    }
+    .LogoPpal {
+      display: table-cell;
+      width: 20%;
+      vertical-align: top;
+      font-size: 0.9em;
+      text-align: left;
+    }
+    .LogoPpal img {
+      display: block;
+      margin-left: 19px;
+      margin-top: -10px;
+    }
+    .sotalogo {
+      display: block;
+      margin-top: -35px;
+      padding: 0px 28px;
+      font-size: 0.85em;
+      line-height: 1.5em;
+      max-width: 50%;
+    }
+    .TitolHeader {
+      display: table-cell;
+      vertical-align: top;
+      max-width: 50%;
+      float: right;
+      margin-top: -175px;
+    }
+    h1.titol {
+      text-align: right;
+      font-size: 1.3em;
+      margin-top:8px;
+    }
+    h2.titol {
+      text-align: center;
+      font-size: 1.1em;
+      margin-bottom: 30px;
+    }
+    .caixaHeader {
+      display: table-cell;
+      background: #EDEEF0;
+      border-bottom: 10px solid #BFC74D;
+      width: 100%;
+      padding-bottom: 15px;
+      float: right;
+    }
+    .dreta, .esquerra {
+      display: table-cell;
+      width: 50%;
+      height: 90px;
+      margin: 0;
+      padding: 0;
+    }
+    .caixaHeader .ContingutDades  {
+      text-align: left;
+      line-height: 1.4em;
+      font-size: 0.85em;
+    }
+    .caixaHeader .doblecaixa {
+      margin-bottom: -15px;
+      padding-bottom: 0px;
+    }
+    .DataDoc {
+      margin: 35px 0;
+      text-align: right;
+      font-size: 1em;
+    }
+    .TitolCaixa {
+      background: #4D4D4D;
+    }
+    .TitolCaixa h2, .CaixaTitTitular h3,.CaixaTitAportacio h3, .InfoAddTitol h3 {
+      font-weight: 900;
+      font-size: 1em;
+      color: white;
+      padding: 8px 27px;
+    }
+    .CaixaFons {
+      background: #EDEEF0;
+    }
+    .doblecaixa{
+      width: 100%;
+      display: table;
+      /*margin-left: 0 auto;*/
+      padding: 20px;
+    }
+    .CaixaTitTitular, .CaixaTitAportacio {
+      display: table-cell;
+      background: #BFC74D;
+      color:white;
+      width:48.5%;
+      margin-top:0px;
+    }
+    .CaixaDadesTitular, .CaixaDadesAportacio {
+      display: table-cell;
+      background: white;
+      padding: 30px 30px;
+      line-height: 2.2em;
+      font-size: 0.85em;
+      text-align: justify;
+      padding-bottom: 54px;
+    }
+    .footer {
+      position: fixed;
+      bottom: 3%;
+      background: white;
+      padding: 0px 30px;
+      text-align: center;
+      font-size: 0.85em;
+      height: 2%;
+
+    }
+    @media print {
+      footer {
+        position:relative;
+        top:-20px;
+      }
+    }
+    </style>
+</head>
+<body>
+
+    %for investment in objects :
+    <%
+    setLang(report.partner_id.lang)
+    %>
+<div class="capsalera">
+  <div class="fila">
+    <div class="LogoPpal">
+      <a href="https://www.somenergia.coop" target="_blank">
+        <img src="${addons_path}/som_inversions/report/logo.jpg" width="150" height="150"/ alt="Logo Som Energia"></a><br>
+      <p class="sotalogo"><b>${data.somenergia.partner_name}</b><br>${_(u"CIF:")} ${data.somenergia.partner_vat.replace('ES','')}<br>${_(u"Domicili:")} ${data.somenergia.address_street} ${data.somenergia.address_zip} - ${data.somenergia.address_city}<br>
+        ${_(u"Adreça electrònica:")} aporta@somenergia.coop
+    </div>
+  </div>
+  <div class="TitolHeader">
+    <h2 class="titol">${_(u"Comunicat de rendiments per a la")}<br/>${_(u"declaració de la RENDA ")}${data.year}</h2>
+    <div class="caixaHeader">
+      <div class="doblecaixa">
+         <div class="fila">
+            <div class="dreta">
+               <p class="ContingutDades">
+                  ${_(u"<b>Data:</b>")}<br/>
+                  ${_(u"<b>Exercici:</b>")}<br/>
+                  ${_(u"<b>Tipus d'aportació:</b>")}<br/>
+               </p>
+            </div>
+            <div class="esquerra">
+              <p class="ContingutDades">
+                ${formatLang(time.strftime('%Y-%m-%d'), date=True)}<br/>
+                ${data.year}<br>
+                ${_("Títols participatius")}
+              </p>
+            </div>
+        </div>
+    </div>
+  </div>
+</div>
+
+</div>
+<div class="DataDoc">
+
+</div>
+<div class="TitolCaixa">
+  <h2></h2>
+</div>
+
+<div class="CaixaFons">
+  <div class="doblecaixa">
+    <div class="fila">
+      <div class="CaixaTitTitular">
+       <h3>${_(u"DADES DEL TITULAR")}</h3>
+      </div>
+      <div class="CaixaEspai">
+      </div>
+      <div class="CaixaTitAportacio">
+       <h3>${_(u"INFORMACIÓ FISCAL")}</h3>
+      </div>
+    </div>
+    <div class="fila">
+      <div class="CaixaDadesTitular">
+        <p class="ContingutDades"><b>${_(u"Nom:")}</b> ${data.partner_name}<br><b>${_(u"NIF/NIE:")}</b> ${data.partner_vat}
+        </p>
+      </div>
+      <div class="CaixaEspai">
+      </div>
+      <div class="CaixaDadesAportacio">
+        <p class="ContingutDades"><b>${_(u"Rendiments bruts:")}</b> ${formatLang(data.amount_untaxed, monetary=True)} €<br>
+        <b>${_(u"19% Retenció sobre l'estalvi:")}</b> ${formatLang(data.amount_tax, monetary=True)} €<br>
+        <b>${_(u"Tipus percepció:")}</b> ${_(u"Dinerària")}</p>
+      </div>
+    </div>
+    <p style="padding-top:15px;"><b>${_(u"Saldo a ")}${formatLang(data.date_last_date_previous_year, date=True)}:</b> ${formatLang(data.balance, monetary=True)} €</p>
+  </div>
+</div>
+<div>
+  <div class="footer">
+    <p class="TextPeu">${_(u"Som Energia, SCCL, CIF F55091367 | Domicili Pic de Peguera, 11 A 28 - 17003 - Girona | aporta@somenergia.coop | www.somenergia.coop")}</p>
+  </div>
+</div>
+
+    %endfor
+</body>
+</html>

--- a/som_inversions/report/report_retencions_interessos_titols.mako
+++ b/som_inversions/report/report_retencions_interessos_titols.mako
@@ -4,7 +4,7 @@
     import logging
     logger = logging.getLogger('openerp')
     report = objects[0]
-    data = report.report_retencions_data()
+    data = report.report_retencions_data_titols()
     setLang(data.lang)
 %>
 

--- a/som_inversions/report/report_retencions_interessos_titols.mako
+++ b/som_inversions/report/report_retencions_interessos_titols.mako
@@ -5,6 +5,7 @@
     logger = logging.getLogger('openerp')
     report = objects[0]
     data = report.report_retencions_data()
+    setLang(data.lang)
 %>
 
 <html>
@@ -145,11 +146,6 @@
     </style>
 </head>
 <body>
-
-    %for investment in objects :
-    <%
-    setLang(report.lang)
-    %>
 <div class="capsalera">
   <div class="fila">
     <div class="LogoPpal">
@@ -224,7 +220,5 @@
     <p class="TextPeu">${_(u"Som Energia, SCCL, CIF F55091367 | Domicili Pic de Peguera, 11 A 28 - 17003 - Girona | aporta@somenergia.coop | www.somenergia.coop")}</p>
   </div>
 </div>
-
-    %endfor
 </body>
 </html>

--- a/som_inversions/report/report_retencions_interessos_titols.mako
+++ b/som_inversions/report/report_retencions_interessos_titols.mako
@@ -148,7 +148,7 @@
 
     %for investment in objects :
     <%
-    setLang(report.partner_id.lang)
+    setLang(report.lang)
     %>
 <div class="capsalera">
   <div class="fila">

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -1,7 +1,7 @@
 from osv import osv
 from yamlns import namespace as ns
 import pooler
-
+import datetime
 
 class ResPartner(osv.osv):
     _name = 'res.partner'
@@ -9,16 +9,23 @@ class ResPartner(osv.osv):
 
     def report_retencions_data(self, cursor, uid, ids):
         partner = self.browse(cursor, uid, ids[0])
-        import pudb;pu.db
-        aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.report')
         data = ns()
+        data.year = str(datetime.date.today().year - 1)
+        import pudb;pu.db
+        aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
+        search_params = [
+            ('partner_id', '=', ids[0]),
+            ('report_id.name', '=', 'TITOLS'),
+            ('fiscal_year_id.name', '=', data.year),
+        ]
+        aeat193_record = aeat193_record_obj.search(
+            cursor, uid, search_params, limit=1)[0]
         data.lang = partner.lang
         data.somenergia = get_somenergia_partner_info(cursor, uid)
-        # data.year = inv.date_invoice.split('-')[0]
         data.partner_name = partner.name
         data.partner_vat = partner.vat[2:]
-        # data.amount_untaxed = inv.amount_untaxed
-        # data.amount_tax = abs(inv.amount_tax)
+        data.amount_untaxed = aeat193_record.amount_untaxed
+        data.amount_tax = abs(aeat193_record.amount_tax)
         data.date_last_date_previous_year = '{}-12-31'.format(data.year)
         data.balance = 0
 

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -1,0 +1,46 @@
+from osv import osv
+from yamlns import namespace as ns
+import pooler
+
+
+class ResPartner(osv.osv):
+    _name = 'res.partner'
+    _inherit = 'res.partner'
+
+    def report_retencions_data(self, cursor, uid, ids):
+        partner = self.browse(cursor, uid, ids[0])
+        import pudb;pu.db
+        aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.report')
+        data = ns()
+        data.lang = partner.lang
+        data.somenergia = get_somenergia_partner_info(cursor, uid)
+        # data.year = inv.date_invoice.split('-')[0]
+        data.partner_name = partner.name
+        data.partner_vat = partner.vat[2:]
+        # data.amount_untaxed = inv.amount_untaxed
+        # data.amount_tax = abs(inv.amount_tax)
+        data.date_last_date_previous_year = '{}-12-31'.format(data.year)
+        data.balance = 0
+
+        return data
+
+
+ResPartner()
+
+
+def get_somenergia_partner_info(cursor, uid):
+    pool = pooler.get_pool(cursor.dbname)
+    ResPartner = pool.get('res.partner')
+    ResPartnerAdress = pool.get('res.partner.address')
+    som_partner_id = 1
+    som_partner = ResPartner.read(
+        cursor, uid, som_partner_id, ['name', 'vat', 'address'])
+    som_address = ResPartnerAdress.read(
+        cursor, uid, som_partner['address'][0], ['street', 'zip', 'city'])
+    data = ns()
+    data.address_city = som_address['city']
+    data.address_zip = som_address['zip']
+    data.address_street = som_address['street']
+    data.partner_name = som_partner['name']
+    data.partner_vat = som_partner['vat']
+    return data

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -8,7 +8,7 @@ class ResPartner(osv.osv):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
-    def report_retencions_data(self, cursor, uid, ids):
+    def report_retencions_data_titols(self, cursor, uid, ids):
         aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
         partner = self.browse(cursor, uid, ids[0])
         data = ns()

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -35,7 +35,7 @@ class ResPartner(osv.osv):
         data.somenergia = get_somenergia_partner_info(cursor, uid)
         data.partner_name = partner.name
         data.partner_vat = partner.vat[2:]
-        data.amount_untaxed = aeat193_record[0].amount_untaxed if aeat193_record else 0
+        data.amount_untaxed = aeat193_record[0].amount_base if aeat193_record else 0
         data.amount_tax = abs(aeat193_record[0].amount_tax) if aeat193_record else 0
         data.date_last_date_previous_year = '{}-12-31'.format(data.year)
         data.balance = 0

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -15,7 +15,7 @@ class ResPartner(osv.osv):
         aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
         search_params = [
             ('partner_id', '=', ids[0]),
-            ('report_id.name', '=', 'TITOLS'),
+            ('report_id.company_name', '=', 'TITOLS'),
             ('fiscal_year_id.name', '=', data.year),
         ]
         aeat193_record = aeat193_record_obj.search(

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -13,7 +13,6 @@ class ResPartner(osv.osv):
         partner = self.browse(cursor, uid, ids[0])
         data = ns()
         data.year = str(datetime.date.today().year - 1)
-        import pudb; pu.db
 
         search_params = [
             ('partner_id', '=', ids[0]),
@@ -38,7 +37,7 @@ class ResPartner(osv.osv):
         data.amount_untaxed = aeat193_record[0].amount_base if aeat193_record else 0
         data.amount_tax = abs(aeat193_record[0].amount_tax) if aeat193_record else 0
         data.date_last_date_previous_year = '{}-12-31'.format(data.year)
-        data.balance = 0
+        data.balance = 0  # no more titles left from 2022 on
 
         return data
 

--- a/som_inversions/report/report_retencions_interessos_titols.py
+++ b/som_inversions/report/report_retencions_interessos_titols.py
@@ -3,29 +3,40 @@ from yamlns import namespace as ns
 import pooler
 import datetime
 
+
 class ResPartner(osv.osv):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
     def report_retencions_data(self, cursor, uid, ids):
+        aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
         partner = self.browse(cursor, uid, ids[0])
         data = ns()
         data.year = str(datetime.date.today().year - 1)
-        import pudb;pu.db
-        aeat193_record_obj = self.pool.get('l10n.es.aeat.mod193.record')
+        import pudb; pu.db
+
         search_params = [
             ('partner_id', '=', ids[0]),
             ('report_id.company_name', '=', 'TITOLS'),
             ('fiscal_year_id.name', '=', data.year),
         ]
-        aeat193_record = aeat193_record_obj.search(
-            cursor, uid, search_params, limit=1)[0]
+        aeat193_record_ids = aeat193_record_obj.search(
+            cursor,
+            uid,
+            search_params,
+            limit=1,
+        )
+        aeat193_record = aeat193_record_obj.browse(
+            cursor,
+            uid,
+            aeat193_record_ids,
+        )
         data.lang = partner.lang
         data.somenergia = get_somenergia_partner_info(cursor, uid)
         data.partner_name = partner.name
         data.partner_vat = partner.vat[2:]
-        data.amount_untaxed = aeat193_record.amount_untaxed
-        data.amount_tax = abs(aeat193_record.amount_tax)
+        data.amount_untaxed = aeat193_record[0].amount_untaxed if aeat193_record else 0
+        data.amount_tax = abs(aeat193_record[0].amount_tax) if aeat193_record else 0
         data.date_last_date_previous_year = '{}-12-31'.format(data.year)
         data.balance = 0
 

--- a/som_inversions/som_inversions_data.xml
+++ b/som_inversions/som_inversions_data.xml
@@ -90,7 +90,7 @@
             <field name="number_increment">1</field>
         </record>
     </data>
-    <data noupdate="1">
+    <data noupdate="0">
         <record model="poweremail.templates" id="email_certificat_retencions_titols">
             <field name="name">Liquidacions - Certificats retencions títols</field>
             <field name="object_name" model="ir.model"
@@ -98,7 +98,7 @@
             <field eval="0" name="save_to_drafts" />
             <field name="model_int_name">som.enviament.massiu</field>
             <field name="def_to">
-                ${object.partner_id.address[0].email}}
+                ${object.partner_id.address[0].email}
             </field>
             <field eval="0" name="auto_email" />
             <field eval="0" name="single_email" />
@@ -129,7 +129,7 @@
             <field eval="0" name="save_to_drafts" />
             <field name="model_int_name">som.enviament.massiu</field>
             <field name="def_to">
-                ${object.partner_id.address[0].email}}
+                ${object.partner_id.address[0].email}
             </field>
             <field eval="0" name="auto_email" />
             <field eval="0" name="single_email" />

--- a/som_inversions/som_inversions_data.xml
+++ b/som_inversions/som_inversions_data.xml
@@ -90,7 +90,7 @@
             <field name="number_increment">1</field>
         </record>
     </data>
-    <data noupdate="0">
+    <data noupdate="1">
         <record model="poweremail.templates" id="email_certificat_retencions_titols">
             <field name="name">Liquidacions - Certificats retencions títols</field>
             <field name="object_name" model="ir.model"

--- a/som_inversions/som_inversions_data.xml
+++ b/som_inversions/som_inversions_data.xml
@@ -90,4 +90,68 @@
             <field name="number_increment">1</field>
         </record>
     </data>
+    <data noupdate="1">
+        <record model="poweremail.templates" id="email_certificat_retencions_titols">
+            <field name="name">Liquidacions - Certificats retencions títols</field>
+            <field name="object_name" model="ir.model"
+                search="[('name', '=', 'som.enviament.massiu')]" />
+            <field eval="0" name="save_to_drafts" />
+            <field name="model_int_name">som.enviament.massiu</field>
+            <field name="def_to">
+                ${object.partner_id.address[0].email}}
+            </field>
+            <field eval="0" name="auto_email" />
+            <field eval="0" name="single_email" />
+            <field eval="0" name="use_sign" />
+            <field name="def_subject">Certificat IRPF 2022 Títols - Som Energia</field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create" />
+            <field name="lang">${object.partner_id.lang}</field>
+            <field eval="0" name="send_on_write" />
+            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field name="enforce_from_account" model="poweremail.core_accounts"
+                search="[('name','=', 'Som Energia Aporta')]" />
+            <field name="def_body_text"><![CDATA[
+                <!doctype html>
+                <html>
+                <head></head>
+                <body>
+                Email text
+                </body>
+                </html>
+                ]]>
+            </field>
+        </record>
+        <record model="poweremail.templates" id="email_certificat_retencions_aportacions">
+            <field name="name">Liquidacions - Certificats retencions aportacions</field>
+            <field name="object_name" model="ir.model"
+                search="[('name', '=', 'som.enviament.massiu')]" />
+            <field eval="0" name="save_to_drafts" />
+            <field name="model_int_name">som.enviament.massiu</field>
+            <field name="def_to">
+                ${object.partner_id.address[0].email}}
+            </field>
+            <field eval="0" name="auto_email" />
+            <field eval="0" name="single_email" />
+            <field eval="0" name="use_sign" />
+            <field name="def_subject">Certificat IRPF 2022 Aportacions voluntàries - Som Energia</field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create" />
+            <field name="lang">${object.partner_id.lang}</field>
+            <field eval="0" name="send_on_write" />
+            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field name="enforce_from_account" model="poweremail.core_accounts"
+                search="[('name','=', 'Som Energia Aporta')]" />
+            <field name="def_body_text"><![CDATA[
+                <!doctype html>
+                <html>
+                <head></head>
+                <body>
+                Email text
+                </body>
+                </html>
+                ]]>
+            </field>
+        </record>
+    </data>
 </openerp>

--- a/som_inversions/som_inversions_data.xml
+++ b/som_inversions/som_inversions_data.xml
@@ -97,9 +97,7 @@
                 search="[('name', '=', 'som.enviament.massiu')]" />
             <field eval="0" name="save_to_drafts" />
             <field name="model_int_name">som.enviament.massiu</field>
-            <field name="def_to">
-                ${object.partner_id.address[0].email}
-            </field>
+            <field name="def_to">${object.partner_id.address[0].email}</field>
             <field eval="0" name="auto_email" />
             <field eval="0" name="single_email" />
             <field eval="0" name="use_sign" />
@@ -128,9 +126,7 @@
                 search="[('name', '=', 'som.enviament.massiu')]" />
             <field eval="0" name="save_to_drafts" />
             <field name="model_int_name">som.enviament.massiu</field>
-            <field name="def_to">
-                ${object.partner_id.address[0].email}
-            </field>
+            <field name="def_to">${object.partner_id.address[0].email}</field>
             <field eval="0" name="auto_email" />
             <field eval="0" name="single_email" />
             <field eval="0" name="use_sign" />

--- a/som_inversions/som_inversions_report.xml
+++ b/som_inversions/som_inversions_report.xml
@@ -64,5 +64,17 @@
             <field name="name">Préstec Generation kWh</field>
             <field name="report_webkit">som_inversions/report/report_generationkwh_doc.mako</field>
         </record>
+        <record id="report_retencions_interessos_titols" model="ir.actions.report.xml">
+            <field name="report_type">webkit</field>
+            <field name="report_name">retencions.interessos.titols</field>
+            <field eval="[(6,0,[])]" name="groups_id"/>
+            <field eval="0" name="multi"/>
+            <field eval="0" name="auto"/>
+            <field eval="0" name="header"/>
+            <field name="model">res.partner</field>
+            <field name="type">ir.actions.report.xml</field>
+            <field name="name">Retencions d'interessos títols</field>
+            <field name="report_webkit">som_inversions/report/report_retencions_interessos_titols.mako</field>
+        </record>
   </data>
 </openerp>

--- a/som_inversions/som_inversions_report.xml
+++ b/som_inversions/som_inversions_report.xml
@@ -76,5 +76,17 @@
             <field name="name">Retencions d'interessos títols</field>
             <field name="report_webkit">som_inversions/report/report_retencions_interessos_titols.mako</field>
         </record>
+        <record id="report_retencions_interessos_apo" model="ir.actions.report.xml">
+            <field name="report_type">webkit</field>
+            <field name="report_name">retencions.interessos.aportacions</field>
+            <field eval="[(6,0,[])]" name="groups_id"/>
+            <field eval="0" name="multi"/>
+            <field eval="0" name="auto"/>
+            <field eval="0" name="header"/>
+            <field name="model">res.partner</field>
+            <field name="type">ir.actions.report.xml</field>
+            <field name="name">Retencions d'interessos aportacions</field>
+            <field name="report_webkit">som_inversions/report/report_retencions_interessos_apo.mako</field>
+        </record>
   </data>
 </openerp>


### PR DESCRIPTION
## Objectiu

Enviar els certificats de l'IRPF 2022 per a les aportacions al capital social i els títols.

## Targeta on es demana o Incidència

https://trello.com/c/OY6FCnMU/5720-enviament-certificats-irpf-aportacions

## Comportament antic

No es podien enviar.

## Comportament nou

- Creades dues noves plantilles, una per les aportacions al capital social i una altra pels títols.
- Creats dos nous reports, un per les aportacions al capital social i un altre pels títols.
- Afegida l'opció de crear enviaments a un lot d'enviaments massiu per CSV amb números de partner.

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions