### PR TITLE
Modificació comportament camp data_alta_autoconsum

### DIFF
--- a/som_switching/giscedata_polissa_view.xml
+++ b/som_switching/giscedata_polissa_view.xml
@@ -9,6 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//page[@string='Autoconsum']/field[@name='is_autoconsum_collectiu']" position="after">
                     <field name="data_alta_autoconsum" readonly="1" select="2"/>
+                    <field name="data_baixa_autoconsum" readonly="1" select="2"/>
                 </xpath>
             </field>
         </record>
@@ -21,6 +22,7 @@
             <field name="arch" type="xml">
                 <field name="lectura_en_baja" position="after" >
                     <field name="data_alta_autoconsum"/>
+                    <field name="data_baixa_autoconsum"/>
                 </field>
                 <field name="data_ultima_lectura" position="after" >
                     <field name="data_ultima_lectura_f1" string="Última lectura de F1"/>


### PR DESCRIPTION
## Objectiu

Modificar comportament per a reflectir qualsevol canvi de tipus d'auto al camp de la pòlissa

## Targeta on es demana o Incidència 

https://trello.com/c/qhDbMRer/5695-autoconsum-arreglar-fitxes-generadores

## Comportament antic

Només mostrava la data d'alta de l'autoconsum i no els canvis o les baixes

## Comportament nou

Mostra qualsevol canvi de tipus d'auto

