### PR TITLE
Eliminació 4€ despeses en casos de pobresa

### DIFF
--- a/som_facturacio_comer/__init__.py
+++ b/som_facturacio_comer/__init__.py
@@ -4,3 +4,4 @@ import giscedata_facturacio_contracte_lot
 import giscedata_facturacio_report_v2
 import wizard
 import giscedata_polissa
+import giscedata_facturacio_factura

--- a/som_facturacio_comer/giscedata_facturacio_factura.py
+++ b/som_facturacio_comer/giscedata_facturacio_factura.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from osv import osv
+
+
+class GiscedataFacturacioFactura(osv.osv):
+    _inherit = 'giscedata.facturacio.factura'
+
+
+    def generate_unpayment_expenses(self, cursor, uid, fact_ids, context=None):
+        '''Comprovem que no té pobresa energètica abans de crear l'extra line'''
+        if context is None:
+            context = {}
+        
+        if len(fact_ids) > 1:
+            raise Exception("Ha arribat més d'un id")
+
+        imd_obj = self.pool.get('ir.model.data')
+
+        factura_browse = self.browse(cursor, uid, fact_ids[0], context=context)
+
+        res = {}
+        pobresa_energetica = False
+
+        # TODO: Posar semantic ID
+        pobresa_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_polissa', 'categ_pobresa_energetica'
+        )[1]
+
+        if pobresa_id and factura_browse.polissa_id.category_id and pobresa_id in [x.id for x in factura_browse.polissa_id.category_id]:
+            pobresa_energetica = True
+
+        if not pobresa_energetica:
+            res = super(GiscedataFacturacioFactura, self).generate_unpayment_expenses(
+                cursor, uid, fact_ids, context=context
+            )
+        
+        return res
+
+GiscedataFacturacioFactura()

--- a/som_facturacio_comer/migrations/5.0.23.6.0/pre-0001_put_pobresa_energeita_as_semantic_id.py
+++ b/som_facturacio_comer/migrations/5.0.23.6.0/pre-0001_put_pobresa_energeita_as_semantic_id.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+from datetime import datetime
+
+
+def up(cursor, installed_version):
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Starting Pobresa Energetica semantic id creation migration script")
+    pool = pooler.get_pool(cursor.dbname)
+
+    model_data_obj = pool.get('ir.model.data')
+    categ_obj = pool.get('giscedata.polissa.category')
+
+   categ_ids = categ_obj.search(cursor, 1, [('name', 'ilike', '%Pobresa Energ%')])
+    if len(categ_ids) == 1:
+        categ_id = categ_ids[0]
+        today = datetime.today().strftime("%Y-%m-%d")
+
+        model_data_vals = {
+            'noupdate': True,
+            'name': 'categ_pobresa_energetica',
+            'module': 'som_facturacio_comer',
+            'model': 'giscedata.polissa.category',
+            'res_id': categ_id,
+            'date_init': today,
+            'date_update': today
+        }
+
+        model_data_obj.create(cursor, 1, model_data_vals)
+
+    logger.info("Finishing Pricelist indexada peninsula semantic id creation migration script")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa/som_polissa_data.xml
+++ b/som_polissa/som_polissa_data.xml
@@ -21,8 +21,12 @@
         </record>
         <record id="categ_eie_CNAE_CIF" model="giscedata.polissa.category">
             <field name="name">3. CNAE + CIF</field>
-            <field name="name">EMPRESA</field>
+            <field name="code">EMPRESA</field>
             <field name="parent_id" ref="categ_entitat_o_empresa"/>
+        </record>
+        <record id="categ_pobresa_energetica" model="giscedata.polissa.category">
+            <field name="name">Pobresa Energètica</field>
+            <field name="name">POBRESA</field>
         </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu
Quan en una factura, en el procés automàtic de tall, se li canvia l’estat pendent cap als annexos II, III.1r, III.2n, IV i 48h, s’aplica un extraline de 4€ en concepte de despeses de gestió d’impagament.

Des de l’equip de Gestió de Cobraments, hem decidit que, en els casos de contractes que tenen categoria de pobresa energètica, aquesta despesa no s'hauria de cobrar.

En el moment de generar-se aquest extraline, volem que primer comprovi la categoria del contracte, i si es tracta d’un cas de pobresa energètica, volem que no es generi aquest extraline de 4€. En la resta de casos, sí.

## Targeta on es demana o Incidència 
https://trello.com/c/t1OAk3q7/5774-eliminaci%C3%B3-4%E2%82%AC-despeses-en-casos-de-pobresa

## Comportament antic
Es cobrava SEMPRE 

## Comportament nou
Ara només es cobra si no té pobresa energètica

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar ERP
- [ ] Actualitzar mòdul
- [x] Script de migració -> pre-0001_put_pobresa_energeita_as_semantic_id
- [ ] Modifica traduccions -> Nein
