### PR TITLE
Canvis al pdf de la factura per tarifes indexades

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2232,7 +2232,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             'gkwh_energy_lines_data': gkwh_energy_lines_data,
             'header_multi': 3*(len(energy_lines_data)+len(gkwh_energy_lines_data))+(1 if mag_line_data else 0),
             'showing_periods': self.get_matrix_show_periods(pol),
-            'mag_line_data': mag_line_data
+            'mag_line_data': mag_line_data,
+            'indexed': pol.mode_facturacio == 'index',
         }
         return data
 

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-04-25 13:44+0000\n"
-"PO-Revision-Date: 2023-04-25 11:47+0000\n"
+"POT-Creation-Date: 2023-06-22 12:40+0000\n"
+"PO-Revision-Date: 2023-06-22 10:43+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2712
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -36,14 +36,14 @@ msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1930
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1932
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1931
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1933
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1926
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
 msgid "estimada"
 msgstr "estimada"
 
@@ -54,14 +54,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2742
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2744
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1965
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1966
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -72,7 +72,7 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1775
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1776
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
@@ -84,13 +84,13 @@ msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1928
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1929
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2624
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
@@ -103,18 +103,18 @@ msgid ""
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1722
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2654
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2656
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1774
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -124,13 +124,13 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2683
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2685
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1724
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
@@ -146,7 +146,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1777
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1778
 msgid "(real)"
 msgstr "(real)"
 
@@ -616,8 +616,8 @@ msgid "Segment tarifari:"
 msgstr "Segmento tarifario:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:60
-msgid "Tarifa comercialitzadora:"
-msgstr "Tarifa comercializadora:"
+msgid "Tarifa:"
+msgstr "Tarifa:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:69
 #, python-format
@@ -883,7 +883,7 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:31
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:42
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:46
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:14
@@ -1134,15 +1134,19 @@ msgstr "Solar fotovoltaica"
 msgid "Minihidràulica"
 msgstr "Minihidráulica"
 
-#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:27
 msgid "Biogàs"
 msgstr "Biogás"
 
-#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:31
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:32
+msgid "Biomassa"
+msgstr "Biomasa"
+
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:38
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:43
 msgid ""
 "Pots veure l'origen dels certificats de garantia d'origen en l'enllaç "
 "següent:"
@@ -1254,9 +1258,9 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:42
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:53
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:58
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:73
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:57
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:62
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:26
@@ -1599,19 +1603,23 @@ msgstr "sujetos a descuento"
 msgid "Electricitat utilitzada [kWh]"
 msgstr "Electricidad utilizada [kWh]"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:40
+msgid "Preu mitjà de l'energia [€/kWh]"
+msgstr "Precio medio de la energía [€/kWh]"
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:25
 msgid "Preu energia [€/kWh]"
 msgstr "Precio energía [€/kWh]"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:54
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:41
 #, python-format
 msgid "kWh x €/kWh (del %s al %s)"
 msgstr "kWh x €/kWh (del %s al %s)"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:64
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:68
 #, python-format
 msgid ""
 "Import de l'energia associada al mecanisme ibèric regulat pel Reial Decret-"

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-04-25 13:44+0000\n"
-"PO-Revision-Date: 2023-04-25 13:44+0000\n"
+"POT-Creation-Date: 2023-06-22 12:40+0000\n"
+"PO-Revision-Date: 2023-06-22 12:40+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2712
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -29,14 +29,14 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1930
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1932
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1931
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1933
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1926
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
 msgid "estimada"
 msgstr ""
 
@@ -47,14 +47,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2742
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2744
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1965
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1966
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -65,7 +65,7 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1775
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1776
 msgid "(sense lectura)"
 msgstr ""
 
@@ -77,13 +77,13 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1928
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1929
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2624
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
@@ -96,18 +96,18 @@ msgid ""
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1722
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2654
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2656
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1773
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1774
 msgid "(estimada)"
 msgstr ""
 
@@ -117,13 +117,13 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2683
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2685
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1724
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1777
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1778
 msgid "(real)"
 msgstr ""
 
@@ -607,7 +607,7 @@ msgid "Segment tarifari:"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:60
-msgid "Tarifa comercialitzadora:"
+msgid "Tarifa:"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:69
@@ -872,7 +872,7 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:31
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:42
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:46
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:14
@@ -1122,15 +1122,19 @@ msgstr ""
 msgid "Minihidràulica"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:27
 msgid "Biogàs"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:31
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:32
+msgid "Biomassa"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:38
 msgid "TOTAL"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:43
 msgid ""
 "Pots veure l'origen dels certificats de garantia d'origen en l'enllaç "
 "següent:"
@@ -1242,9 +1246,9 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:42
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:53
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:58
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:73
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:57
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:62
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:26
@@ -1589,19 +1593,23 @@ msgstr ""
 msgid "Electricitat utilitzada [kWh]"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:40
+msgid "Preu mitjà de l'energia [€/kWh]"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:25
 msgid "Preu energia [€/kWh]"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:54
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:41
 #, python-format
 msgid "kWh x €/kWh (del %s al %s)"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:64
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:68
 #, python-format
 msgid ""
 "Import de l'energia associada al mecanisme ibèric regulat pel Reial "

--- a/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
@@ -57,7 +57,7 @@ autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_di
                     ${_(u"Peatge de transport i distribució:")} <span style="font-weight: bold;">${cd.tariff}</span> <br />
                     ${_(u"Segment tarifari:")} <span style="font-weight: bold;">${cd.segment_tariff}</span> <br />
                     % if cd.invoicing_mode == 'index':
-                        ${_(u"Tarifa comercialitzadora:")} <span style="font-weight: bold;">${cd.pricelist}</span> <br />
+                        ${_(u"Tarifa:")} <span style="font-weight: bold;">${cd.pricelist}</span> <br />
                     % endif
                     ${_(u"CUPS:")} <span style="font-weight: bold;">${cd.cups}</span> <br />
                     ${_(u"Comptador telegestionat:")} <span style="font-weight: bold;">${cd.remote_managed_meter and _(u'Sí') or _(u'No')}</span> <br />

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako
@@ -36,7 +36,11 @@ first_energy_line = True
         <td></td>
     </tr>
     <tr>
-        <td class="detall_td">${_(u"Preu energia [€/kWh]")}</td>
+        % if id.indexed:
+            <td class="detall_td">${_(u"Preu mitjà de l'energia [€/kWh]")}</td>
+        % else:
+            <td class="detall_td">${_(u"Preu energia [€/kWh]")}</td>
+        % endif
         % for p in id.showing_periods:
             % if p in energy_lines_data:
                 <td>${_(u"%s") %(locale.str(locale.atof(formatLang(energy_lines_data[p]["price_unit_multi"], digits=6))))}</td>


### PR DESCRIPTION
## Objectiu

modificar texts a les factures en pdf quan es tracta de factures amb tarifa indexada

## Targeta on es demana o Incidència 

https://trello.com/c/5sDMtoF6/5765-gegc-ep288-canviar-dues-frases-del-pdf-factura-amb-tarifa-indexada

## Comportament antic

No es mostrava correctament

## Comportament nou

Es mostra el text de preu mitjà quan es una tarifa indexada i s'escurça de "tarifa comercialitzadora" a "tarifa"

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
    - giscedata_facturacio_comer_som
- [ ] Script de migració
- [x] Modifica traduccions
