### PR TITLE
Webforms can only change standard prices

### DIFF
--- a/som_indexada/som_indexada_webforms_helpers.py
+++ b/som_indexada/som_indexada_webforms_helpers.py
@@ -4,40 +4,42 @@ from som_indexada.exceptions import indexada_exceptions
 from datetime import datetime
 from decorator import decorator
 
-@decorator
-def www_entry_point(f, self, cursor *args, expected_exceptions=tuple(), **kwds):
-    """
-    Wrapps an erp method so that it can be called safely from the web.
+def www_entry_point(expected_exceptions=tuple()):
 
-    - Establishes a database savepoint to return at if an exception happens.
-    - Translates any expected_exceptions to a error dictionary.
-    - Any other exception will be also translated but with code 'Unexpected'
-    - To any exception, expected or unexpected,
-      it adds the backtrace as attribute of the dictionary.
-    """
-    def traceback_info(exception):
-        import traceback
-        import sys
-        exc_type, exc_value, exc_tb = sys.exc_info()
-        return traceback.format_exception(exc_type, exc_value, exc_tb)
+    def wrapper(f, self, cursor, *args, **kwds):
+        """
+        Wrapps an erp method so that it can be called safely from the web.
 
-    savepoint = 'change_pricelist_{}'.format(id(cursor))
-    cursor.savepoint(savepoint)
-    try:
-        return f(self, cursor, *args, **kwds)
-    except expected_exceptions as e:
-        cursor.rollback(savepoint)
-        return dict(
-            e.to_dict(),
-            trace=self.traceback_info(e),
-        )
-    except Exception as e:
-        cursor.rollback(savepoint)
-        return dict(
-            error=str(e),
-            code="Unexpected",
-            trace=self.traceback_info(e),
-        )
+        - Establishes a database savepoint to return at if an exception happens.
+        - Translates any expected_exceptions to a error dictionary.
+        - Any other exception will be also translated but with code 'Unexpected'
+        - To any exception, expected or unexpected,
+          it adds the backtrace as attribute of the dictionary.
+        """
+        def traceback_info(exception):
+            import traceback
+            import sys
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            return traceback.format_exception(exc_type, exc_value, exc_tb)
+
+        savepoint = 'change_pricelist_{}'.format(id(cursor))
+        cursor.savepoint(savepoint)
+        try:
+            return f(self, cursor, *args, **kwds)
+        except expected_exceptions as e:
+            cursor.rollback(savepoint)
+            return dict(
+                e.to_dict(),
+                trace=traceback_info(e),
+            )
+        except Exception as e:
+            cursor.rollback(savepoint)
+            return dict(
+                error=str(e),
+                code="Unexpected",
+                trace=traceback_info(e),
+            )
+    return decorator(wrapper)
 
 class SomIndexadaWebformsHelpers(osv.osv_memory):
 

--- a/som_indexada/som_indexada_webforms_helpers.py
+++ b/som_indexada/som_indexada_webforms_helpers.py
@@ -2,7 +2,42 @@
 from osv import osv
 from som_indexada.exceptions import indexada_exceptions
 from datetime import datetime
+from decorator import decorator
 
+@decorator
+def www_entry_point(f, self, cursor *args, expected_exceptions=tuple(), **kwds):
+    """
+    Wrapps an erp method so that it can be called safely from the web.
+
+    - Establishes a database savepoint to return at if an exception happens.
+    - Translates any expected_exceptions to a error dictionary.
+    - Any other exception will be also translated but with code 'Unexpected'
+    - To any exception, expected or unexpected,
+      it adds the backtrace as attribute of the dictionary.
+    """
+    def traceback_info(exception):
+        import traceback
+        import sys
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        return traceback.format_exception(exc_type, exc_value, exc_tb)
+
+    savepoint = 'change_pricelist_{}'.format(id(cursor))
+    cursor.savepoint(savepoint)
+    try:
+        return f(self, cursor, *args, **kwds)
+    except expected_exceptions as e:
+        cursor.rollback(savepoint)
+        return dict(
+            e.to_dict(),
+            trace=self.traceback_info(e),
+        )
+    except Exception as e:
+        cursor.rollback(savepoint)
+        return dict(
+            error=str(e),
+            code="Unexpected",
+            trace=self.traceback_info(e),
+        )
 
 class SomIndexadaWebformsHelpers(osv.osv_memory):
 
@@ -30,12 +65,6 @@ class SomIndexadaWebformsHelpers(osv.osv_memory):
         else:
             raise indexada_exceptions.KCoefficientNotFound(pricelist_id)
 
-    def traceback_info(self, exception):
-        import traceback
-        import sys
-        exc_type, exc_value, exc_tb = sys.exc_info()
-        return traceback.format_exception(exc_type, exc_value, exc_tb)
-
     def _get_change_type(self, cursor, uid, polissa_id):
         change_type = "from_period_to_index"
         cfg_obj = self.pool.get('res.config')
@@ -51,100 +80,73 @@ class SomIndexadaWebformsHelpers(osv.osv_memory):
 
         return change_type
 
+    @www_entry_point(
+        expected_exceptions=indexada_exceptions.IndexadaException,
+    )
     def check_new_pricelist_www(self, cursor, uid, polissa_id, context=None):
-        savepoint = 'check_new_pricelist_{}'.format(id(cursor))
-        cursor.savepoint(savepoint)
-        try:
-            change_type = self._get_change_type(cursor, uid, polissa_id)
+        change_type = self._get_change_type(cursor, uid, polissa_id)
 
-            polissa_obj = self.pool.get('giscedata.polissa')
-            pricelist_obj = self.pool.get('product.pricelist')
-            polissa = polissa_obj.browse(cursor, uid, polissa_id)
+        polissa_obj = self.pool.get('giscedata.polissa')
+        pricelist_obj = self.pool.get('product.pricelist')
+        polissa = polissa_obj.browse(cursor, uid, polissa_id)
 
-            wiz_o = self.pool.get('wizard.change.to.indexada')
-            wiz_o.validate_polissa_can_change(
-                cursor,
-                uid,
-                polissa,
-                change_type,
-                only_standard_prices=True,
-            )
-            pricelist_id = wiz_o.calculate_new_pricelist(
-                cursor,
-                uid,
-                polissa,
-                change_type,
-                context=context,
-            )
-            pricelist_name = pricelist_obj.read(
-                cursor,
-                uid,
-                pricelist_id,
-                ['name', 'nom_comercial'],
-            )
-            if pricelist_name.get('nom_comercial'):
-                pricelist_name = pricelist_name['nom_comercial']
-            else:
-                pricelist_name = pricelist_name['name']
-            coefficient_k = self.get_k_from_pricelist(
-                cursor,
-                uid,
-                pricelist_id
-            ) if change_type == "from_period_to_index" else None
-            return {
-                'tariff_name': pricelist_name,
-                'k_coefficient_eurkwh': coefficient_k,
-            }
-
-        except indexada_exceptions.IndexadaException as e:
-            cursor.rollback(savepoint)
-            return dict(
-                e.to_dict(),
-                trace=self.traceback_info(e),
-            )
-        except Exception as e:
-            cursor.rollback(savepoint)
-            return dict(
-                error=str(e),
-                code="Unexpected",
-                trace=self.traceback_info(e),
-            )
+        wiz_o = self.pool.get('wizard.change.to.indexada')
+        wiz_o.validate_polissa_can_change(
+            cursor,
+            uid,
+            polissa,
+            change_type,
+            only_standard_prices=True,
+        )
+        pricelist_id = wiz_o.calculate_new_pricelist(
+            cursor,
+            uid,
+            polissa,
+            change_type,
+            context=context,
+        )
+        pricelist_name = pricelist_obj.read(
+            cursor,
+            uid,
+            pricelist_id,
+            ['name', 'nom_comercial'],
+        )
+        if pricelist_name.get('nom_comercial'):
+            pricelist_name = pricelist_name['nom_comercial']
+        else:
+            pricelist_name = pricelist_name['name']
+        coefficient_k = self.get_k_from_pricelist(
+            cursor,
+            uid,
+            pricelist_id
+        ) if change_type == "from_period_to_index" else None
+        return {
+            'tariff_name': pricelist_name,
+            'k_coefficient_eurkwh': coefficient_k,
+        }
 
     def change_to_indexada_www(self, cursor, uid, polissa_id, context=None):
         return self.change_pricelist_www(cursor, uid, polissa_id, context)
 
+    @www_entry_point(
+        expected_exceptions=indexada_exceptions.IndexadaException,
+    )
     def change_pricelist_www(self, cursor, uid, polissa_id, context=None):
-        savepoint = 'change_pricelist_{}'.format(id(cursor))
-        cursor.savepoint(savepoint)
-        try:
-            change_type = self._get_change_type(cursor, uid, polissa_id)
+        change_type = self._get_change_type(cursor, uid, polissa_id)
 
-            wiz_o = self.pool.get('wizard.change.to.indexada')
-            context = {
-                'active_id': polissa_id,
-                'change_type': change_type,
-                'webapps': True,
-            }
-            wiz_id = wiz_o.create(cursor, uid, {}, context=context)
-            return wiz_o.change_to_indexada(
-                cursor,
-                uid,
-                [wiz_id],
-                context=context,
-            )
-        except indexada_exceptions.IndexadaException as e:
-            cursor.rollback(savepoint)
-            return dict(
-                e.to_dict(),
-                trace=self.traceback_info(e),
-            )
-        except Exception as e:
-            cursor.rollback(savepoint)
-            return dict(
-                error=str(e),
-                code="Unexpected",
-                trace=self.traceback_info(e),
-            )
+        wiz_o = self.pool.get('wizard.change.to.indexada')
+        context = {
+            'active_id': polissa_id,
+            'change_type': change_type,
+            'webapps': True,
+        }
+        wiz_id = wiz_o.create(cursor, uid, {}, context=context)
+        return wiz_o.change_to_indexada(
+            cursor,
+            uid,
+            [wiz_id],
+            context=context,
+        )
 
     def has_indexada_prova_pilot_category_www(self, cursor, uid, polissa_id):
         polissa_obj = self.pool.get('giscedata.polissa')


### PR DESCRIPTION
## Objectiu

If a contract has a non-standard tariff, changing it from webforms should not be allowed. It must be done by our staff on the erp client.

## Targeta on es demana o Incidència 

https://secure.helpscout.net/conversation/2299177058/15197723?folderId=3063450

## Comportament antic

El bloqueig es feia des de formulari d'una forma molt fragil: fent servir el fet que les tarifes standards tenen el numero del peatge al nom. Es un mecanisme feble davant de canvis de noms de tarifes. A més hi ha molts punts d'entrada (4) a la interficie d'usuari on fer aquest control.

## Comportament nou

- Fem servir la funció de l'erp que determina si el canvi de tarifa es factible
- Cridem a una nova funció que determina si la tarifa es standard o no. Es standard si es una de les tarifes de desti.
- Afegim un parametre opcional per dir que faci aquesta restricció i el setejem nomes quan es crida des del wrapper per webforms. D'aquesta forma encara es podra fer des del client erp.
- La comprobació no la fem quan apliquem el canvi, perque funcionalment no calia pero si cal fer-ho per consistencia caldria afegir tambe un parametre a la funcio d'aplicar.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
