### PR TITLE
Canvi prioritzat llistat polissa cau per no sobrescriure cerca polissa general

### DIFF
--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -145,7 +145,7 @@
             <field name="name">giscedata_polissa_cau_tree</field>
             <field name="model">giscedata.polissa</field>
             <field name="type">tree</field>
-            <field name="priority" eval="1"/>
+            <field name="priority" eval="16"/>
             <field name="arch" type="xml">
                 <tree string="Contractes per CAU" colors="red:state in ['tall', 'baixa', 'cancelada']">
                     <field name="distribuidora"/>


### PR DESCRIPTION
## Objectiu
Baixar prioritat de la nova vista "Polisses per CAU" perquè no sobrescrigui el llistat de Pòlisses general quan es fa CTRL+F al llistat de pòlisses.
https://github.com/Som-Energia/openerp_som_addons/pull/367

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2325928928/15351338?folderId=3063374

## Comportament antic
Quan es feia CTRL+F al llistat de pòlisses, sortia el llistat per CAU.

## Comportament nou
Quan es fa CTRL+F al llistat de pòlisses, sort el llistat de pòlisses general.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions