### PR TITLE
Refactor del codi de canvi de compte

### DIFF
--- a/som_polissa/__init__.py
+++ b/som_polissa/__init__.py
@@ -1,3 +1,4 @@
 import giscedata_polissa
 import report
 import wizard
+import som_polissa_webforms_helpers

--- a/som_polissa/__terp__.py
+++ b/som_polissa/__terp__.py
@@ -21,7 +21,8 @@
         "giscedata_facturacio_impagat_comer",
         "som_switching",
         "base_bank_extended",
-        "l10n_ES_remesas"
+        "l10n_ES_remesas",
+        "www_base",
     ],
     "init_xml": [],
     "demo_xml": [

--- a/som_polissa/som_polissa_webforms_helpers.py
+++ b/som_polissa/som_polissa_webforms_helpers.py
@@ -1,0 +1,65 @@
+from osv import osv
+
+class SomPolissaWebformsHelpers(osv.osv_memory):
+
+    _name = 'som.polissa.webforms.helpers'
+
+    def www_get_iban(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+        if isinstance(ids, (list, set, tuple)):
+            polissa_id = ids[0]
+        else:
+            polissa_id = ids
+
+        pol_obj = self.pool.get('giscedata.polissa')
+        bank = pol_obj.read(
+            cursor, uid, polissa_id, ['bank'], context=context
+        )
+        iban = ''
+        if bank.get('bank'):
+            iban_prefix = bank['bank'][1][-4:]
+            iban = '**** **** **** **** **** {}'.format(iban_prefix)
+        return iban
+
+    def www_check_iban(self, cursor, uid, iban, context=None):
+        if context is None:
+            context = {}
+
+        pol_obj = self.pool.get('giscedata.polissa')
+        result = pol_obj.www_check_iban(cursor, uid, iban, context=context)
+
+        return result
+
+    def www_set_iban(self, cursor, uid, ids, iban, context=None):
+        if context is None:
+            context = {}
+        if isinstance(ids, (list, set, tuple)):
+            polissa_id = ids[0]
+        else:
+            polissa_id = ids
+
+        wiz_obj = self.pool.get('wizard.bank.account.change')
+
+        vals = {
+            'account_iban': iban,
+            'print_mandate': False,
+            'state': 'end'
+        }
+
+        context = {
+            'active_id': polissa_id
+        }
+
+        wiz_id = wiz_obj.create(cursor, uid, vals, context=context)
+        wizard_result = wiz_obj.action_bank_account_change_confirm(
+            cursor, uid, [wiz_id], context=context
+        )
+
+        result = False
+        if wizard_result == {}:
+            result = True
+        return result
+
+
+SomPolissaWebformsHelpers()

--- a/som_polissa/som_polissa_webforms_helpers.py
+++ b/som_polissa/som_polissa_webforms_helpers.py
@@ -18,8 +18,8 @@ class SomPolissaWebformsHelpers(osv.osv_memory):
         )
         iban = ''
         if bank.get('bank'):
-            iban_prefix = bank['bank'][1][-4:]
-            iban = '**** **** **** **** **** {}'.format(iban_prefix)
+            iban_suffix = bank['bank'][1][-4:]
+            iban = '**** **** **** **** **** {}'.format(iban_suffix)
         return iban
 
     def www_check_iban(self, cursor, uid, iban, context=None):

--- a/som_polissa/tests/__init__.py
+++ b/som_polissa/tests/__init__.py
@@ -1,2 +1,3 @@
 from test_wizard_gestio_text_to_polissa import *
 from som_polissa_tests import *
+from som_polissa_webforms_helpers_tests import *

--- a/som_polissa/tests/som_polissa_demo.xml
+++ b/som_polissa/tests/som_polissa_demo.xml
@@ -27,5 +27,8 @@
             <field name="tg">1</field>
             <field name="autoconsumo">00</field>
         </record>
+        <record id="giscedata_polissa.polissa_tarifa_018" model="giscedata.polissa">
+            <field name="bank" ref="base_iban.res_partner_bank_iban_0001"/>
+        </record>
     </data>
 </openerp>

--- a/som_polissa/tests/som_polissa_demo.xml
+++ b/som_polissa/tests/som_polissa_demo.xml
@@ -5,6 +5,14 @@
             <field name="vat">ES78106306P</field>
             <field name="name">Física, Persona</field>
         </record>
+        <record id="res_partner_bank_som_iban" model="res.partner.bank">
+            <field name="name">0001_som_iban_bank</field>
+            <field name="state">iban</field>
+            <field name="partner_id" ref="base.res_partner_gisce"/>
+            <field name="bank" ref="base.partner_bank"/>
+            <field name="acc_country_id">1</field>
+            <field name="iban">ES5131050395675655409397</field>
+        </record>
         <record id="polissa_domestica_0100" model="giscedata.polissa">
             <field name="name">0100</field>
             <field name="name_auto" eval="1"/>
@@ -26,9 +34,18 @@
             <field name="tipus_vivenda">habitual</field>
             <field name="tg">1</field>
             <field name="autoconsumo">00</field>
-        </record>
-        <record id="giscedata_polissa.polissa_tarifa_018" model="giscedata.polissa">
-            <field name="bank" ref="base_iban.res_partner_bank_iban_0001"/>
+            <field name="llista_preu" ref="giscedata_facturacio.pricelist_tarifas_electricidad"/>
+            <field name="bank" ref="res_partner_bank_som_iban"/>
+            <field name="facturacio" eval="1"/>
+            <field name="facturacio_potencia">icp</field>
+            <field name="notificacio">titular</field>
+            <field name="pagador_sel">titular</field>
+            <field name="pagador" ref="base.res_partner_gisce"/>
+            <field name="direccio_notificacio" ref="base.res_partner_address_1"/>
+            <field name="direccio_pagament" ref="base.res_partner_address_1"/>
+            <field name="tipo_pago">1</field>
+            <field name="contract_type">01</field>
+            <field name="property_unitat_potencia" search="[('name','=','kW/dia')]"/>
         </record>
     </data>
 </openerp>

--- a/som_polissa/tests/som_polissa_demo.xml
+++ b/som_polissa/tests/som_polissa_demo.xml
@@ -5,6 +5,13 @@
             <field name="vat">ES78106306P</field>
             <field name="name">Física, Persona</field>
         </record>
+        <record model="payment.mode" id="payment_mode_demo_som">
+            <field name="name">ENGINYERS</field>
+            <field name="type" ref="account_payment.payment_type_demo"/>
+            <field name="bank_id" ref="base.main_bank"/>
+            <field name="journal" model="account.journal" search="[('type','=','cash')]"/>
+            <field name="sepa_creditor_code">ES62000B98670003</field>
+        </record>
         <record id="res_partner_bank_som_iban" model="res.partner.bank">
             <field name="name">0001_som_iban_bank</field>
             <field name="state">iban</field>
@@ -46,6 +53,7 @@
             <field name="tipo_pago">1</field>
             <field name="contract_type">01</field>
             <field name="property_unitat_potencia" search="[('name','=','kW/dia')]"/>
+            <field name="payment_mode_id" ref="payment_mode_demo_som"/>
         </record>
     </data>
 </openerp>

--- a/som_polissa/tests/som_polissa_webforms_helpers_tests.py
+++ b/som_polissa/tests/som_polissa_webforms_helpers_tests.py
@@ -23,7 +23,7 @@ class TestSomWebformsHelpersPolissa(testing.OOTestCase):
 
     def _open_polissa(self, xml_ref):
         polissa_id = self.imd_obj.get_object_reference(
-            self.cursor, self.uid, 'giscedata_polissa', xml_ref
+            self.cursor, self.uid, 'som_polissa', xml_ref
         )[1]
 
         self.polissa_obj.send_signal(self.cursor, self.uid, [polissa_id], [
@@ -33,7 +33,7 @@ class TestSomWebformsHelpersPolissa(testing.OOTestCase):
         return polissa_id
 
     def test_www_get_iban(self):
-        polissa_id = self._open_polissa('polissa_tarifa_018')
+        polissa_id = self._open_polissa('polissa_domestica_0100')
         result = self.helper_obj.www_get_iban(self.cursor, self.uid, polissa_id)
         self.assertEqual(result, '**** **** **** **** **** 7890')
 
@@ -46,7 +46,7 @@ class TestSomWebformsHelpersPolissa(testing.OOTestCase):
         self.assertEqual(result, False)
 
     def test_www_set_iban(self):
-        polissa_id = self._open_polissa('polissa_tarifa_018')
+        polissa_id = self._open_polissa('polissa_domestica_0100')
         new_iban = 'ES3120170806126133002095'
         result = self.helper_obj.www_set_iban(
             self.cursor, self.uid, polissa_id, new_iban

--- a/som_polissa/tests/som_polissa_webforms_helpers_tests.py
+++ b/som_polissa/tests/som_polissa_webforms_helpers_tests.py
@@ -35,7 +35,7 @@ class TestSomWebformsHelpersPolissa(testing.OOTestCase):
     def test_www_get_iban(self):
         polissa_id = self._open_polissa('polissa_domestica_0100')
         result = self.helper_obj.www_get_iban(self.cursor, self.uid, polissa_id)
-        self.assertEqual(result, '**** **** **** **** **** 7890')
+        self.assertEqual(result, '**** **** **** **** **** 9397')
 
     def test_www_check_iban(self):
         correct_iban = 'ES3120170806126133002095'
@@ -47,7 +47,7 @@ class TestSomWebformsHelpersPolissa(testing.OOTestCase):
 
     def test_www_set_iban(self):
         polissa_id = self._open_polissa('polissa_domestica_0100')
-        new_iban = 'ES3120170806126133002095'
+        new_iban = 'ES31 2017 0806 1261 3300 2095'
         result = self.helper_obj.www_set_iban(
             self.cursor, self.uid, polissa_id, new_iban
         )

--- a/som_polissa/tests/som_polissa_webforms_helpers_tests.py
+++ b/som_polissa/tests/som_polissa_webforms_helpers_tests.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from destral import testing
+from destral.transaction import Transaction
+import unittest
+from osv import fields
+import mock
+from mock import Mock, ANY
+
+class TestSomWebformsHelpersPolissa(testing.OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+        self.polissa_obj = self.openerp.pool.get('giscedata.polissa')
+        self.helper_obj = self.openerp.pool.get('som.polissa.webforms.helpers')
+        self.imd_obj = self.openerp.pool.get('ir.model.data')
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def _open_polissa(self, xml_ref):
+        polissa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', xml_ref
+        )[1]
+
+        self.polissa_obj.send_signal(self.cursor, self.uid, [polissa_id], [
+            'validar', 'contracte'
+        ])
+
+        return polissa_id
+
+    def test_www_get_iban(self):
+        polissa_id = self._open_polissa('polissa_tarifa_018')
+        result = self.helper_obj.www_get_iban(self.cursor, self.uid, polissa_id)
+        self.assertEqual(result, '**** **** **** **** **** 7890')
+
+    def test_www_check_iban(self):
+        correct_iban = 'ES3120170806126133002095'
+        incorrect_iban = 'ES2222170806122222222222'
+        result = self.helper_obj.www_check_iban(self.cursor, self.uid, correct_iban)
+        self.assertEqual(result, correct_iban)
+        result = self.helper_obj.www_check_iban(self.cursor, self.uid, incorrect_iban)
+        self.assertEqual(result, False)
+
+    def test_www_set_iban(self):
+        polissa_id = self._open_polissa('polissa_tarifa_018')
+        new_iban = 'ES3120170806126133002095'
+        result = self.helper_obj.www_set_iban(
+            self.cursor, self.uid, polissa_id, new_iban
+        )
+        new_iban_pol = self.polissa_obj.read(
+            self.cursor, self.uid, polissa_id, ['bank']
+        )['bank'][1]
+        self.assertEqual(new_iban_pol, new_iban)


### PR DESCRIPTION
## Objectiu

S'estaven cridant unes funcions molt antigues pel canvi de compte que no estaven mantingudes.

Amb aquest codi es crida l'assistent estàndard el qual sí que està mantingut.

També fa que hi hagi coherència amb el canvi de compte ja que des de la OV sempre es modificava la última modificació contractual i des de l'ERP es feia una nova modificació contractual

## Targeta on es demana o Incidència 

https://trello.com/c/hbNjo0oy/5772-refactor-endpoint-de-canvi-compte-bancari-des-de-lov

## Comportament antic

Mateix comportament però modificava la modcon vigent del contracte

## Comportament nou

Es crea una nova modcon al contracte

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar ERP de webforms

