### PR TITLE
1a versio modificacio vistes

### DIFF
--- a/account_account_som/account_payment_form_view.xml
+++ b/account_account_som/account_payment_form_view.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+      <record id="view_payment_mode_form_inherit" model="ir.ui.view">
+            <field name="name">payment.mode.form</field>
+            <field name="model">payment.mode</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="account_payment.payment_view"/>
+            <field name="arch" type="xml">
+                <form string="Payment Mode">
+                    <field name="name" readonly="1" select="1"/>
+                    <group colspan="2">
+                        <field name="active" readonly="1" select="1"/>
+                    </group>
+                    <field name="type" readonly="1"/>
+                    <field name="journal" readonly="1"/>
+                    <field name="bank_id" readonly="1"/>
+                </form>
+            </field>
+        </record>
+        <record id="action_payment_mode_form" model="ir.actions.act_window">
+            <field name="name">Payment Mode</field>
+            <field name="res_model">payment.mode</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        <menuitem id="next_id_44" name="Payment" parent="account.menu_finance_configuration"/>
+        <menuitem action="action_payment_mode_form" id="menu_action_payment_mode_form" parent="next_id_44"/>
+
+        <record id="view_payment_mode_form" model="ir.ui.view">
+            <field name="name">payment.mode.form</field>
+            <field name="model">payment.mode</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="account_payment.payment_view"/>
+            <field name="arch" type="xml">
+                <form string="Payment Mode">
+                    <field name="name" select="1"/>
+                    <group colspan="2">
+                        <field name="active" select="1"/>
+                    </group>
+                    <field name="type"/>
+                    <field name="journal"/>
+                    <field name="bank_id"/>
+                </form>
+            </field>
+        </record>
+        <record id="menu_action_payment_mode_form_editable" model="ir.actions.act_window">
+            <field name="name">Payment Mode</field>
+            <field name="res_model">payment.mode</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="view_payment_mode_form"/>
+        </record>
+        <menuitem id="payment_editable" name="Payment Editable" parent="account.menu_finance_configuration"/>
+        <menuitem action="action_payment_mode_form" id="menu_action_payment_mode_form_editable" parent="payment_editable"/>
+    </data>
+</openerp>

--- a/account_account_som/account_payment_form_view.xml
+++ b/account_account_som/account_payment_form_view.xml
@@ -7,15 +7,21 @@
             <field name="type">form</field>
             <field name="inherit_id" ref="account_payment.payment_view"/>
             <field name="arch" type="xml">
-                <form string="Payment Mode">
+                <xpath expr="//field[@name='name']" position="replace">
                     <field name="name" readonly="1" select="1"/>
-                    <group colspan="2">
-                        <field name="active" readonly="1" select="1"/>
-                    </group>
+                </xpath>
+                <xpath expr="//field[@name='active']" position="replace">
+                    <field name="active" readonly="1" select="1"/>
+                </xpath>
+                <xpath expr="//field[@name='type']" position="replace">
                     <field name="type" readonly="1"/>
+                </xpath>
+                <xpath expr="//field[@name='journal']" position="replace">
                     <field name="journal" readonly="1"/>
+                </xpath>
+                <xpath expr="//field[@name='bank_id']" position="replace">
                     <field name="bank_id" readonly="1"/>
-                </form>
+                </xpath>
             </field>
         </record>
         <record id="action_payment_mode_form" model="ir.actions.act_window">

--- a/account_account_som/account_payment_form_view.xml
+++ b/account_account_som/account_payment_form_view.xml
@@ -24,14 +24,6 @@
                 </xpath>
             </field>
         </record>
-        <record id="action_payment_mode_form" model="ir.actions.act_window">
-            <field name="name">Payment Mode</field>
-            <field name="res_model">payment.mode</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">tree,form</field>
-        </record>
-        <menuitem id="next_id_44" name="Payment" parent="account.menu_finance_configuration"/>
-        <menuitem action="action_payment_mode_form" id="menu_action_payment_mode_form" parent="next_id_44"/>
 
         <record id="view_payment_mode_form" model="ir.ui.view">
             <field name="name">payment.mode.form</field>
@@ -57,7 +49,6 @@
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_payment_mode_form"/>
         </record>
-        <menuitem id="payment_editable" name="Payment Editable" parent="account.menu_finance_configuration"/>
-        <menuitem action="action_payment_mode_form" id="menu_action_payment_mode_form_editable" parent="payment_editable"/>
+        <menuitem id="payment_editable" name="Payment Editable" parent="account.menu_finance_configuration" action="menu_action_payment_mode_form_editable"/>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu

Evitar que es pugui modificarf el grup de pagament des de la vista de pòlisses i factures

## Targeta on es demana o Incidència 

https://trello.com/c/Yzpc5nvb/5644-0-2-modificacions-grup-de-pagament

## Comportament antic

Es podia modificar el grup de pagament des de la vista de pòlisses i factures

## Comportament nou

S'ha implementat una nova vista editable del model de dades 'payment.group', i la vista antiga d'aquest model s'ha convertit a 'readonly'

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions
