### PR TITLE
Crear entrada a wizard de selecció des de CSV per factures rectificades

### DIFF
--- a/som_facturacio_switching/wizard/wizard_model_list_from_file_data.xml
+++ b/som_facturacio_switching/wizard/wizard_model_list_from_file_data.xml
@@ -11,5 +11,10 @@
             <field name="name">Id de pòlissa</field>
             <field name="column">polissa_id.id</field>
         </record>
+        <record model="wizard.model.list.from.file.filter" id="model_list_wizard_filter_importacio_factura_rectificada">
+            <field name="model">giscedata.facturacio.importacio.linia</field>
+            <field name="name">Codi factura rectificada/anulada</field>
+            <field name="column">factura_rectificada</field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu

Crear una entrada als filtres del wizard de selecció des de CSV per "giscedata.facturacio.importacio.linia" (fitxers f1 importats) pel camp "Codi factura rectificada/anulada" de forma correcta, eliminant-ne la creada manual via migració.

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2246565156/14936041

## Comportament antic

Fallava al fer la migració de la columna se som antiga cap a la columna de gisce "factura_rectificada", impossibilitat de detectar-ho al ser una modificació a mà a la bbdd sense rastre al codi.

## Comportament nou

Definir el camp correctament per futures migracions

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
     - som_facturacio_switching
- [x] Script de migració
- [ ] Modifica traduccions
