### PR TITLE
Add more error codes and reimport phase 1 f1s

### DIFF
--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -8,6 +8,7 @@ from tools import cache
 import logging
 
 TIPO_AUTOCONSUMO_SEL = [(ac[0], '[{}] - {}'.format(ac[0], ac[1])) for ac in TABLA_113]
+IMPORT_PHASE_1 = 10  # 10 = Fase de càrrega XML
 
 class GiscedataFacturacioImportacioLinia(osv.osv):
     _name = 'giscedata.facturacio.importacio.linia'
@@ -130,6 +131,13 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
                 ('state','=','erroni'), ('info', 'ilike','%[{}]%{}%'.format(code, text)),('fecha_factura','>=',date_to_check)
             ])
             f1_ids += _ids
+
+        _ids = self.search(cursor, uid, [
+            ('state', 'not in', ["erroni", "incident"]),
+            ('import_phase', '=', IMPORT_PHASE_1),
+            ('fecha_factura', '>=', date_to_check),
+        ])
+        f1_ids += _ids
 
         if f1_ids:
             self.reimport_f1_by_cups(cursor, uid, f1_ids, context=context)

--- a/som_facturacio_switching/giscedata_facturacio_switching_cron.xml
+++ b/som_facturacio_switching/giscedata_facturacio_switching_cron.xml
@@ -3,20 +3,31 @@
     <data>
         <record id="ir_cron_reimport_f1" model="ir.cron" forcecreate="1">
             <field name="name">Reimportació de F1ns amb error diària</field>
-            <field name="user_id" ref="base.user_admin"/>
+            <field name="user_id" ref="base.user_admin" />
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
-            <field eval="False" name="doall"/>
-            <field eval="False" name="active"/>
-            <field eval="'giscedata.facturacio.importacio.linia'" name="model"/>
-            <field eval="'do_reimport_f1'" name="function"/>
+            <field eval="False" name="doall" />
+            <field eval="False" name="active" />
+            <field eval="'giscedata.facturacio.importacio.linia'" name="model" />
+            <field eval="'do_reimport_f1'" name="function" />
         </record>
     </data>
     <data noupdate="1">
         <record id="ir_cron_reimport_f1" model="ir.cron">
-            <field name="args" eval="({'error_codes': [{'code':'2999', 'text': 'no file in gridfs collection'},{'code':'3044', 'text':''}], 'days_to_check': 30})"/>
+            <field
+                name="args"
+                eval="({
+                    'error_codes': [
+                        {'code':'3033', 'text':''},
+                        {'code':'2005', 'text':''},
+                        {'code':'1001', 'text':''},
+                        {'code':'3041', 'text':''},
+                        {'code':'1999', 'text':''},
+                        {'code':'2999', 'text':''},
+                        {'code':'3999', 'text':''},
+                        {'code':'4999', 'text':''},
+                    ], 'days_to_check': 30})" />
         </record>
     </data>
- 
 </openerp>


### PR DESCRIPTION
## Objectiu

- Millorar la reimportació dels fitxers F1 amb error

## Targeta on es demana o Incidència 

https://trello.com/c/wx1666Mk/5746-0-6-get-analitzar-cron-per-reimportar-f1s-a-la-nit

## Comportament antic

- Es reimportaven els fitxers F1 en estat erroni amb uns codis d'error concrets

## Comportament nou

- S'han afegit més codis d'error que han de ser reimportats
- Es reimporten també els fitxers F1 en fase 1 que no tinguin estat erroni o incident

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
