### PR TITLE
Nou model per gestionar el comportament del cron de reimportació de F1's

### DIFF
--- a/som_facturacio_switching/__init__.py
+++ b/som_facturacio_switching/__init__.py
@@ -5,4 +5,4 @@ import giscedata_facturacio_importacio_linia
 import res_municipi
 import wizard
 import giscedata_facturacio_switching_error
-
+import som_error_cron_f1_reimport

--- a/som_facturacio_switching/__terp__.py
+++ b/som_facturacio_switching/__terp__.py
@@ -32,6 +32,7 @@
         "giscedata_facturacio_switching_view.xml",
         "som_error_cron_f1_reimport_data.xml",
         "som_error_cron_f1_reimport_view.xml",
+        "wizard/wizard_change_cron_reimport_days_view.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_switching/__terp__.py
+++ b/som_facturacio_switching/__terp__.py
@@ -30,6 +30,8 @@
         "giscedata_facturacio_switching_cron.xml",
         "wizard/wizard_refund_rectify_from_origin_view.xml",
         "giscedata_facturacio_switching_view.xml",
+        "som_error_cron_f1_reimport_data.xml",
+        "som_error_cron_f1_reimport_view.xml",
     ],
     "active": False,
     "installable": True

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -120,8 +120,10 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
         )
 
         data = {}
-        data['days_to_check'] = confvar_obj.get(
-            cursor, uid, 'som_error_cron_f1_reimport_days_to_check', 30
+        data['days_to_check'] = int(
+            confvar_obj.get(
+                cursor, uid, 'som_error_cron_f1_reimport_days_to_check', 30
+            )
         )
 
         data['error_code'] = []

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -115,13 +115,20 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
         # Un altre cop el diccionari
         errors_obj = self.pool.get('som.error.cron.f1.reimport')
         confvar_obj = self.pool.get('res.config')
-        err_ids = errors_obj.search([('active', '=', True)])
+        err_ids = errors_obj.search(
+            cursor, uid, [('active', '=', True)], context=context
+        )
 
         data = {}
         data['days_to_check'] = confvar_obj.get(
-            cursor, uid, 'som_error_cron_f1_reimport_days_to_check', 30)
+            cursor, uid, 'som_error_cron_f1_reimport_days_to_check', 30
+        )
 
-        data['error_code'] = errors_obj.read(err_ids, ['code', 'text'])
+        data['error_code'] = errors_obj.read(
+            cursor, uid,
+            err_ids, ['code', 'text'],
+            context=context
+        )
         return data
 
     def do_reimport_f1(self, cursor, uid, data=None, context=None):

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -124,11 +124,16 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
             cursor, uid, 'som_error_cron_f1_reimport_days_to_check', 30
         )
 
-        data['error_code'] = errors_obj.read(
-            cursor, uid,
-            err_ids, ['code', 'text'],
-            context=context
-        )
+        data['error_code'] = []
+        for err_id in err_ids:
+            e_data = errors_obj.read(
+                cursor, uid, err_id, ['code', 'text'], context=context
+            )
+            data['error_code'].append({
+                'code': e_data['code'],
+                'text': e_data['text'] if e_data['text'] else '',
+            })
+
         return data
 
     def do_reimport_f1(self, cursor, uid, data=None, context=None):

--- a/som_facturacio_switching/giscedata_facturacio_switching_cron.xml
+++ b/som_facturacio_switching/giscedata_facturacio_switching_cron.xml
@@ -15,19 +15,7 @@
     </data>
     <data noupdate="1">
         <record id="ir_cron_reimport_f1" model="ir.cron">
-            <field
-                name="args"
-                eval="({
-                    'error_codes': [
-                        {'code':'3033', 'text':''},
-                        {'code':'2005', 'text':''},
-                        {'code':'1001', 'text':''},
-                        {'code':'3041', 'text':''},
-                        {'code':'1999', 'text':''},
-                        {'code':'2999', 'text':''},
-                        {'code':'3999', 'text':''},
-                        {'code':'4999', 'text':''},
-                    ], 'days_to_check': 30})" />
+            <field name="args" eval="({})" />
         </record>
     </data>
 </openerp>

--- a/som_facturacio_switching/security/ir.model.access.csv
+++ b/som_facturacio_switching/security/ir.model.access.csv
@@ -5,3 +5,6 @@
 "access_wizard_refund_rectify_from_origin_rcwd","wizard.refund.rectify.from.origin","model_wizard_refund_rectify_from_origin","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
 "access_wizard_refund_rectify_from_origin_rcwd","wizard.refund.rectify.from.origin","model_wizard_refund_rectify_from_origin","giscedata_facturacio.group_giscedata_facturacio_r",1,1,1,1
 "access_wizard_refund_rectify_from_origin_rcwd","wizard.refund.rectify.from.origin","model_wizard_refund_rectify_from_origin","giscedata_facturacio.group_giscedata_facturacio_w",1,1,1,1
+"access_som_error_cron_f1_reimport_u","som.error.cron.f1.reimport","model_som_error_cron_f1_reimport","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
+"access_som_error_cron_f1_reimport_r","som.error.cron.f1.reimport","model_som_error_cron_f1_reimport","giscedata_facturacio.group_giscedata_facturacio_r",1,0,0,0
+"access_som_error_cron_f1_reimport_w","som.error.cron.f1.reimport","model_som_error_cron_f1_reimport","giscedata_facturacio.group_giscedata_facturacio_w",1,1,1,0

--- a/som_facturacio_switching/security/ir.model.access.csv
+++ b/som_facturacio_switching/security/ir.model.access.csv
@@ -8,3 +8,6 @@
 "access_som_error_cron_f1_reimport_u","som.error.cron.f1.reimport","model_som_error_cron_f1_reimport","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
 "access_som_error_cron_f1_reimport_r","som.error.cron.f1.reimport","model_som_error_cron_f1_reimport","giscedata_facturacio.group_giscedata_facturacio_r",1,0,0,0
 "access_som_error_cron_f1_reimport_w","som.error.cron.f1.reimport","model_som_error_cron_f1_reimport","giscedata_facturacio.group_giscedata_facturacio_w",1,1,1,0
+"access_wizard_change_cron_reimport_days_u","wizard.change.cron.reimport.days","model_wizard_change_cron_reimport_days","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
+"access_wizard_change_cron_reimport_days_r","wizard.change.cron.reimport.days","model_wizard_change_cron_reimport_days","giscedata_facturacio.group_giscedata_facturacio_r",1,0,0,0
+"access_wizard_change_cron_reimport_days_w","wizard.change.cron.reimport.days","model_wizard_change_cron_reimport_days","giscedata_facturacio.group_giscedata_facturacio_w",1,1,1,0

--- a/som_facturacio_switching/som_error_cron_f1_reimport.py
+++ b/som_facturacio_switching/som_error_cron_f1_reimport.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+
+
+class SomErrorCronF1Reimport(osv.osv):
+    _name = 'som.error.cron.f1.reimport'
+
+    _columns = {
+        'code': fields.many2one(
+            'giscedata.facturacio.switching.error.template', 'Codis d\'error de F1'
+        ),
+        'text': fields.text(
+            _(u"Text"),
+            help=_("Text del error al F1 importat erroniament"),
+        ),
+        'active': fields.boolean(
+            string=_(u'Actiu'),
+            help=_(u"Indica si l'error es reimportarà al cron o no"),
+            required=True
+        ),
+
+
+    }
+
+
+SomErrorCronF1Reimport()

--- a/som_facturacio_switching/som_error_cron_f1_reimport.py
+++ b/som_facturacio_switching/som_error_cron_f1_reimport.py
@@ -6,8 +6,33 @@ from tools.translate import _
 class SomErrorCronF1Reimport(osv.osv):
     _name = 'som.error.cron.f1.reimport'
 
+    def _get_fase(self, cursor, uid, ids, name, args, context=None):
+        if context is None:
+            context = {}
+        error_obj = self.pool.get('giscedata.facturacio.switching.error.template')
+
+        res = dict.fromkeys(ids, 0.0)
+        for id_registre in ids:
+            id_error = self.read(cursor, uid, id_registre, ['error_code'])['error_code'][0]
+            fase = error_obj.read(cursor, uid, id_error, ['phase'])['phase']
+            res[id_registre] = fase
+        return res
+
+    def _get_code(self, cursor, uid, ids, name, args, context=None):
+        if context is None:
+            context = {}
+        error_obj = self.pool.get('giscedata.facturacio.switching.error.template')
+
+        res = dict.fromkeys(ids, "")
+        for id_registre in ids:
+            id_error = self.read(cursor, uid, id_registre, ['error_code'])['error_code'][0]
+            data = error_obj.read(cursor, uid, id_error, ['code', 'phase'])
+            code = '{}{}'.format(data['phase'], data['code'])
+            res[id_registre] = code
+        return res
+
     _columns = {
-        'code': fields.many2one(
+        'error_code': fields.many2one(
             'giscedata.facturacio.switching.error.template', 'Codis d\'error de F1'
         ),
         'text': fields.text(
@@ -19,8 +44,8 @@ class SomErrorCronF1Reimport(osv.osv):
             help=_(u"Indica si l'error es reimportarà al cron o no"),
             required=True
         ),
-
-
+        'fase': fields.function(_get_fase, string='Fase', type='char', method=True),
+        'code': fields.function(_get_code, string='Fase', type='char', method=True),
     }
 
 

--- a/som_facturacio_switching/som_error_cron_f1_reimport.py
+++ b/som_facturacio_switching/som_error_cron_f1_reimport.py
@@ -36,8 +36,8 @@ class SomErrorCronF1Reimport(osv.osv):
             'giscedata.facturacio.switching.error.template', 'Codis d\'error de F1'
         ),
         'text': fields.text(
-            _(u"Text"),
-            help=_("Text del error al F1 importat erroniament"),
+            _(u"Text contingut al F1 erroni"),
+            help=_("Text que ha de contenir l'error del F1 que es vol importar"),
         ),
         'active': fields.boolean(
             string=_(u'Actiu'),

--- a/som_facturacio_switching/som_error_cron_f1_reimport_data.xml
+++ b/som_facturacio_switching/som_error_cron_f1_reimport_data.xml
@@ -6,5 +6,33 @@
             <field name="description">Dies a mirar enrere del cron d'importació d'F1 erronis</field>
             <field name="value">30</field>
         </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_1001'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_1_code_001"/>
+        </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_1999'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_1_code_999"/>
+        </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_2005'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_2_code_005"/>
+        </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_2999'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_2_code_999"/>
+        </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_3033'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_3_code_033"/>
+        </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_3041'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_3_code_041"/>
+        </record>
+        <record model='som.error.cron.f1.reimport' id='som_error_cron_f1_reimport_4999'>
+            <field name="active" eval="True"/>
+            <field name="error_code" ref="giscedata_facturacio_switching.error_phase_4_code_999"/>
+        </record>
     </data>
 </openerp>

--- a/som_facturacio_switching/som_error_cron_f1_reimport_data.xml
+++ b/som_facturacio_switching/som_error_cron_f1_reimport_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record model="res.config" id="som_error_cron_f1_reimport_days_to_check">
+            <field name="name">som_error_cron_f1_reimport_days_to_check</field>
+            <field name="description">Dies a mirar enrere del cron d'importació d'F1 erronis</field>
+            <field name="value">30</field>
+        </record>
+    </data>
+</openerp>

--- a/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
+++ b/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_som_error_cron_f1_reimport_tree">
+            <field name="name">som.error.cron.f1.reimport.tree</field>
+            <field name="model">som.error.cron.f1.reimport</field>
+            <field name="type">tree</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <tree string="Errors de f1 a reimportar">
+                    <field name="active"/>
+                    <field name="text"/>
+                    <field name="code"/>
+                </tree>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_som_error_cron_f1_reimport_form">
+            <field name="name">som.error.cron.f1.reimport.form</field>
+            <field name="model">som.error.cron.f1.reimport</field>
+            <field name="type">form</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <form string="Errors de f1 a reimportar">
+                    <group colspan="2" col="4">
+                        <field name="active" select="1"/>
+                        <group colspan="4" col="2" string="Definició del error a cercar">
+                            <field name="code" select="1"/>
+                            <field name="text" select="1"/>
+                        </group>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record id="action_som_error_cron_f1_reimport_tree" model="ir.actions.act_window">
+            <field name="name">Action Som Error Cron F1 Reimport</field>
+            <field name="res_model">som.error.cron.f1.reimport</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{'active_test': False}</field>
+            <field name="view_id" ref="view_som_error_cron_f1_reimport_tree"/>
+        </record>
+        <menuitem id="menu_folder_som_error_cron_f1_reimport" parent="giscedata_facturacio_switching.menu_gestio_f1" name="Configuració cron reimportacio f1"/>
+        <menuitem id="menu_som_error_cron_f1_reimport_config" action="action_som_error_cron_f1_reimport_tree" parent="menu_folder_som_error_cron_f1_reimport"/>
+    </data>
+</openerp>

--- a/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
+++ b/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
@@ -6,6 +6,7 @@
             <field name="model">som.error.cron.f1.reimport</field>
             <field name="type">tree</field>
             <field name="priority">16</field>
+            <field name="context">{'active_test': False}</field>
             <field name="arch" type="xml">
                 <tree string="Errors de f1 a reimportar">
                     <field name="active"/>
@@ -34,13 +35,13 @@
             </field>
         </record>
         <record id="action_som_error_cron_f1_reimport_tree" model="ir.actions.act_window">
-            <field name="name">Configuració cron reimportació de f1's</field>
+            <field name="name">Configuració cron reimportació de F1's</field>
             <field name="res_model">som.error.cron.f1.reimport</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_som_error_cron_f1_reimport_tree"/>
         </record>
-        <menuitem id="menu_som_error_cron_f1_reimport_folder" parent="giscedata_facturacio_switching.menu_gestio_f1" name="Config. cron reimportacio f1"/>
+        <menuitem id="menu_som_error_cron_f1_reimport_folder" parent="giscedata_facturacio_switching.menu_gestio_f1" name="Config. cron reimportació F1"/>
         <menuitem id="menu_som_error_cron_f1_reimport_config" action="action_som_error_cron_f1_reimport_tree" parent="menu_som_error_cron_f1_reimport_folder"/>
     </data>
 </openerp>

--- a/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
+++ b/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
@@ -6,7 +6,6 @@
             <field name="model">som.error.cron.f1.reimport</field>
             <field name="type">tree</field>
             <field name="priority">16</field>
-            <field name="context">{'active_test': False}</field>
             <field name="arch" type="xml">
                 <tree string="Errors de f1 a reimportar">
                     <field name="active"/>
@@ -39,6 +38,7 @@
             <field name="res_model">som.error.cron.f1.reimport</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
+            <field name="context">{'active_test': False}</field>
             <field name="view_id" ref="view_som_error_cron_f1_reimport_tree"/>
         </record>
         <menuitem id="menu_som_error_cron_f1_reimport_folder" parent="giscedata_facturacio_switching.menu_gestio_f1" name="Config. cron reimportació F1"/>

--- a/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
+++ b/som_facturacio_switching/som_error_cron_f1_reimport_view.xml
@@ -9,8 +9,9 @@
             <field name="arch" type="xml">
                 <tree string="Errors de f1 a reimportar">
                     <field name="active"/>
+                    <field name="fase"/>
+                    <field name="error_code"/>
                     <field name="text"/>
-                    <field name="code"/>
                 </tree>
             </field>
         </record>
@@ -24,7 +25,8 @@
                     <group colspan="2" col="4">
                         <field name="active" select="1"/>
                         <group colspan="4" col="2" string="Definició del error a cercar">
-                            <field name="code" select="1"/>
+                            <field name="fase" select="1"/>
+                            <field name="error_code" select="1"/>
                             <field name="text" select="1"/>
                         </group>
                     </group>
@@ -32,14 +34,13 @@
             </field>
         </record>
         <record id="action_som_error_cron_f1_reimport_tree" model="ir.actions.act_window">
-            <field name="name">Action Som Error Cron F1 Reimport</field>
+            <field name="name">Configuració cron reimportació de f1's</field>
             <field name="res_model">som.error.cron.f1.reimport</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
-            <field name="context">{'active_test': False}</field>
             <field name="view_id" ref="view_som_error_cron_f1_reimport_tree"/>
         </record>
-        <menuitem id="menu_folder_som_error_cron_f1_reimport" parent="giscedata_facturacio_switching.menu_gestio_f1" name="Configuració cron reimportacio f1"/>
-        <menuitem id="menu_som_error_cron_f1_reimport_config" action="action_som_error_cron_f1_reimport_tree" parent="menu_folder_som_error_cron_f1_reimport"/>
+        <menuitem id="menu_som_error_cron_f1_reimport_folder" parent="giscedata_facturacio_switching.menu_gestio_f1" name="Config. cron reimportacio f1"/>
+        <menuitem id="menu_som_error_cron_f1_reimport_config" action="action_som_error_cron_f1_reimport_tree" parent="menu_som_error_cron_f1_reimport_folder"/>
     </data>
 </openerp>

--- a/som_facturacio_switching/wizard/__init__.py
+++ b/som_facturacio_switching/wizard/__init__.py
@@ -2,3 +2,4 @@ import wizard_gestio_text_to_polissa
 import wizard_model_list_from_file
 import wizard_delete_reimport_2001_f1
 import wizard_refund_rectify_from_origin
+import wizard_change_cron_reimport_days

--- a/som_facturacio_switching/wizard/wizard_change_cron_reimport_days.py
+++ b/som_facturacio_switching/wizard/wizard_change_cron_reimport_days.py
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+
+
+DAYS_TO_CHECK_VARIABLE_NAME = 'som_error_cron_f1_reimport_days_to_check'
+
+
+class WizardChangeCronReimportDays(osv.osv_memory):
+
+    _name = 'wizard.change.cron.reimport.days'
+
+    def change_days(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+
+        wiz = self.browse(cursor, uid, ids[0])
+        confvar_obj = self.pool.get('res.config')
+        conf_ids = confvar_obj.search(cursor, uid, [('name', '=', DAYS_TO_CHECK_VARIABLE_NAME)])
+        if len(conf_ids) == 1:
+            confvar_obj.write(cursor, uid, conf_ids[0], {'value': str(wiz.days)})
+        return {}
+
+    def _get_default_days(self, cursor, uid, context=None):
+        confvar_obj = self.pool.get('res.config')
+        res = int(
+            confvar_obj.get(
+                cursor, uid, DAYS_TO_CHECK_VARIABLE_NAME, 30
+            )
+        )
+        return res
+
+    _columns = {
+        'days': fields.integer("Dies a reimportar", help=_(u"Canvia el numero de dies a cercar cap enrere del cron de reimportació de F1's a partir d'avuí")),
+    }
+
+    _defaults = {
+        'days': _get_default_days,
+    }
+
+
+WizardChangeCronReimportDays()

--- a/som_facturacio_switching/wizard/wizard_change_cron_reimport_days_view.xml
+++ b/som_facturacio_switching/wizard/wizard_change_cron_reimport_days_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_wizard_change_cron_reimport_days">
+            <field name="name">wizard.change.cron.reimport.days.form</field>
+            <field name="model">wizard.change.cron.reimport.days</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Canvia el numero de dies del cron de reimportació de F1's">
+                    <field name="days" />
+                    <group colspan="4" col="4">
+                        <button name="change_days" string="Acceptar" icon="gtk-ok" type="object"/>
+                        <button special="cancel" string="Cancel·lar" icon="gtk-close"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_wizard_change_cron_reimport_days_form">
+            <field name="name">Canvia el numero de dies del cron de reimportació de F1's</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.change.cron.reimport.days</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_wizard_change_cron_reimport_days"/>
+            <field name="target">new</field>
+        </record>
+        <menuitem id="menu_wizard_change_cron_reimport_days" action="action_wizard_change_cron_reimport_days_form" parent="menu_som_error_cron_f1_reimport_folder"/>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu

Dotar al ET de l'eina per poder controlar que reimporta el cron de reimportació de f1's nocturn

## Targeta on es demana o Incidència 

https://trello.com/c/wx1666Mk/5746-0-4-get-permetre-gestionar-els-errors-que-es-reimporten-amb-el-cron-per-reimportar-f1s-a-la-nit

## Comportament antic

Edició de variable complexa i requereix permisos d'administració

## Comportament nou

Model amb vistes que permet la seva modificació per part de les persones del ET

## Comprovacions

- [X] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
    -  som_facturacio_switching     
- [ ] Script de migració
- [ ] Modifica traduccions
