### PR TITLE
Permetre adjunts en els enviaments massius d'un lot

### DIFF
--- a/som_indexada/data/email_template_data.xml
+++ b/som_indexada/data/email_template_data.xml
@@ -55,5 +55,34 @@
                 ]]>
             </field>
         </record>
+        <record model="poweremail.templates" id="email_canvi_massiu_k">
+            <field name="name">Email canvi massiu K</field>
+            <field name="object_name" model="ir.model"
+                search="[('name', '=', 'som.enviament.massiu')]" />
+            <field eval="0" name="save_to_drafts" />
+            <field name="model_int_name">som.enviament.massiu</field>
+            <field eval="0" name="use_filter" />
+            <field name="def_to">${object.polissa_id.titular.address[0].email}</field>
+            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field eval="0" name="auto_email" />
+            <field eval="0" name="use_sign" />
+            <field name="def_subject">[IMPORTANT] Actualització de la franja K de la tarifa indexada a partir del juliol</field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create" />
+            <field name="lang">${object.polissa_id.titular.lang}</field>
+            <field eval="0" name="send_on_write" />
+            <field name="enforce_from_account" model="poweremail.core_accounts"
+                search="[('email_id','=', 'empresa@somenergia.coop')]" />
+            <field name="def_body_text"><![CDATA[
+                <!doctype html>
+                <html>
+                <head></head>
+                <body>
+                Email text
+                </body>
+                </html>
+                ]]>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/som_infoenergia/__terp__.py
+++ b/som_infoenergia/__terp__.py
@@ -10,7 +10,7 @@
     "version": "0-dev",
     "author": "SomEnergia",
     "category": "SomEnergia",
-    "depends":[
+    "depends": [
         "poweremail_references",
         "som_polissa_soci",
         "som_generationkwh",
@@ -19,7 +19,7 @@
     "demo_xml": [
         "tests/som_infoenergia_demo.xml"
     ],
-    "update_xml":[
+    "update_xml": [
         "som_infoenergia_report.xml",
         "som_infoenergia_sepa.xml",
         "som_infoenergia_data.xml",
@@ -36,6 +36,7 @@
         "wizard/wizard_cancel_from_csv_view.xml",
         "wizard/wizard_create_enviaments_from_csv_view.xml",
         "wizard/wizard_create_enviaments_from_partner_view.xml",
+        "wizard/wizard_create_attachments_from_zip_view.xml",
     ],
     "active": False,
     "installable": True

--- a/som_infoenergia/security/ir.model.access.csv
+++ b/som_infoenergia/security/ir.model.access.csv
@@ -41,3 +41,6 @@
 "access_wizard_add_partners_lot_rcwd","wizard.add.partners.lot","model_wizard_add_partners_lot","som_infoenergia.group_infoenergia_u",1,1,1,1
 "access_wizard_add_partners_lot_rcw","wizard.add.partners.lot","model_wizard_add_partners_lot","som_infoenergia.group_infoenergia_w",1,1,1,0
 "access_wizard_add_partners_lot_r","wizard.add.partners.lot","model_wizard_add_partners_lot","som_infoenergia.group_infoenergia_r",1,0,0,0
+"access_wizard_create_attachments_from_zip_rcwd","wizard.create.attachments.from.zip","model_wizard_create_attachments_from_zip","som_infoenergia.group_infoenergia_u",1,1,1,1
+"access_wizard_create_attachments_from_zip_rcw","wizard.create.attachments.from.zip","model_wizard_create_attachments_from_zip","som_infoenergia.group_infoenergia_w",1,1,1,0
+"access_wizard_create_attachments_from_zip_r","wizard.create.attachments.from.zip","model_wizard_create_attachments_from_zip","som_infoenergia.group_infoenergia_r",1,0,0,0

--- a/som_infoenergia/som_enviament_massiu.py
+++ b/som_infoenergia/som_enviament_massiu.py
@@ -125,6 +125,7 @@ class SomEnviamentMassiu(osv.osv):
         if isinstance(_id, (tuple, list)):
             _id = _id[0]
 
+        attach_obj = self.pool.get('ir.attachment')
         pe_send_obj = self.pool.get('poweremail.send.wizard')
         enviament = self.browse(cursor, uid, _id, context=context)
         allowed_states = ['obert']
@@ -150,6 +151,15 @@ class SomEnviamentMassiu(osv.osv):
             vals.update({'bcc':''})
         if context.get('email_subject', False):
             vals.update({'subject': context.get('email_subject')})
+        attachment_id = attach_obj.search(
+            cursor,
+            uid,
+            [('res_id', '=', _id), ('res_model', '=', 'som.enviament.massiu')],
+        )
+        if attachment_id:
+            vals.update({
+                'attachment_ids': [(6, 0, [attachment_id[0]])]
+            })
         pe_send_obj.write(cursor, uid, [send_id], vals, context=ctx)
         sender = pe_send_obj.browse(cursor, uid, send_id, context=ctx)
         sender.send_mail(context=ctx)

--- a/som_infoenergia/som_enviament_massiu.py
+++ b/som_infoenergia/som_enviament_massiu.py
@@ -15,6 +15,7 @@ from tools.translate import _
 from tools import config
 from som_infoenergia.pdf_tools import topdf
 
+import unicodedata
 
 ESTAT_ENVIAT = [
     ('obert', 'Obert'),
@@ -23,8 +24,50 @@ ESTAT_ENVIAT = [
     ('cancellat', 'Cancel·lat')
 ]
 
+
+def strip_accents(s):
+    return ''.join(
+        c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn'
+    )
+
+
 class SomEnviamentMassiu(osv.osv):
     _name = 'som.enviament.massiu'
+
+    def attach_pdf(self, cursor, uid, ids, filepath):
+        if isinstance(ids, (tuple, list)):
+            ids = ids[0]
+        enviament = self.browse(cursor, uid, ids)
+        attachment_obj = self.pool.get('ir.attachment')
+        attachment_to_delete = attachment_obj.search(
+            cursor,
+            uid,
+            [('res_id', '=', ids), ('res_model', '=', 'som.enviament.massiu')],
+        )
+
+        with open(filepath, 'r') as pdf_file:
+            data = pdf_file.read()
+            values = {
+                'name': 'Lot {}, contracte {}'.format(
+                        enviament.lot_enviament.name,
+                        enviament.polissa_id.name
+                ),
+                'datas_fname': strip_accents(
+                    u'{}_{}.pdf'.format(
+                        enviament.polissa_id.name,
+                        enviament.lot_enviament.name
+                    )
+                ),
+                'datas': base64.b64encode(data),
+                'res_model': 'som.enviament.massiu',
+                'res_id': ids,
+            }
+            attachment_obj.create(cursor, uid, values)
+
+        attachment_obj.unlink(cursor, uid, attachment_to_delete)
+
+        if os.path.isfile(filepath) or os.path.islink(filepath):
+            os.unlink(filepath)
 
     def create(self, cursor, uid, vals=None, context=None):
         if 'polissa_id' in vals:

--- a/som_infoenergia/wizard/__init__.py
+++ b/som_infoenergia/wizard/__init__.py
@@ -7,3 +7,4 @@ import wizard_add_contracts_lot
 import wizard_cancel_from_csv
 import wizard_create_enviaments_from_csv
 import wizard_create_enviaments_from_partner
+import wizard_create_attachments_from_zip

--- a/som_infoenergia/wizard/wizard_create_attachments_from_zip.py
+++ b/som_infoenergia/wizard/wizard_create_attachments_from_zip.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from datetime import datetime
+from tools.translate import _
+import zipfile
+import base64
+from io import BytesIO
+import os
+
+STATES = [("init", "Estat Inicial"), ("finished", "Estat Final")]
+
+
+class WizardCreateAttachmentsFromZip(osv.osv_memory):
+    _name = "wizard.create.attachments.from.zip"
+
+    _columns = {
+        "state": fields.selection(STATES, _(u"Estat del wizard de creació d'adjunts des de ZIP")),
+        "name": fields.char(_(u"Nom del fitxer"), size=256),
+        "zip_file": fields.binary(
+            _(u"Fitxer ZIP"),
+            required=True
+        ),
+    }
+
+    _defaults = {"state": "init"}
+
+    def attach_files(self, cursor, uid, ids, context=None):
+        lot_obj = self.pool.get('som.infoenergia.lot.enviament')
+        env_obj = self.pool.get('som.enviament.massiu')
+        wiz = self.browse(cursor, uid, ids[0], context=context)
+        lot_id = context.get('active_id', 0)
+
+        lot = lot_obj.browse(cursor, uid, lot_id)
+        if lot.tipus != "infoenergia":
+            env_ids = env_obj.search(cursor, uid, [('lot_enviament', '=', lot_id)])
+            zip_data = base64.b64decode(wiz.zip_file)
+
+            tmp_dir = (
+                "/tmp/enviament_massiu_"
+                + str(lot.id)
+                + "_"
+                + datetime.now().strftime("%Y-%m-%d_%H_%M_%S_%f")
+            )
+            if not os.path.exists(tmp_dir):
+                os.makedirs(tmp_dir)
+            zip_file = zipfile.ZipFile(BytesIO(zip_data))
+            zip_file.extractall(tmp_dir)
+            filenames = zip_file.namelist()
+            for env_id in env_ids:
+                try:
+                    env = env_obj.browse(cursor, uid, env_id)
+                    filename = "contracte_" + env.polissa_id.name + ".pdf"
+                    if filename in filenames:
+                        filepath = os.path.join(tmp_dir, filename)
+                        env.attach_pdf(filepath)
+                except Exception:
+                    pass
+
+        wiz.write({'state': "finished"})
+
+
+WizardCreateAttachmentsFromZip()

--- a/som_infoenergia/wizard/wizard_create_attachments_from_zip_view.xml
+++ b/som_infoenergia/wizard/wizard_create_attachments_from_zip_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_wizard_create_attachments_from_zip_form">
+            <field name="name">wizard.create.attachments.from.zip.form</field>
+            <field name="model">wizard.create.attachments.from.zip</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Crear adjunts des de ZIP">
+                    <field name="state" invisible="1"/>
+                    <group attrs="{'invisible': [('state', '!=', 'init')]}">
+                        <label string="Crear adjunts als enviaments a partir d'un ZIP." colspan="4"/>
+                        <label string="El nom del fitxer ha de coincidir amb el número de pòlissa." colspan="4"/>
+                        <field name="zip_file" filename="name" string="Arxiu ZIP" colspan="4"/>
+                        <button name="attach_files" type="object" string="Afegir adjunts" icon="gtk-ok" colspan="4"/>
+                    </group>
+                    <group attrs="{'invisible': [('state', '!=', 'finished')]}">
+                        <label string="S'han afegit els adjunts dels enviaments." colspan="4"/>
+                        <button special="cancel" string="Sortir" icon="gtk-ok" colspan="4"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_wizard_create_attachments_from_zip">
+            <field name="name">Crear adjunts des de ZIP</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.create.attachments.from.zip</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="view_wizard_create_attachments_from_zip_form"/>
+        </record>
+        <record id="values_wizard_create_attachments_from_zip_form" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Crear adjunts des de ZIP</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">som.infoenergia.lot.enviament</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_create_attachments_from_zip'))"/>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu

- Poder adjuntar fitxers externs a l'ERP a enviaments massius d'un lot
- Es necessita per les comunicacions del canvi massiu de K's en pòlisses amb indexada

## Targeta on es demana o Incidència 

https://trello.com/c/pzhhI7Mo/5749-ep288-canviar-les-k-personalitzades-de-manera-massiva

## Comportament antic

- No es podien afegir adjunts de fora l'ERP en els enviaments massius d'un lot

## Comportament nou

- Hi ha un _wizard_ en els lots que permeten afegir adjunts als enviaments massius a partir d'un ZIP
- S'afegeix l'adjunt als enviaments que tenen pòlissa si hi ha un fitxer amb el nom: `contracte_<numero_polissa>.pdf`
- Al fer l'enviament, si l'enviament massiu té un adjunt s'afegeix al correu

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
