### PR TITLE
Modificacions origen

### DIFF
--- a/som_facturacio_comer/__init__.py
+++ b/som_facturacio_comer/__init__.py
@@ -3,3 +3,5 @@ import giscedata_facturacio_validation
 import giscedata_facturacio_contracte_lot
 import wizard
 import giscedata_polissa
+import giscedata_bateria_virtual_percentatges_acumulacio
+import giscedata_bateria_virtual

--- a/som_facturacio_comer/__terp__.py
+++ b/som_facturacio_comer/__terp__.py
@@ -16,6 +16,7 @@
         "som_switching",
         "som_generationkwh",
         "giscedata_repercussio_mecanismo_ajuste_gas",
+        "giscedata_facturacio_bateria_virtual",
     ],
     "init_xml": [],
     "demo_xml": [],
@@ -31,6 +32,7 @@
         "giscedata_facturacio_data.xml",
         "giscedata_lectures_view.xml",
         "giscedata_polissa_view.xml",
+        "giscedata_bateria_virtual_origen.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_comer/giscedata_bateria_virtual.py
+++ b/som_facturacio_comer/giscedata_bateria_virtual.py
@@ -11,10 +11,11 @@ STATES_GESTIO_ACUMULACIO = [
 
 class GiscedataBateriaVirtualOrigen(osv.osv):
     _name = "giscedata.bateria.virtual.origen"
-    _inherit = "giscedata.bateria.virtual.origen"
+    _inherit = 'giscedata.bateria.virtual.origen'
 
     _columns = {
         'gestio_descomptes': fields.selection(STATES_GESTIO_ACUMULACIO, 'Gestió dels descomptes'),
+        'percentatges_acumulacio': fields.one2many('giscedata.bateria.virtual.percentatges.acumulacio', 'percentatge_acumulacio_id', 'Percentatges acumulacio'),
     }
 
     _defaults = {

--- a/som_facturacio_comer/giscedata_bateria_virtual.py
+++ b/som_facturacio_comer/giscedata_bateria_virtual.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Modificacions del model giscedata_facturacio_factura per SOMENERGIA.
+"""
+
+from osv import osv, fields
+from tools.translate import _
+
+STATES_GESTIO_ACUMULACIO = [
+    ('estandard', _("Acumular segons saldo d'excedents")),
+]
+
+class GiscedataBateriaVirtualOrigen(osv.osv):
+    _name = "giscedata.bateria.virtual.origen"
+    _inherit = "giscedata.bateria.virtual.origen"
+
+    _columns = {
+        'gestio_descomptes': fields.selection(STATES_GESTIO_ACUMULACIO, 'Gestió dels descomptes'),
+    }
+
+    _defaults = {
+        'gestio_acumulacio': lambda *a: 'estandard',
+    }
+
+
+GiscedataBateriaVirtualOrigen()

--- a/som_facturacio_comer/giscedata_bateria_virtual_origen.xml
+++ b/som_facturacio_comer/giscedata_bateria_virtual_origen.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_giscedata_bateria_virtual_percentatges">
+            <field name="name">giscedata.bateria.virtual.origen</field>
+            <field name="model">giscedata.bateria.virtual.origen</field>
+			<field name="inherit_id" ref="giscedata_facturacio_bateria_virtual.view_bateries_virtuals_origens_form" />
+            <field name="arch" type="xml">
+                <field name="gestio_acumulacio" position="after">
+                    <field name="percentatges_acumulacio" colspan="2"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>
+

--- a/som_facturacio_comer/giscedata_bateria_virtual_percentatges_acumulacio.py
+++ b/som_facturacio_comer/giscedata_bateria_virtual_percentatges_acumulacio.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Nou modesl de dades per gestionar els percentatges d'acumulacio dels origens de bateria virtual per SOMENERGIA.
+"""
+
+from osv import osv, fields
+from tools.translate import _
+
+
+class GiscedataBateriaVirtualPercentatgesAcumulacio(osv.osv):
+
+    _name = 'giscedata.bateria.virtual.percentatges.acumulacio'
+    _description = _('Bateria virtual percentatge acumulable')
+
+    _columns = {
+        'percentatge': fields.integer('Pecentatge', help=_("Percentatge que acumula la bateria virtual")),
+        'data_inici': fields.datetime(_("Data inici")),
+        'data_fi': fields.datetime(_("Data fi")),
+
+    }
+
+    _defaults = {
+        'percentatge': lambda *a: 100,
+    }
+
+
+GiscedataBateriaVirtualPercentatgesAcumulacio()


### PR DESCRIPTION
## Objectiu
- El desplegable “gestió de l’acumulació” només ha de permetre l’opció de “Acumular saldo excedents”, treure les altres opcions.
- Poder acumular saldo segons percentatge en un origen de bateria virtual.

Afegir camp per definir percentatge

## Targeta on es demana o Incidència 
https://trello.com/c/1GD8yFH9/5731-bateria-t03-modificacions-sobre-lorigen

## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
