### PR TITLE
[Bateria Virtual] - Accions i columnes llistat + Modificacions Origen + Percentatges Acumulacio

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio.py
+++ b/som_facturacio_comer/giscedata_facturacio.py
@@ -50,19 +50,5 @@ class GiscedataFacturacioFacturador(osv.osv):
 
         return vals
 
-    def search_polissa_segons_vals(self, cursor, uid, fact_vals, context=None):
-        polissa_bat_obj = self.pool.get("giscedata.bateria.virtual.polissa")
-        res = polissa_bat_obj.search(
-            cursor, uid, [
-                ('polissa_id', '=', fact_vals['polissa_id'][0]),
-                ('data_inici', '>=', fact_vals['data_inici']),
-                ('gestio_descomptes', '!=', 'no_aplicar'),
-                '|',
-                ('data_final', '>', fact_vals['data_final']),
-                ('data_final', '=', False),
-            ], context=context
-        )
-        return res
-
 
 GiscedataFacturacioFacturador()

--- a/som_facturacio_comer/giscedata_facturacio.py
+++ b/som_facturacio_comer/giscedata_facturacio.py
@@ -50,5 +50,19 @@ class GiscedataFacturacioFacturador(osv.osv):
 
         return vals
 
+    def search_polissa_segons_vals(self, cursor, uid, fact_vals, context=None):
+        polissa_bat_obj = self.pool.get("giscedata.bateria.virtual.polissa")
+        res = polissa_bat_obj.search(
+            cursor, uid, [
+                ('polissa_id', '=', fact_vals['polissa_id'][0]),
+                ('data_inici', '>=', fact_vals['data_inici']),
+                ('gestio_descomptes', '!=', 'no_aplicar'),
+                '|',
+                ('data_final', '>', fact_vals['data_final']),
+                ('data_final', '=', False),
+            ], context=context
+        )
+        return res
+
 
 GiscedataFacturacioFacturador()

--- a/som_facturacio_flux_solar/__init__.py
+++ b/som_facturacio_flux_solar/__init__.py
@@ -1,0 +1,1 @@
+import giscedata_bateria_virtual

--- a/som_facturacio_flux_solar/__init__.py
+++ b/som_facturacio_flux_solar/__init__.py
@@ -1,1 +1,3 @@
+import giscedata_bateria_virtual_percentatges_acumulacio
+import giscedata_bateria_virtual_origen
 import giscedata_bateria_virtual

--- a/som_facturacio_flux_solar/__init__.py
+++ b/som_facturacio_flux_solar/__init__.py
@@ -1,3 +1,4 @@
 import giscedata_bateria_virtual_percentatges_acumulacio
 import giscedata_bateria_virtual_origen
 import giscedata_bateria_virtual
+import giscedata_bateria_virtual_polissa

--- a/som_facturacio_flux_solar/__terp__.py
+++ b/som_facturacio_flux_solar/__terp__.py
@@ -15,6 +15,7 @@
     "demo_xml": [],
     "update_xml": [
         "giscedata_bateria_virtual.xml",
+        "giscedata_bateria_virtual_origen.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_flux_solar/__terp__.py
+++ b/som_facturacio_flux_solar/__terp__.py
@@ -17,6 +17,7 @@
         "security/ir.model.access.csv",
         "giscedata_bateria_virtual.xml",
         "giscedata_bateria_virtual_origen.xml",
+        "giscedata_bateria_virtual_percentatges_acumulacio_data.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_flux_solar/__terp__.py
+++ b/som_facturacio_flux_solar/__terp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Funcions de suport a bateria virtual comer per SOM",
+    "description": """
+    This module provide :
+        * Validació propia a giscedata_facturacio_bateria_virtual
+    """,
+    "version": "0-dev",
+    "author": "GISCE",
+    "category": "SomEnergia",
+    "depends":[
+        "giscedata_facturacio_bateria_virtual",
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml": [
+        "giscedata_bateria_virtual.xml",
+    ],
+    "active": False,
+    "installable": True
+}

--- a/som_facturacio_flux_solar/__terp__.py
+++ b/som_facturacio_flux_solar/__terp__.py
@@ -14,6 +14,7 @@
     "init_xml": [],
     "demo_xml": [],
     "update_xml": [
+        "security/ir.model.access.csv",
         "giscedata_bateria_virtual.xml",
         "giscedata_bateria_virtual_origen.xml",
     ],

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+from osv import osv, fields
+
+
+class GiscedataBateriaVirtual(osv.osv):
+
+    _name = "giscedata.bateria.virtual"
+    _inherit = 'giscedata.bateria.virtual'
+
+    def _ff_origen(self, cursor, uid, ids, name, args, context=None):
+        res = {}
+        for bateria_virtual in self.browse(cursor, uid, ids, context={'prefetch': False}):
+            origens = ""
+            for it, origen_br in enumerate(bateria_virtual.origen_ids):
+                # A partir d'ara nomes n'hi haura un pero en antigues bateries pot ser que no
+                model, id = origen_br.origen_ref.split(",")
+                model_obj = self.pool.get(model)
+                name = model_obj.read(cursor, uid, int(id), ['name'])['name']
+                if it > 0:
+                    origens += "\n" + str(name)
+                else:
+                    origens += str(name)
+            res[bateria_virtual.id] = origens
+        return res
+
+    def _ff_receptor(self, cursor, uid, ids, name, args, context=None):
+        res = {}
+        for bateria_virtual in self.browse(cursor, uid, ids, context={'prefetch': False}):
+            receptors = ""
+            for it, polissa_br in enumerate(bateria_virtual.polissa_ids):
+                # A partir d'ara nomes n'hi haura un pero en antigues bateries pot ser que no
+                name = polissa_br.polissa_id.name
+                pes = polissa_br.pes
+                msg = str(name) + " (" + str(pes) + ")"
+                if it > 0:
+                    receptors += "\n" + msg
+                else:
+                    receptors += msg
+            res[bateria_virtual.id] = receptors
+        return res
+
+    def _ff_data_inici_descomptes(self, cursor, uid, ids, name, args, context=None):
+        res = {}
+        for bateria_virtual in self.browse(cursor, uid, ids, context={'prefetch': False}):
+            for polissa_br in bateria_virtual.polissa_ids:
+                res[bateria_virtual.id] = str(polissa_br.data_inici)
+        return res
+
+    _columns = {
+        'origen_info': fields.function(_ff_origen, type="text", method=True, string='Origen'),
+        'receptor_info': fields.function(_ff_receptor, type="text", method=True, string='Receptor (pes)'),
+        'data_inici_descomptes': fields.function(_ff_data_inici_descomptes, type="text", method=True, string='Data inici descomptes'),
+    }
+
+
+GiscedataBateriaVirtual()

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual.xml
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_som_bateria_virtual_tree">
+            <field name="name">view.som.bateria.virtual.tree</field>
+            <field name="model">giscedata.bateria.virtual</field>
+            <field name="type">tree</field>
+            <field name="inherit_id" ref="giscedata_facturacio_bateria_virtual.view_bateries_virtuals_tree"/>
+            <field name="arch" type="xml">
+                <field name="total_descompte_bateria" position="after">
+                    <field name="receptor_info"/>
+                    <field name="origen_info"/>
+                    <field name="data_inici_descomptes"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -18,6 +18,8 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
     def get_bateria_virtual_origen_descomptes(self, cursor, uid, ids, data_final, context=None):
         # [descompte_date, price, 'giscedata.facturacio.factura, factura.id']
         # [05-05-2023, 25.3, 'giscedata.facturacio.factura, 3642']
+        if len(ids) > 1:
+            raise osv.except_osv("Error", _(u"No es pot clacular descomptes per més de un origen alhora."))
         descomptes_totals = super(GiscedataBateriaVirtualOrigen, self).get_bateria_virtual_origen_descomptes(cursor, uid, ids, data_final, context=context)
 
         descomptes = []

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Modificacions del model giscedata_facturacio_factura per SOMENERGIA.
+"""
+from datetime import datetime
+
+from osv import osv, fields
+from tools.translate import _
+
+STATES_GESTIO_ACUMULACIO = [
+    ('estandard', _("Acumular segons saldo d'excedents")),
+    ('percentatge', _("Acumular saldo d'excedents (percentatge)")),
+]
+
+class GiscedataBateriaVirtualOrigen(osv.osv):
+    _name = "giscedata.bateria.virtual.origen"
+    _inherit = 'giscedata.bateria.virtual.origen'
+
+    def get_bateria_virtual_origen_descomptes(self, cursor, uid, ids, data_final, context=None):
+        # [descompte_date, price, 'giscedata.facturacio.factura, factura.id']
+        # [05-05-2023, 25.3, 'giscedata.facturacio.factura, 3642']
+        descomptes_totals = super(GiscedataBateriaVirtualOrigen, self).get_bateria_virtual_origen_descomptes(cursor, uid, ids, data_final, context=context)
+
+        descomptes = []
+        for id in ids:
+            gestio_acumulacio = self.read(cursor, uid, id, ['gestio_acumulacio'], context=context)['gestio_acumulacio']
+            if gestio_acumulacio == 'estandard':
+                return descomptes_totals
+            # per percentatge
+            else:
+                # aplicar el percentatge corresponent segons data, sobre el descompte total
+                for descompte_total in descomptes_totals:
+                    descompte_percentatge = self.get_descompte_amb_percentatge_acumulacio(cursor, uid, id, descompte_total)
+                    descomptes.append(descompte_percentatge)
+                return descomptes
+
+    def get_descompte_amb_percentatge_acumulacio(self, cursor, uid, id, descompte_total):
+        # [descompte_date, price, 'giscedata.facturacio.factura, factura.id']
+        # [05-05-2023, 25.3, 'giscedata.facturacio.factura, 3642']
+        percentatge_acum_obj = self.pool.get('giscedata.bateria.virtual.percentatges.acumulacio')
+
+        descompte_data = descompte_total[0]
+        descompte_preu = descompte_total[1]
+        descompte_ref = descompte_total[2]
+
+        percetatge_acum_id = self.get_percentatge_acumulacio_from_date(cursor, uid, id, descompte_data)
+        percentatge = percentatge_acum_obj.read(cursor, uid, percetatge_acum_id[0], ['percentatge'])['percentatge']
+        amount = descompte_preu * (percentatge/100)
+        return (descompte_data, amount, descompte_ref)
+
+    def get_percentatge_acumulacio_from_date(self, cursor, uid, id, descompte_date):
+        percentatge_acum_obj = self.pool.get('giscedata.bateria.virtual.percentatges.acumulacio')
+        percetatge_acum_id = percentatge_acum_obj.search(cursor, uid, [
+            ('origen_id', '=', id),
+            ('data_inici', '<=', descompte_date),
+            ('data_fi', '>=', descompte_date),
+        ])
+        if len(percetatge_acum_id) > 1:
+            raise osv.except_osv(u"Error", _("Hi ha poercentatges d'acumulacio que comprenen dates en comú"))
+        return percetatge_acum_id
+
+
+    _columns = {
+        'gestio_acumulacio': fields.selection(STATES_GESTIO_ACUMULACIO, "Gestió de l'acumulació"),
+        'percentatges_acumulacio': fields.one2many('giscedata.bateria.virtual.percentatges.acumulacio', 'origen_id', 'Percentatges acumulacio'),
+    }
+
+    _defaults = {
+        'gestio_acumulacio': lambda *a: 'estandard',
+    }
+
+
+GiscedataBateriaVirtualOrigen()

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -81,8 +81,9 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
         polissa_id = orig_br.origen_ref.split(',')[1]
         bat_polissa_id = bat_polissa_obj.search(cursor, uid, [('polissa_id.id','=',polissa_id)], context=context)
-        if bat_polissa_id:
-            data_inici = bat_polissa_obj.read(cursor, uid, bat_polissa_id[0], ['data_inici'])['data_inici']
+        if bat_polissa_id and len(bat_polissa_id) == 1:
+            bat_pol_br = bat_polissa_obj.browse(cursor, uid, bat_polissa_id[0], context={'prefetch': False})
+            data_inici = bat_pol_br.polissa_id.data_inici
             if not orig_br.percentatges_acumulacio:
                 vals = {
                     'percentatge': percentatge_defecte,

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -55,7 +55,7 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
             raise Exception ("Hi ha percentatges d'acumulacio que comprenen dates en comú")
         else:
             percentatge = percentatge_acum_obj.read(cursor, uid, percetatge_acum_ids[0], ['percentatge'])['percentatge']
-            amount = descompte_preu * (percentatge/100)
+            amount = descompte_preu * (percentatge/100.0)
             return (descompte_data, amount, descompte_ref)
 
     def get_percentatge_acumulacio_from_date(self, cursor, uid, id, descompte_date):

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -70,21 +70,19 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
 
         return percetatge_acum_ids
 
-    def _default_percentatge_acumulacio(self, cursor, uid, context=None):
+    def create(self, cursor, uid, vals, context=None):
         percentatge_acum_obj = self.pool.get('giscedata.bateria.virtual.percentatges.acumulacio')
         bat_polissa_obj = self.pool.get('giscedata.bateria.virtual.polissa')
         conf_obj = self.pool.get('res.config')
 
-        origen_id = context.get('active_ids', [])
+        origen_id = super(GiscedataBateriaVirtualOrigen, self).create(cursor, uid, vals, context=context)
         orig_br = self.browse(cursor, uid, origen_id, context={'prefetch': False})
 
         polissa_id = orig_br.bateria_id.origen_ref.split(',')[1]
-
         bateria_polissa_id = bat_polissa_obj.search(cursor, uid, {
             'bateria_id', '=', orig_br.bateria_id.id,
             'polissa_id', '=', polissa_id,
         })
-
         data_inici = bat_polissa_obj.read(cursor, uid, bateria_polissa_id, ['data_inici'])['data_inici']
         percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
 
@@ -93,7 +91,6 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
             'data_inici': data_inici,
             'origen': origen_id,
         }
-
         percentatge_acum_obj.create(cursor, uid, vals, context=context)
 
     _columns = {
@@ -103,7 +100,6 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
 
     _defaults = {
         'gestio_acumulacio': lambda *a: 'estandard',
-        'percentatges_acumulacio': _default_percentatge_acumulacio
     }
 
 

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -78,14 +78,15 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         origen_id = super(GiscedataBateriaVirtualOrigen, self).create(cursor, uid, vals, context=context)
         orig_br = self.browse(cursor, uid, origen_id, context={'prefetch': False})
 
-        if not orig_br.percentatges_acumulacio:
-            polissa_ids = orig_br.bateria_id.polissa_ids
-            for polissa_id in polissa_ids:
-                percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
-
+        percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
+        polissa_id = orig_br.origen_ref.split(',')[1]
+        bat_polissa_id = bat_polissa_obj.search(cursor, uid, [('polissa_id','=',polissa_id)], context=context)
+        if bat_polissa_id:
+            data_inici = bat_polissa_obj.read(cursor, uid, bat_polissa_id, ['data_inici'])['data_inici']
+            if not orig_br.percentatges_acumulacio:
                 vals = {
                     'percentatge': percentatge_defecte,
-                    'data_inici': polissa_id.data_inici,
+                    'data_inici': data_inici,
                     'data_fi': None,
                     'origen_id': origen_id,
                 }

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -78,21 +78,15 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         origen_id = super(GiscedataBateriaVirtualOrigen, self).create(cursor, uid, vals, context=context)
         orig_br = self.browse(cursor, uid, origen_id, context={'prefetch': False})
 
-        polissa_id = orig_br.origen_ref.split(',')[1]
-        bateria_polissa_id = bat_polissa_obj.search(cursor, uid, [
-            ('bateria_id', '=', orig_br.bateria_id.id),
-            ('polissa_id', '=', polissa_id)
-        ])
-
-        if bateria_polissa_id:
-            data_inici = bat_polissa_obj.read(cursor, uid, bateria_polissa_id, ['data_inici'])['data_inici']
+        polissa_ids = orig_br.bateria_id.polissa_ids
+        for polissa_id in polissa_ids:
             percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
 
             vals = {
                 'percentatge': percentatge_defecte,
-                'data_inici': data_inici,
+                'data_inici': polissa_id.data_inici,
                 'data_fi': None,
-                'origen_id': origen_id.id,
+                'origen_id': origen_id,
             }
             percentatge_acum_obj.create(cursor, uid, vals, context=context)
 

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -78,20 +78,22 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         origen_id = super(GiscedataBateriaVirtualOrigen, self).create(cursor, uid, vals, context=context)
         orig_br = self.browse(cursor, uid, origen_id, context={'prefetch': False})
 
-        polissa_id = orig_br.bateria_id.origen_ref.split(',')[1]
+        polissa_id = orig_br.origen_ref.split(',')[1]
         bateria_polissa_id = bat_polissa_obj.search(cursor, uid, {
             'bateria_id', '=', orig_br.bateria_id.id,
             'polissa_id', '=', polissa_id,
         })
-        data_inici = bat_polissa_obj.read(cursor, uid, bateria_polissa_id, ['data_inici'])['data_inici']
-        percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
 
-        vals = {
-            'precerntatge': percentatge_defecte,
-            'data_inici': data_inici,
-            'origen': origen_id,
-        }
-        percentatge_acum_obj.create(cursor, uid, vals, context=context)
+        if bateria_polissa_id:
+            data_inici = bat_polissa_obj.read(cursor, uid, bateria_polissa_id, ['data_inici'])['data_inici']
+            percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
+
+            vals = {
+                'precerntatge': percentatge_defecte,
+                'data_inici': data_inici,
+                'origen': origen_id,
+            }
+            percentatge_acum_obj.create(cursor, uid, vals, context=context)
 
     _columns = {
         'gestio_acumulacio': fields.selection(STATES_GESTIO_ACUMULACIO, "Gestió de l'acumulació"),

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -80,9 +80,9 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
 
         percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
         polissa_id = orig_br.origen_ref.split(',')[1]
-        bat_polissa_id = bat_polissa_obj.search(cursor, uid, [('polissa_id','=',polissa_id)], context=context)
+        bat_polissa_id = bat_polissa_obj.search(cursor, uid, [('polissa_id.id','=',polissa_id)], context=context)
         if bat_polissa_id:
-            data_inici = bat_polissa_obj.read(cursor, uid, bat_polissa_id, ['data_inici'])['data_inici']
+            data_inici = bat_polissa_obj.read(cursor, uid, bat_polissa_id[0], ['data_inici'])['data_inici']
             if not orig_br.percentatges_acumulacio:
                 vals = {
                     'percentatge': percentatge_defecte,

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -78,17 +78,18 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         origen_id = super(GiscedataBateriaVirtualOrigen, self).create(cursor, uid, vals, context=context)
         orig_br = self.browse(cursor, uid, origen_id, context={'prefetch': False})
 
-        polissa_ids = orig_br.bateria_id.polissa_ids
-        for polissa_id in polissa_ids:
-            percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
+        if not orig_br.percentatges_acumulacio:
+            polissa_ids = orig_br.bateria_id.polissa_ids
+            for polissa_id in polissa_ids:
+                percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
 
-            vals = {
-                'percentatge': percentatge_defecte,
-                'data_inici': polissa_id.data_inici,
-                'data_fi': None,
-                'origen_id': origen_id,
-            }
-            percentatge_acum_obj.create(cursor, uid, vals, context=context)
+                vals = {
+                    'percentatge': percentatge_defecte,
+                    'data_inici': polissa_id.data_inici,
+                    'data_fi': None,
+                    'origen_id': origen_id,
+                }
+                percentatge_acum_obj.create(cursor, uid, vals, context=context)
 
     _columns = {
         'gestio_acumulacio': fields.selection(STATES_GESTIO_ACUMULACIO, "Gestió de l'acumulació"),

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -79,19 +79,20 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         orig_br = self.browse(cursor, uid, origen_id, context={'prefetch': False})
 
         polissa_id = orig_br.origen_ref.split(',')[1]
-        bateria_polissa_id = bat_polissa_obj.search(cursor, uid, {
-            'bateria_id', '=', orig_br.bateria_id.id,
-            'polissa_id', '=', polissa_id,
-        })
+        bateria_polissa_id = bat_polissa_obj.search(cursor, uid, [
+            ('bateria_id', '=', orig_br.bateria_id.id),
+            ('polissa_id', '=', polissa_id)
+        ])
 
         if bateria_polissa_id:
             data_inici = bat_polissa_obj.read(cursor, uid, bateria_polissa_id, ['data_inici'])['data_inici']
             percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
 
             vals = {
-                'precerntatge': percentatge_defecte,
+                'percentatge': percentatge_defecte,
                 'data_inici': data_inici,
-                'origen': origen_id,
+                'data_fi': None,
+                'origen_id': origen_id.id,
             }
             percentatge_acum_obj.create(cursor, uid, vals, context=context)
 

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -83,7 +83,7 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         bat_polissa_id = bat_polissa_obj.search(cursor, uid, [('polissa_id.id','=',polissa_id)], context=context)
         if bat_polissa_id and len(bat_polissa_id) == 1:
             bat_pol_br = bat_polissa_obj.browse(cursor, uid, bat_polissa_id[0], context={'prefetch': False})
-            data_inici = bat_pol_br.data_inici
+            data_inici = max(bat_pol_br.data_inici, bat_pol_br.polissa_id.data_alta)
             if not orig_br.percentatges_acumulacio:
                 vals = {
                     'percentatge': percentatge_defecte,

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.py
@@ -83,7 +83,7 @@ class GiscedataBateriaVirtualOrigen(osv.osv):
         bat_polissa_id = bat_polissa_obj.search(cursor, uid, [('polissa_id.id','=',polissa_id)], context=context)
         if bat_polissa_id and len(bat_polissa_id) == 1:
             bat_pol_br = bat_polissa_obj.browse(cursor, uid, bat_polissa_id[0], context={'prefetch': False})
-            data_inici = bat_pol_br.polissa_id.data_inici
+            data_inici = bat_pol_br.data_inici
             if not orig_br.percentatges_acumulacio:
                 vals = {
                     'percentatge': percentatge_defecte,

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.xml
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_origen.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Percentatges acumulacio -->
+        <record model="ir.ui.view" id="view_giscedata_bateria_virtual_percentatges_acumulacio_tree">
+            <field name="name">giscedata.bateria.virtual.percentatges.acumulacio.tree</field>
+            <field name="model">giscedata.bateria.virtual.percentatges.acumulacio</field>
+            <field name="type">tree</field>
+            <field name="arch" type="xml" >
+                <tree string="Percentatges acumulacio">
+                    <field name="data_inici"/>
+                    <field name="data_fi"/>
+                    <field name="percentatge"/>
+                </tree>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_giscedata_bateria_virtual_percentatges_acumulacio_form">
+            <field name="name">giscedata.bateria.virtual.percentatges.acumulacio.form</field>
+            <field name="model">giscedata.bateria.virtual.percentatges.acumulacio</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml" >
+                <form string="Percentatges acumulacio">
+                    <field name="data_inici"/>
+                    <field name="data_fi"/>
+                    <field name="percentatge"/>
+                </form>
+            </field>
+        </record>
+
+        <!-- Percentatges en origen -->
+        <record model="ir.ui.view" id="view_giscedata_bateria_virtual_origen_percentatges">
+            <field name="name">giscedata.bateria.virtual.origen.percentatges</field>
+            <field name="model">giscedata.bateria.virtual.origen</field>
+			<field name="inherit_id" ref="giscedata_facturacio_bateria_virtual.view_bateries_virtuals_origens_form" />
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="gestio_acumulacio" position="after">
+                    <newline/>
+                    <group colspan="4" attrs="{'invisible':[('gestio_acumulacio','!=','percentatge')]}">
+                        <field name="percentatges_acumulacio" nolabel="1"/>
+                    </group>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_percentatges_acumulacio.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_percentatges_acumulacio.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Nou modesl de dades per gestionar els percentatges d'acumulacio dels origens de bateria virtual per SOMENERGIA.
+"""
+
+from osv import osv, fields
+from tools.translate import _
+
+
+class GiscedataBateriaVirtualPercentatgesAcumulacio(osv.osv):
+
+    _name = 'giscedata.bateria.virtual.percentatges.acumulacio'
+    _description = _('Bateria virtual percentatge acumulable')
+
+    _columns = {
+        'percentatge': fields.integer('Pecentatge', help=_("Percentatge que acumula la bateria virtual")),
+        'data_inici': fields.date(_("Data inici"), required=True),
+        'data_fi': fields.date(_("Data fi")),
+        'origen_id': fields.many2one('giscedata.bateria.virtual.origen', 'Origen', ondelete='cascade')
+    }
+
+    _defaults = {
+        'percentatge': lambda *a: 100,
+    }
+
+
+GiscedataBateriaVirtualPercentatgesAcumulacio()

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_percentatges_acumulacio.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_percentatges_acumulacio.py
@@ -25,3 +25,31 @@ class GiscedataBateriaVirtualPercentatgesAcumulacio(osv.osv):
 
 
 GiscedataBateriaVirtualPercentatgesAcumulacio()
+
+
+class GiscedataPolissa(osv.osv):
+
+    _name = 'giscedata.polissa'
+    _inherit = 'giscedata.polissa'
+
+    def wkf_baixa(self, cursor, uid, ids):
+        # Afegir la data de baixa al percentatge d'acumulacio de la bateria virtual quan es dona de baixa la polissa
+
+        res = super(GiscedataPolissa, self).wkf_baixa(cursor, uid, ids)
+
+        pol_obj = self.pool.get('giscedata.polissa')
+        bat_percentatge_obj = self.pool.get('giscedata.bateria.virtual.percentatges.acumulacio')
+
+        for pol_id in ids:
+            pol_br = pol_obj.browse(cursor, uid, pol_id, context={'prefetch': False})
+            for pol_bat_br in pol_br.bateria_ids:
+                for orig_br in pol_bat_br.bateria_id.origen_ids:
+                    for percentatge_acum_br in orig_br.percentatges_acumulacio:
+                        if not percentatge_acum_br.data_fi or percentatge_acum_br.data_fi > pol_br.data_baixa:
+                            bat_percentatge_obj.write(cursor, uid, percentatge_acum_br.id, {
+                                'data_fi': pol_br.data_baixa
+                            })
+        return res
+
+
+GiscedataPolissa()

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_percentatges_acumulacio_data.xml
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_percentatges_acumulacio_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record model="res.config" id="account_link_join_43">
+            <field name="name">percentatge_acumulacio</field>
+            <field name="value">80</field>
+            <field name="description">Percentatge d'acumulació per defecte en origens de Bateria Virtual.</field>
+        </record>
+    </data>
+</openerp>

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
@@ -26,7 +26,7 @@ class GiscedataBateriaVirtualPolissa(osv.osv):
                 'percentatge': percentatge_defecte,
                 'data_inici': polissa_br.data_inici,
                 'data_fi': None,
-                'origen': origen_id.id,
+                'origen_id': origen_id.id,
             })
 
 

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
@@ -22,12 +22,13 @@ class GiscedataBateriaVirtualPolissa(osv.osv):
 
         origen_ids = polissa_br.bateria_id.origen_ids
         for origen_id in origen_ids:
-            percentatge_acum_obj.create(cursor, uid, {
-                'percentatge': percentatge_defecte,
-                'data_inici': polissa_br.data_inici,
-                'data_fi': None,
-                'origen_id': origen_id.id,
-            })
+            if not origen_id.precentatge_acumulacio:
+                percentatge_acum_obj.create(cursor, uid, {
+                    'percentatge': percentatge_defecte,
+                    'data_inici': polissa_br.data_inici,
+                    'data_fi': None,
+                    'origen_id': origen_id.id,
+                })
 
 
 GiscedataBateriaVirtualPolissa()

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+from osv import osv, fields
+from tools.translate import _
+
+
+class GiscedataBateriaVirtualPolissa(osv.osv):
+    _name = "giscedata.bateria.virtual.polissa"
+    _inherit = 'giscedata.bateria.virtual.polissa'
+    
+    def create(self, cursor, uid, vals, context=None):
+        percentatge_acum_obj = self.pool.get('giscedata.bateria.virtual.percentatges.acumulacio')
+        origen_obj = self.pool.get('giscedata.bateria.virtual.origen')
+        conf_obj = self.pool.get('res.config')
+
+        bat_polissa_id = super(GiscedataBateriaVirtualPolissa, self).create(cursor, uid, vals, context=context)
+        polissa_br = self.browse(cursor, uid, bat_polissa_id, context={'prefetch': False})
+
+        percentatge_defecte = int(conf_obj.get(cursor, uid, 'percentatge_acumulacio', '100'))
+
+        origen_ids = polissa_br.bateria_id.origen_ids
+        for origen_id in origen_ids:
+            percentatge_acum_obj.create(cursor, uid, {
+                'percentatge': percentatge_defecte,
+                'data_inici': polissa_br.data_inici,
+                'data_fi': None,
+                'origen': origen_id.id,
+            })
+
+
+GiscedataBateriaVirtualPolissa()

--- a/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual_polissa.py
@@ -22,7 +22,7 @@ class GiscedataBateriaVirtualPolissa(osv.osv):
 
         origen_ids = polissa_br.bateria_id.origen_ids
         for origen_id in origen_ids:
-            if not origen_id.precentatge_acumulacio:
+            if not origen_id.percentatges_acumulacio:
                 percentatge_acum_obj.create(cursor, uid, {
                     'percentatge': percentatge_defecte,
                     'data_inici': polissa_br.data_inici,

--- a/som_facturacio_flux_solar/migrations/5.0.23.9.0/post-0001_flux_solar_inici.py
+++ b/som_facturacio_flux_solar/migrations/5.0.23.9.0/post-0001_flux_solar_inici.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data, load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Creating pooler")
+    pool = pooler.get_pool(cursor.dbname)
+
+    ##UPDATAR UN MODUL NOU AL CREAR-LO O AFEGIR UNA COLUMNA##
+    logger.info("Creating table: giscedata.bateria.virtual")
+    pool.get("giscedata.bateria.virtual")._auto_init(cursor, context={'module': 'som_facturacio_flux_solar'})
+    logger.info("Table created succesfully.")
+
+    logger.info("Creating table: giscedata.bateria.virtual.origen")
+    pool.get("giscedata.bateria.virtual.origen")._auto_init(cursor, context={'module': 'som_facturacio_flux_solar'})
+    logger.info("Table created succesfully.")
+
+    logger.info("Creating table: giscedata.bateria.virtual.percentatges.acumulacio")
+    pool.get("giscedata.bateria.virtual.percentatges.acumulacio")._auto_init(cursor, context={'module': 'som_facturacio_flux_solar'})
+    logger.info("Table created succesfully.")
+
+    ##UPATAR UN XML SENCER##
+    logger.info("Updating XML giscedata_bateria_virtual.xml")
+    load_data(
+        cursor, 'som_facturacio_flux_solar', 'giscedata_bateria_virtual.xml', idref=None, mode='update'
+    )
+    logger.info("Updating XML giscedata_bateria_virtual_origen.xml")
+    load_data(
+        cursor, 'som_facturacio_flux_solar', 'giscedata_bateria_virtual_origen.xml', idref=None, mode='update'
+    )
+    logger.info("Updating XML giscedata_bateria_virtual_percentatges_acumulacio_data.xml")
+    load_data(
+        cursor, 'som_facturacio_flux_solar', 'giscedata_bateria_virtual_percentatges_acumulacio_data.xml', idref=None, mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_facturacio_flux_solar/security/ir.model.access.csv
+++ b/som_facturacio_flux_solar/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_giscedata_bateria_virtual_percentatges_acumulacio_u","giscedata.bateria.virtual.percentatges.acumulacio","model_giscedata_bateria_virtual_percentatges_acumulacio","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
+"access_giscedata_bateria_virtual_percentatges_acumulacio_r","giscedata.bateria.virtual.percentatges.acumulacio","model_giscedata_bateria_virtual_percentatges_acumulacio","giscedata_facturacio.group_giscedata_facturacio_r",1,0,0,0
+"access_giscedata_bateria_virtual_percentatges_acumulacio_w","giscedata.bateria.virtual.percentatges.acumulacio","model_giscedata_bateria_virtual_percentatges_acumulacio","giscedata_facturacio.group_giscedata_facturacio_w",1,1,1,0


### PR DESCRIPTION
### Objectiu

Varies millores sobre la bateria virtual

## Acció des del llistat de bateria i columnes noves
Afegir accions des del llistat de bateries virtuals
- Comprovar nous descomptes
- Poder activar descomptes per tots els contractes
- Anar a la vista “Contractes”
- Anar a la vista “Descomptes de la Bateria Virtual”
- Poder anar a la vista “Origens”

Afegir noves columens en el llistat de bateries virtuals
- origen
- receptor + pes
- data creacio bateria (es fa generic)
- data inici descomptes

## Modificacions sobre l'origen
El desplegable “gestió de l’acumulació” només ha de permetre l’opció de “Acumular saldo excedents”, treure les altres opcions.

### - Poder acumular saldo segons percentatge en un origen de bateria virtual.
A "Gestió de l'acumulació", si marquem l'opció "Acumular saldo d'excedents (percentatge)", veurem com es mostra una nova taula amb els percentatges d'acumulació.
Aquests tenen una data inici, una data fi i un perentatge (numero del 0 al 100). Per defecte sempre es crea un percentatge d'acumulacio amb la data inici del contracte receptor i el percentatge fixat per la variable de configuració "percentatge_acumulacio".
No hi ha data fi per defecte, aquesta s'emplena automàticament en cas que la polissa corresponent es dongui de baixa. Es pot afegir manualment i crear diferents percentatges de descomptes en diferents periodes. En cas que coincideixin dos periodes de percentatges d' acumulació, saltarà un error.

![image](https://github.com/Som-Energia/openerp_som_addons/assets/98807045/23c80d3b-ca0d-4b1f-be37-179a4a38d78b)


## PR Relacionades
Corregir importe de backend de bateria virtual
https://github.com/gisce/erp/pull/16988
Crea les accions des del llistat i afegeix el camp data creacio bateria a la vista del llistat de bateries.
https://github.com/gisce/erp/pull/17209

## Targeta on es demana o Incidència 
Acció des del llistat de bateria i columnes noves
https://trello.com/c/h22WGjnx/5734-bateria-t01-acci%C3%B3-des-del-llistat-de-bateria-i-columnes-noves
Modificacions sobre l'origen
https://trello.com/c/1GD8yFH9/5731-bateria-t03-modificacions-sobre-lorigen

## Comportament antic
No es mostrava cap de els columens anteriros

## Comportament nou
Es mostren les columnes demanades

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
