### PR TITLE
Accions des de llistat i Noves columnes Bateria virtual

### DIFF
--- a/som_facturacio_comer/__init__.py
+++ b/som_facturacio_comer/__init__.py
@@ -3,3 +3,4 @@ import giscedata_facturacio_validation
 import giscedata_facturacio_contracte_lot
 import wizard
 import giscedata_polissa
+import giscedata_bateria_virtual

--- a/som_facturacio_comer/__terp__.py
+++ b/som_facturacio_comer/__terp__.py
@@ -16,6 +16,7 @@
         "som_switching",
         "som_generationkwh",
         "giscedata_repercussio_mecanismo_ajuste_gas",
+        "giscedata_facturacio_bateria_virtual",
     ],
     "init_xml": [],
     "demo_xml": [],
@@ -31,6 +32,7 @@
         "giscedata_facturacio_data.xml",
         "giscedata_lectures_view.xml",
         "giscedata_polissa_view.xml",
+        "giscedata_bateria_virtual.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_comer/giscedata_bateria_virtual.py
+++ b/som_facturacio_comer/giscedata_bateria_virtual.py
@@ -1,0 +1,52 @@
+# -*- encoding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+from osv.osv import TransactionExecute
+import pooler
+from psycopg2.errors import LockNotAvailable
+from datetime import datetime
+import logging
+import time
+from tools import float_round
+
+
+class GiscedataBateriaVirtual(osv.osv):
+
+    _name = "giscedata.bateria.virtual"
+    _inherit = 'giscedata.bateria.virtual'
+
+    def _ff_origen(self, cursor, uid, ids, name, args, context=None):
+        res = {}
+        for bateria_virtual in self.browse(cursor, uid, ids, context):
+            if bateria_virtual.origen_ids:
+                for origen_id in bateria_virtual.origen_ids:
+                    res[origen_id] = str(origen_id.name)
+        return res
+
+    def _ff_receptor(self, cursor, uid, ids, name, args, context=None):
+        res = {}
+        for bateria_virtual in self.browse(cursor, uid, ids, context):
+            if bateria_virtual.polissa_ids:
+                for polissa_id in bateria_virtual.polissa_ids:
+                    pes = ""
+                    if bateria_virtual.polissa_ids.pes:
+                        pes = str(bateria_virtual.polissa_ids.pes)
+                    res[polissa_id] = str(polissa_id.name) + ", " + pes
+        return res
+
+    def _ff_data_inici_descomptes(self, cursor, uid, ids, name, args, context=None):
+        res = {}
+        for bateria_virtual in self.browse(cursor, uid, ids, context):
+            if bateria_virtual.polissa_ids.data_final:
+                res[bateria_virtual.id] = bateria_virtual.polissa_ids.data_final
+        return res
+
+    _columns = {
+        'origen_id': fields.function(_ff_origen, type="text", method=True, string='Origen'),
+        'receptor_info': fields.function(_ff_receptor, type="text", method=True, string='Receptor'),
+        'data_inici_descomptes': fields.function(_ff_data_inici_descomptes, type="text", method=True, string='Receptor'),
+    }
+
+
+GiscedataBateriaVirtual()
+

--- a/som_facturacio_comer/giscedata_bateria_virtual.py
+++ b/som_facturacio_comer/giscedata_bateria_virtual.py
@@ -17,34 +17,47 @@ class GiscedataBateriaVirtual(osv.osv):
 
     def _ff_origen(self, cursor, uid, ids, name, args, context=None):
         res = {}
-        for bateria_virtual in self.browse(cursor, uid, ids, context):
-            if bateria_virtual.origen_ids:
-                for origen_id in bateria_virtual.origen_ids:
-                    res[origen_id] = str(origen_id.name)
+        for bateria_virtual in self.browse(cursor, uid, ids, context={'prefetch': False}):
+            origens = ""
+            for it, origen_br in enumerate(bateria_virtual.origen_ids):
+                # A partir d'ara nomes n'hi haura un pero en antigues bateries pot ser que no
+                model, id = origen_br.origen_ref.split(",")
+                model_obj = self.pool.get(model)
+                name = model_obj.read(cursor, uid, int(id), ['name'])['name']
+                if it > 0:
+                    origens += "\n" + str(name)
+                else:
+                    origens += str(name)
+            res[bateria_virtual.id] = origens
         return res
 
     def _ff_receptor(self, cursor, uid, ids, name, args, context=None):
         res = {}
-        for bateria_virtual in self.browse(cursor, uid, ids, context):
-            if bateria_virtual.polissa_ids:
-                for polissa_id in bateria_virtual.polissa_ids:
-                    pes = ""
-                    if bateria_virtual.polissa_ids.pes:
-                        pes = str(bateria_virtual.polissa_ids.pes)
-                    res[polissa_id] = str(polissa_id.name) + ", " + pes
+        for bateria_virtual in self.browse(cursor, uid, ids, context={'prefetch': False}):
+            receptors = ""
+            for it, polissa_br in enumerate(bateria_virtual.polissa_ids):
+                # A partir d'ara nomes n'hi haura un pero en antigues bateries pot ser que no
+                name = polissa_br.polissa_id.name
+                pes = polissa_br.pes
+                msg = str(name) + " (" + str(pes) + ")"
+                if it > 0:
+                    receptors += "\n" + msg
+                else:
+                    receptors += msg
+            res[bateria_virtual.id] = receptors
         return res
 
     def _ff_data_inici_descomptes(self, cursor, uid, ids, name, args, context=None):
         res = {}
-        for bateria_virtual in self.browse(cursor, uid, ids, context):
-            if bateria_virtual.polissa_ids.data_final:
-                res[bateria_virtual.id] = bateria_virtual.polissa_ids.data_final
+        for bateria_virtual in self.browse(cursor, uid, ids, context={'prefetch': False}):
+            for polissa_br in bateria_virtual.polissa_ids:
+                res[bateria_virtual.id] = str(polissa_br.data_inici)
         return res
 
     _columns = {
-        'origen_id': fields.function(_ff_origen, type="text", method=True, string='Origen'),
-        'receptor_info': fields.function(_ff_receptor, type="text", method=True, string='Receptor'),
-        'data_inici_descomptes': fields.function(_ff_data_inici_descomptes, type="text", method=True, string='Receptor'),
+        'origen_info': fields.function(_ff_origen, type="text", method=True, string='Origen'),
+        'receptor_info': fields.function(_ff_receptor, type="text", method=True, string='Receptor (pes)'),
+        'data_inici_descomptes': fields.function(_ff_data_inici_descomptes, type="text", method=True, string='Data inici descomptes'),
     }
 
 

--- a/som_facturacio_comer/giscedata_bateria_virtual.xml
+++ b/som_facturacio_comer/giscedata_bateria_virtual.xml
@@ -4,12 +4,12 @@
         <record model="ir.ui.view" id="view_som_bateria_virtual_tree">
             <field name="name">view.som.bateria.virtual.tree</field>
             <field name="model">giscedata.bateria.virtual</field>
-            <field name="type">form</field>
-            <field name="inherit_id" ref="giscedata_facturacio_bateria_virtual.giscegas_polissa.view_bateries_virtuals_tree"/>
+            <field name="type">tree</field>
+            <field name="inherit_id" ref="giscedata_facturacio_bateria_virtual.view_bateries_virtuals_tree"/>
             <field name="arch" type="xml">
-                <field name="titular_nif" position="total_descompte_bateria">
-                    <field name="origen_ids"/>
+                <field name="total_descompte_bateria" position="after">
                     <field name="receptor_info"/>
+                    <field name="origen_info"/>
                     <field name="data_inici_descomptes"/>
                 </field>
             </field>

--- a/som_facturacio_comer/giscedata_bateria_virtual.xml
+++ b/som_facturacio_comer/giscedata_bateria_virtual.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_som_bateria_virtual_tree">
+            <field name="name">view.som.bateria.virtual.tree</field>
+            <field name="model">giscedata.bateria.virtual</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="giscedata_facturacio_bateria_virtual.giscegas_polissa.view_bateries_virtuals_tree"/>
+            <field name="arch" type="xml">
+                <field name="titular_nif" position="total_descompte_bateria">
+                    <field name="origen_ids"/>
+                    <field name="receptor_info"/>
+                    <field name="data_inici_descomptes"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu
Afegir accions des del llistat de bateries virtuals
- Comprovar nous descomptes
- Poder activar descomptes per tots els contractes
- Anar a la vista “Contractes”
- Anar a la vista “Descomptes de la Bateria Virtual”
- Poder anar a la vista “Origens”

Afegir noves columens en el llistat de bateries virtuals
- origen
- receptor + pes
- data creacio bateria (es fa generic)
- data inici descomptes

## PR Relacionada
https://github.com/gisce/erp/pull/17209
Crea les accions des del llistat i afegeix el camp data creacio bateria a la vista del llistat de bateries.

## Targeta on es demana o Incidència 
https://trello.com/c/h22WGjnx/5734-bateria-t01-acci%C3%B3-des-del-llistat-de-bateria-i-columnes-noves

## Comportament antic
No es mostrava cap de els columens anteriros

## Comportament nou
Es mostren les columnes demanades

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
