### PR TITLE
Fix som_crawlers errors not being detected

### DIFF
--- a/som_crawlers/data/som_crawlers_config_data.xml
+++ b/som_crawlers/data/som_crawlers_config_data.xml
@@ -243,7 +243,7 @@
             <field name="user_ultima_modificacio" ref="base.user_admin"/>
         </record>
         <record model="som.crawlers.config" id="scq_conf">
-            <field name="name">SCQ</field>
+            <field name="name">scq</field>
             <field name="crawler">Selenium</field>
             <field name="days_of_margin">5</field>
             <field name="pending_files_only" eval="False"/>

--- a/som_crawlers/models/som_crawlers_task.py
+++ b/som_crawlers/models/som_crawlers_task.py
@@ -118,6 +118,7 @@ class SomCrawlersTask(osv.osv):
                 break
             except Exception as e:
                 resultat += "ERROR " + str(e)
+                resultat_correcte = False
                 break
             finally:
                 output = resultat + "\n\n" + output


### PR DESCRIPTION
## Objectiu

- Evitar que hi hagi errors no detectats
- Evitar errors en el `crawler` SCQ

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2279801144/15097598/

## Comportament antic

- Només es marcava el resultat com erroni si la excepció era en el primer pas
- El nom de la configuració de la tasca SCQ no concordava amb el del `crawler`

## Comportament nou

- Es marca el resultat com a erroni també si falla en un pas que no sigui el primer
- Els noms del `crawler` SCQ concorden

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
