### PR TITLE
Validacions custom assistent bateria virtual

### DIFF
--- a/som_facturacio_comer/wizard/__init__.py
+++ b/som_facturacio_comer/wizard/__init__.py
@@ -3,3 +3,4 @@ import wizard_revert_incident_fact_contracte_lot
 import wizard_open_factures_send_mail
 import wizard_move_contracts_to_prev_lot
 import wizard_informe_factures_dades_desagregades
+import wizard_afegir_contracte_bateria_virtual

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -4,6 +4,11 @@ from osv import fields, osv
 from tools.translate import _
 from datetime import datetime
 
+STATES_GESTIO_DESCOMPTES = [
+    ('no_aplicar', 'No aplicar descomptes'),
+    ('aplicar', 'Aplicar descomptes disponibles')
+]
+
 class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
     """Wizard per afegir contractes a un bateria virtual
     """
@@ -11,10 +16,52 @@ class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
     _inherit = 'wizard.afegir.contracte.bateria.virtual'
 
     def action_assignar_bateria_virtual(self, cursor, uid, ids, context=None):
-        # validar origens
-        
-        # cridar al super
+        """
+        Acció per assignar el contracte a la bateria virutal
+        Es valida que una bateria virtual no pugui tenir més d'un origen
+        """
+        if context is None:
+            context = {}
 
+        bat_obj = self.pool.get('giscedata.bateria.virtual')
+        polissa_ids = context['active_ids']
+
+        self_fields = [
+            'bateria_id', 'es_receptor_descomptes',
+            'es_origen_descomptes', 'data_inici', 'pes',
+            'gestio_descomptes', 'crear_bateria_automaticament'
+        ]
+        self_vals = self.read(
+            cursor, uid, ids, self_fields, context=context
+        )[0]
+
+        # validacions
+        if self_vals['bateria_id'] and self_vals['es_origen_descomptes']:
+            # Intentem afegir més d'una polissa com a origen a una bateria virtual
+            if len(polissa_ids) > 1:
+                raise osv.except_osv(
+                    _("Error"),
+                    _("Estas intentant afegir més d'una pólissa a la bateria virtual com a origen")
+                )
+
+            polissa_descompte_ids = bat_obj.read(cursor, uid, self_vals['bateria_id'],
+                                                 ['polissa_descompte_ids'])['polissa_descompte_ids']
+            # Intentem afegir una polissa com a origen a una bateria virtual que ja te origen
+            if polissa_descompte_ids:
+                raise osv.except_osv(
+                    _("Error"),
+                    _("La bateria virtual seleccionada ja te origen.")
+                )
+
+        return super(WizardAfegirContracteBateriaVirtual, self).action_assignar_bateria_virtual(
+            cursor, uid, ids, context=context
+        )
+
+    _columns = {
+        'gestio_descomptes': fields.selection(
+            STATES_GESTIO_DESCOMPTES, 'Gestió dels descomptes'
+        ),
+    }
 
 
 WizardAfegirContracteBateriaVirtual()

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -24,6 +24,8 @@ class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
             context = {}
 
         bat_obj = self.pool.get('giscedata.bateria.virtual')
+        origen_obj = self.pool.get('giscedata.bateria.virtual.origen')
+        pol_obj = self.pool.get('giscedata.polissa')
         polissa_ids = context['active_ids']
 
         self_fields = [
@@ -47,11 +49,28 @@ class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
             origen_ids = bat_obj.read(cursor, uid, self_vals['bateria_id'],
                                                  ['origen_ids'])['origen_ids']
             # Intentem afegir una polissa com a origen a una bateria virtual que ja te origen
+            origin_cups = []
+            pol_cups = []
             if origen_ids:
-                raise osv.except_osv(
-                    _("Error"),
-                    _("La bateria virtual seleccionada ja te origen.")
-                )
+                for origen_id in origen_ids:
+                    orig_pol_id = origen_obj.read(
+                        cursor, uid, origen_id, ['origen_ref'], context=context
+                        )['origen_ref'].split(',')[1]
+                    pol_cups_id = pol_obj.read(cursor, uid, orig_pol_id, ['cups'], context=context)['cups'][0]
+                    origin_cups.append(pol_cups_id)
+                for pol_id in context.get('active_ids', []):
+                    cups_pol_id = pol_obj.read(cursor, uid, pol_id, ['cups'], context=context)['cups'][0]
+                    if cups_pol_id not in origin_cups:
+                        raise osv.except_osv(
+                            _("Error"),
+                            _("La bateria virtual seleccionada ja té un origen amb un CUPS diferent.")
+                        )
+                    if pol_cups and (cups_pol_id not in pol_cups):
+                        raise osv.except_osv(
+                            _("Error"),
+                            _("S'estan intentant assignar varies pòlisses amb diferent CUPS com a orígens de la bateria virtual.")
+                        )
+                    pol_cups.append(cups_pol_id)
 
         return super(WizardAfegirContracteBateriaVirtual, self).action_assignar_bateria_virtual(
             cursor, uid, ids, context=context

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -31,7 +31,7 @@ class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
         self_fields = [
             'bateria_id', 'es_receptor_descomptes',
             'es_origen_descomptes', 'data_inici', 'pes',
-            'gestio_descomptes', 'crear_bateria_automaticament'
+            'crear_bateria_automaticament'
         ]
         self_vals = self.read(
             cursor, uid, ids, self_fields, context=context

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import time
+from osv import fields, osv
+from tools.translate import _
+from datetime import datetime
+
+class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
+    """Wizard per afegir contractes a un bateria virtual
+    """
+    _name = "wizard.afegir.contracte.bateria.virtual"
+    _inherit = 'wizard.afegir.contracte.bateria.virtual'
+
+    def action_assignar_bateria_virtual(self, cursor, uid, ids, context=None):
+        # validar origens
+        
+        # cridar al super
+
+
+
+WizardAfegirContracteBateriaVirtual()

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -4,10 +4,6 @@ from osv import fields, osv
 from tools.translate import _
 from datetime import datetime
 
-STATES_GESTIO_DESCOMPTES = [
-    ('no_aplicar', 'No aplicar descomptes'),
-    ('aplicar', 'Aplicar descomptes disponibles')
-]
 
 class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
     """Wizard per afegir contractes a un bateria virtual

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -44,10 +44,10 @@ class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
                     _("Estas intentant afegir més d'una pólissa a la bateria virtual com a origen")
                 )
 
-            polissa_descompte_ids = bat_obj.read(cursor, uid, self_vals['bateria_id'],
-                                                 ['polissa_descompte_ids'])['polissa_descompte_ids']
+            origen_ids = bat_obj.read(cursor, uid, self_vals['bateria_id'],
+                                                 ['origen_ids'])['origen_ids']
             # Intentem afegir una polissa com a origen a una bateria virtual que ja te origen
-            if polissa_descompte_ids:
+            if origen_ids:
                 raise osv.except_osv(
                     _("Error"),
                     _("La bateria virtual seleccionada ja te origen.")

--- a/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
+++ b/som_facturacio_comer/wizard/wizard_afegir_contracte_bateria_virtual.py
@@ -76,11 +76,5 @@ class WizardAfegirContracteBateriaVirtual(osv.osv_memory):
             cursor, uid, ids, context=context
         )
 
-    _columns = {
-        'gestio_descomptes': fields.selection(
-            STATES_GESTIO_DESCOMPTES, 'Gestió dels descomptes'
-        ),
-    }
-
 
 WizardAfegirContracteBateriaVirtual()


### PR DESCRIPTION
## Objectiu
Impedir que una bateria virtual tingui més d'un origen.

## Targeta on es demana o Incidència 
https://trello.com/c/2TL95Ww6/5732-bateria-t02-millores-en-lassistent-afegir-p%C3%B2lissa-a-la-bateria-des-de-la-p%C3%B2lissa

## Comportament antic
Una abteria virtual podia tenir més d'un origen.

## Comportament nou
Des de l'assitent d'afegir polissa a bateria virtual es controla que una polissa no pugui tenir més d'un origen.

## PR base
https://github.com/gisce/erp/pull/17179

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
