### PR TITLE
Add only standard prices from indexed form without exceptions

### DIFF
--- a/som_indexada/data/product_pricelist_data.xml
+++ b/som_indexada/data/product_pricelist_data.xml
@@ -46,7 +46,7 @@
             <field name="type">sale</field>
             <field name="currency_id" ref="base.EUR"/>
         </record>
-        <record model="product.pricelist" id="pricelist_indexada_empresa_peninsula">
+        <record model="product.pricelist" id="pricelist_indexada_empresa_peninsula_non_standard">
             <field name="name">Indexada Empresa Peninsula</field>
             <field name="type">sale</field>
             <field name="currency_id" ref="base.EUR"/>

--- a/som_indexada/data/product_pricelist_data.xml
+++ b/som_indexada/data/product_pricelist_data.xml
@@ -46,5 +46,10 @@
             <field name="type">sale</field>
             <field name="currency_id" ref="base.EUR"/>
         </record>
+        <record model="product.pricelist" id="pricelist_indexada_empresa_peninsula">
+            <field name="name">Indexada Empresa Peninsula</field>
+            <field name="type">sale</field>
+            <field name="currency_id" ref="base.EUR"/>
+        </record>
     </data>
 </openerp>

--- a/som_indexada/exceptions/indexada_exceptions.py
+++ b/som_indexada/exceptions/indexada_exceptions.py
@@ -91,6 +91,20 @@ class PolissaSimultaneousATR(IndexadaException):
             polissa_number=self.polissa_number,
         )
 
+class PolissaNotStandardPrice(IndexadaException):
+    def __init__(self, polissa_number):
+        super(PolissaNotStandardPrice, self).__init__(
+            title=_('Non standard pricelist'),
+            text=_("Pòlissa {} has a non-standard pricelist").format(polissa_number),
+        )
+        self.polissa_number = polissa_number
+
+    def to_dict(self):
+        return dict(
+            super(PolissaNotStandardPrice, self).to_dict(),
+            polissa_number=self.polissa_number,
+        )
+
 class FailSendEmail(IndexadaException):
     def __init__(self, polissa_number):
         super(FailSendEmail, self).__init__(

--- a/som_indexada/migrations/5.0.2.108/pre-0001_pricelist_indexada_peninsula_semantic_id_creation.py
+++ b/som_indexada/migrations/5.0.2.108/pre-0001_pricelist_indexada_peninsula_semantic_id_creation.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+from datetime import datetime
+
+
+def up(cursor, installed_version):
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Starting Pricelist indexada peninsula semantic id creation migration script")
+    pool = pooler.get_pool(cursor.dbname)
+
+    model_data_obj = pool.get('ir.model.data')
+    pricelist_obj = pool.get('product.pricelist')
+
+    pricelist_ids = pricelist_obj.search(cursor, 1, [('name', '=', 'Indexada Empresa Península')])
+    if len(pricelist_ids) == 1:
+        pricelist_id = pricelist_ids[0]
+        today = datetime.today().strftime("%Y-%m-%d")
+
+        model_data_vals = {
+            'noupdate': True,
+            'name': 'pricelist_indexada_empresa_peninsula_non_standard',
+            'module': 'som_indexada',
+            'model': 'product.pricelist',
+            'res_id': pricelist_id,
+            'date_init': today,
+            'date_update': today
+        }
+
+        model_data_obj.create(cursor, 1, model_data_vals)
+
+    logger.info("Finishing Pricelist indexada peninsula semantic id creation migration script")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_indexada/som_indexada_webforms_helpers.py
+++ b/som_indexada/som_indexada_webforms_helpers.py
@@ -67,6 +67,7 @@ class SomIndexadaWebformsHelpers(osv.osv_memory):
                 uid,
                 polissa,
                 change_type,
+                only_standard_prices=True,
             )
             pricelist_id = wiz_o.calculate_new_pricelist(
                 cursor,

--- a/som_indexada/wizard/wizard_change_to_indexada.py
+++ b/som_indexada/wizard/wizard_change_to_indexada.py
@@ -186,7 +186,7 @@ class WizardChangeToIndexada(osv.osv_memory):
                         'som_indexada',
                         semantic_id,
                     )
-                    if price_list_mode == standard_price_list_id:
+                    if price_list_id == standard_price_list_id:
                         return True
         return False
 

--- a/som_indexada/wizard/wizard_change_to_indexada.py
+++ b/som_indexada/wizard/wizard_change_to_indexada.py
@@ -173,6 +173,8 @@ class WizardChangeToIndexada(osv.osv_memory):
         return new_pricelist_id
 
     def _is_standard_price_list(self, cursor, uid, price_list_id, context=None):
+        IrModel = self.pool.get('ir.model.data')
+
         for price_list_mode in (
             TARIFA_CODIS_PERIODES,
             TARIFA_CODIS_INDEXADA,
@@ -186,7 +188,7 @@ class WizardChangeToIndexada(osv.osv_memory):
                         'som_indexada',
                         semantic_id,
                     )
-                    if price_list_id == standard_price_list_id:
+                    if price_list_id == standard_price_list_id.id:
                         return True
         return False
 

--- a/som_indexada/wizard/wizard_change_to_indexada.py
+++ b/som_indexada/wizard/wizard_change_to_indexada.py
@@ -172,7 +172,25 @@ class WizardChangeToIndexada(osv.osv_memory):
 
         return new_pricelist_id
 
-    def validate_polissa_can_change(self, cursor, uid, polissa, change_type, context=None):
+    def _is_standard_price_list(self, cursor, uid, price_list_id, context=None):
+        for price_list_mode in (
+            TARIFA_CODIS_PERIODES,
+            TARIFA_CODIS_INDEXADA,
+        ):
+            for tarifa_codi, locations in price_list_mode.items():
+                for location, semantic_id in locations.items():
+                    # TODO: Could this resolution be calculated once?
+                    standard_price_list_id = IrModel._get_obj(
+                        cursor,
+                        uid,
+                        'som_indexada',
+                        semantic_id,
+                    )
+                    if price_list_mode == standard_price_list_id:
+                        return True
+        return False
+
+    def validate_polissa_can_change(self, cursor, uid, polissa, change_type, only_standard_prices=False, context=None):
         sw_obj = self.pool.get('giscedata.switching')
         if polissa.state != 'activa':
             raise indexada_exceptions.PolissaNotActive(polissa.name)
@@ -183,6 +201,12 @@ class WizardChangeToIndexada(osv.osv_memory):
             raise indexada_exceptions.PolissaAlreadyIndexed(polissa.name)
         if change_type == "from_index_to_period" and polissa.mode_facturacio == 'atr':
             raise indexada_exceptions.PolissaAlreadyPeriod(polissa.name)
+
+        if only_standard_prices:
+            price_list_id = polissa.llista_preu.id
+            is_standard_price = self._is_standard_price_list(cursor, uid,  price_list_id, context)
+            if not is_standard_price:
+                raise indexada_exceptions.PolissaNotStandardPrice(polissa.name)
 
         res = sw_obj.search(cursor, uid, [
             ('polissa_ref_id', '=', polissa.id),


### PR DESCRIPTION
## Objectiu
If a contract has a non-standard tariff, changing it from webforms should not be allowed. It must be done by our staff on the erp client.

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2299177058/15197723?folderId=3063450

## Comportament antic
El bloqueig es feia des de formulari d'una forma molt fragil: fent servir el fet que les tarifes standards tenen el numero del peatge al nom. Es un mecanisme feble davant de canvis de noms de tarifes. A més hi ha molts punts d'entrada (4) a la interficie d'usuari on fer aquest control.

## Comportament nou
- Fem servir la funció de l'erp que determina si el canvi de tarifa es factible
- Cridem a una nova funció que determina si la tarifa es standard o no. Es standard si es una de les tarifes de desti.
- Afegim un parametre opcional per dir que faci aquesta restricció i el setejem nomes quan es crida des del wrapper per webforms. D'aquesta forma encara es podra fer des del client erp.
- La comprobació no la fem quan apliquem el canvi, perque funcionalment no calia pero si cal fer-ho per consistencia caldria afegir tambe un parametre a la funcio d'aplicar.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
