### PR TITLE
Afegir "helper" per comprovar si es pot modificar el contracte

### DIFF
--- a/www_som/__terp__.py
+++ b/www_som/__terp__.py
@@ -11,6 +11,7 @@ Mòdul per la integració de l'oficina virtual
         "base_extended",
         "www_base",
         "som_polissa_soci",
+        "som_indexada",
         "giscedata_lectures_comer",
         "giscedata_lectures_pool",
         "giscedata_facturacio_impagat_comer",

--- a/www_som/giscedata_polissa.py
+++ b/www_som/giscedata_polissa.py
@@ -117,7 +117,7 @@ class GiscedataPolissa(osv.osv):
         return traceback.format_exception(exc_type, exc_value, exc_tb)
 
     def www_check_modifiable_polissa(
-        self, cursor, uid, polissa_id, skip_atr_check=False, excluded_cases=[], context=None
+        self, cursor, uid, polissa_id, skip_atr_check=False, excluded_cases=None, context=None
     ):
         """
         Things to check before allowing modcons to the contract.
@@ -127,6 +127,9 @@ class GiscedataPolissa(osv.osv):
 
         if context is None:
             context = {}
+    
+        if excluded_cases is None:
+            excluded_cases = []
 
         sw_obj = self.pool.get('giscedata.switching')
 

--- a/www_som/giscedata_polissa.py
+++ b/www_som/giscedata_polissa.py
@@ -116,7 +116,9 @@ class GiscedataPolissa(osv.osv):
         exc_type, exc_value, exc_tb = sys.exc_info()
         return traceback.format_exception(exc_type, exc_value, exc_tb)
 
-    def www_check_modifiable_polissa(self, cursor, uid, polissa_id, skip_atr_check=False, context=None):
+    def www_check_modifiable_polissa(
+        self, cursor, uid, polissa_id, skip_atr_check=False, excluded_cases=[], context=None
+    ):
         """
         Things to check before allowing modcons to the contract.
         - Contract doesn't have ANY pending modcons
@@ -138,10 +140,11 @@ class GiscedataPolissa(osv.osv):
             if prev_modcon.state == 'pendent':
                 raise indexada_exceptions.PolissaModconPending(polissa.name)
 
+            excluded_cases.append('R1')
             atr_case = sw_obj.search(cursor, uid, [
                 ('polissa_ref_id', '=', polissa.id),
                 ('state', 'in', ['open', 'draft', 'pending']),
-                ('proces_id.name', '!=', 'R1'),
+                ('proces_id.name', 'not in', excluded_cases),
             ])
 
             if atr_case and not skip_atr_check:

--- a/www_som/giscedata_polissa.py
+++ b/www_som/giscedata_polissa.py
@@ -116,7 +116,7 @@ class GiscedataPolissa(osv.osv):
         exc_type, exc_value, exc_tb = sys.exc_info()
         return traceback.format_exception(exc_type, exc_value, exc_tb)
 
-    def www_check_modifiable_polissa(self, cursor, uid, polissa_id, context=None):
+    def www_check_modifiable_polissa(self, cursor, uid, polissa_id, skip_atr_check=False, context=None):
         """
         Things to check before allowing modcons to the contract.
         - Contract doesn't have ANY pending modcons
@@ -144,7 +144,7 @@ class GiscedataPolissa(osv.osv):
                 ('proces_id.name', '!=', 'R1'),
             ])
 
-            if atr_case:
+            if atr_case and not skip_atr_check:
                 raise indexada_exceptions.PolissaSimultaneousATR(polissa.name)
         except indexada_exceptions.IndexadaException as e:
             return dict(

--- a/www_som/tests/tests_polissa.py
+++ b/www_som/tests/tests_polissa.py
@@ -196,6 +196,33 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
         self.assertEqual(result['code'], u"PolissaSimultaneousATR")
 
 
+    def test_www_check_modifiable_polissa_modifiable_atr_skip_check(self):
+        pol_id = self._open_polissa('polissa_tarifa_018')
+
+        ctx = {
+            'lang': 'en_US'
+        }
+
+        proces_id = self.swproc_obj.search(
+            self.cursor, self.uid, [('name', '=', 'M1')]
+        )[0]
+
+        sw_params = {
+            'proces_id': proces_id,
+            'cups_polissa_id': pol_id,
+            'ref_contracte': pol_id,
+            'polissa_ref_id': pol_id,
+        }
+
+        self.sw_obj.create(
+            self.cursor, self.uid, sw_params, context=ctx
+        )
+
+        result = self.pol_obj.www_check_modifiable_polissa(
+            self.cursor, self.uid, pol_id, skip_atr_check=True, context=ctx
+        )
+
+        self.assertEqual(result, True)
 
     def test_www_check_modifiable_polissa_not_modifiable_for_pending_modcon(self):
         pol_id = self._open_polissa('polissa_tarifa_018')

--- a/www_som/tests/tests_polissa.py
+++ b/www_som/tests/tests_polissa.py
@@ -188,11 +188,13 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
             self.cursor, self.uid, sw_params, context=ctx
         )
 
-        with self.assertRaises(indexada_exceptions.PolissaSimultaneousATR) as error:
-            self.pol_obj.www_check_modifiable_polissa(
-                self.cursor, self.uid, pol_id, context=ctx
-            )
-        self.assertEqual(error.exception.to_dict()['error'], u"Pòlissa 0018 with simultaneous ATR")
+        result = self.pol_obj.www_check_modifiable_polissa(
+            self.cursor, self.uid, pol_id, context=ctx
+        )
+
+        self.assertEqual(result['error'], u"Pòlissa 0018 with simultaneous ATR")
+        self.assertEqual(result['code'], u"PolissaSimultaneousATR")
+
 
 
     def test_www_check_modifiable_polissa_not_modifiable_for_pending_modcon(self):
@@ -213,11 +215,11 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
             self.cursor, self.uid, pol_id, values, today_plus_10_days, today_plus_100_days, context=ctx
         )
 
-        with self.assertRaises(indexada_exceptions.PolissaModconPending) as error:
-            self.pol_obj.www_check_modifiable_polissa(
-                self.cursor, self.uid, pol_id, context=ctx
-            )
-        self.assertEqual(error.exception.to_dict()['error'], u"Pòlissa 0018 already has a pending modcon")
+        result = self.pol_obj.www_check_modifiable_polissa(
+            self.cursor, self.uid, pol_id, context=ctx
+        )
+        self.assertEqual(result['error'], u"Pòlissa 0018 already has a pending modcon")
+        self.assertEqual(result['code'], u"PolissaModconPending")
 
 
     def test_www_check_modifiable_polissa_modifiable(self):
@@ -227,9 +229,9 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
             'lang': 'en_US'
         }
 
-        res = self.pol_obj.www_check_modifiable_polissa(self.cursor, self.uid, pol_id, context=ctx)
+        result = self.pol_obj.www_check_modifiable_polissa(self.cursor, self.uid, pol_id, context=ctx)
 
-        self.assertEqual(res, True)
+        self.assertEqual(result, True)
 
 
     def test_www_check_modifiable_polissa_not_modifiable_for_not_active(self):
@@ -241,8 +243,8 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
             'lang': 'en_US'
         }
 
-        with self.assertRaises(indexada_exceptions.PolissaNotActive) as error:
-            self.pol_obj.www_check_modifiable_polissa(
-                self.cursor, self.uid, pol_id, context=ctx
-            )
-        self.assertEqual(error.exception.to_dict()['error'], u"Pòlissa 0018 not active")
+        result = self.pol_obj.www_check_modifiable_polissa(
+            self.cursor, self.uid, pol_id, context=ctx
+        )
+        self.assertEqual(result['error'], u"Pòlissa 0018 not active")
+        self.assertEqual(result['code'], u"PolissaNotActive")

--- a/www_som/tests/tests_polissa.py
+++ b/www_som/tests/tests_polissa.py
@@ -181,6 +181,7 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
             'proces_id': proces_id,
             'cups_polissa_id': pol_id,
             'ref_contracte': pol_id,
+            'polissa_ref_id': pol_id,
         }
 
         self.sw_obj.create(


### PR DESCRIPTION
## Objectiu
Afegir "helper" per comprovar si es pot modificar el contracte

## Targeta on es demana o Incidència 
https://trello.com/c/pLkgUKbJ/5769-ep288-implementar-validador-de-modcon-pendents-per-a-lov


## Comportament antic
La OV no comprobaba si hi havia alguna modificació pendent abans de fer una modificació

## Comportament nou
Ara ho comprova

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar ERP
