### PR TITLE
✨ Afegir Flux Solar parametres a factura PDF

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1334,7 +1334,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         lloguer_lines = []
         bosocial_lines = []
         donatiu_lines = []
-        flux_lines = []
         altres_lines = []
         for l in fact.linia_ids:
             if l.tipus in 'lloguer':
@@ -1351,12 +1350,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 })
             if l.tipus in 'altres' and l.invoice_line_id.product_id.code == 'DN01':
                 donatiu_lines.append({
-                    'quantity': l.quantity,
-                    'price_unit_multi': l.price_unit_multi,
-                    'price_subtotal': l.price_subtotal,
-                })
-            if l.tipus in 'altres' and l.invoice_line_id.product_id.code == 'PBV':
-                flux_lines.append({
                     'quantity': l.quantity,
                     'price_unit_multi': l.price_unit_multi,
                     'price_subtotal': l.price_subtotal,
@@ -1434,7 +1427,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 'lloguer_lines': lloguer_lines,
                 'bosocial_lines': bosocial_lines,
                 'donatiu_lines': donatiu_lines,
-                'flux_lines': flux_lines,
                 'altres_lines': altres_lines,
                 'iese_lines': iese_lines,
                 'iva_lines': iva_lines,
@@ -1925,6 +1917,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             'excess_power_maximeter': self.get_sub_component_invoice_details_td_excess_power_maximeter(fact, pol),
             'excess_power_quarterhours': self.get_sub_component_invoice_details_td_excess_power_quarterhours(fact, pol),
             'bo_social_2023': self.get_sub_component_invoice_details_td_bo_social_2023_data(fact, pol),
+            'flux_solar': self.get_sub_component_invoice_details_td_flux_solar_data(fact, pol),
             'generation': self.get_sub_component_invoice_details_td_generation_data(fact, pol),
             'inductive': self.get_sub_component_invoice_details_td_inductive_data(fact, pol),
             'capacitive': self.get_sub_component_invoice_details_td_capacitive_data(fact, pol),
@@ -2430,6 +2423,22 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             'number_of_columns': len(self.get_matrix_show_periods(pol)) + 1,
             'days':days,
             'price_per_day': price_per_day,
+            'subtotal': subtotal,
+        }
+        return data
+
+    def get_sub_component_invoice_details_td_flux_solar_data(self, fact, pol):
+        subtotal = 0.0
+        visible = False
+
+        for l in fact.linia_ids:
+            if l.tipus in 'altres' and l.invoice_line_id.product_id.code == 'PBV':
+                subtotal += l.price_subtotal
+                visible = True
+
+        data = {
+            'is_visible': visible,
+            'number_of_columns': len(self.get_matrix_show_periods(pol)) + 1,
             'subtotal': subtotal,
         }
         return data

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1334,6 +1334,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         lloguer_lines = []
         bosocial_lines = []
         donatiu_lines = []
+        flux_lines = []
         altres_lines = []
         for l in fact.linia_ids:
             if l.tipus in 'lloguer':
@@ -1354,7 +1355,13 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     'price_unit_multi': l.price_unit_multi,
                     'price_subtotal': l.price_subtotal,
                 })
-            if l.tipus in ('altres', 'cobrament') and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'DESC1721', 'DESC1721ENE', 'DESC1721POT', 'RBS'):
+            if l.tipus in 'altres' and l.invoice_line_id.product_id.code == 'PBV':
+                flux_lines.append({
+                    'quantity': l.quantity,
+                    'price_unit_multi': l.price_unit_multi,
+                    'price_subtotal': l.price_subtotal,
+                })
+            if l.tipus in ('altres', 'cobrament') and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'DESC1721', 'DESC1721ENE', 'DESC1721POT', 'RBS', 'PBV'):
                 altres_lines.append({
                     'name': l.name,
                     'price_subtotal': l.price_subtotal,

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1660,7 +1660,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         donatiu_lines = [l for l in fact.linia_ids if l.tipus in 'altres'
                         and l.invoice_line_id.product_id.code == 'DN01']
         altres_lines = [l for l in fact.linia_ids if l.tipus in ('altres', 'cobrament')
-                        and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'RBS')]
+                        and l.invoice_line_id.product_id.code not in ('DN01', 'BS01', 'RBS', 'PBV')]
 
         extra_energy_lines = self.get_extra_energy_lines(fact, pol)
 
@@ -1710,6 +1710,12 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         bosocial2023_lines = [l for l in fact.linia_ids if l.tipus in 'altres'
                              and l.invoice_line_id.product_id.code == 'RBS']
         data['total_bosocial2023'] = sum([l.price_subtotal for l in bosocial2023_lines])
+
+        flux_lines = [l for l in fact.linia_ids if l.tipus in ('altres', 'cobrament')
+                     and l.invoice_line_id.product_id.code == 'PBV']
+
+        data['has_flux_solar_discount'] = len(flux_lines) > 0
+        data['flux_solar_discount'] = sum([l.price_subtotal for l in flux_lines])
         return data
 
     def get_component_partner_info_data(self, fact, pol):

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1434,6 +1434,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 'lloguer_lines': lloguer_lines,
                 'bosocial_lines': bosocial_lines,
                 'donatiu_lines': donatiu_lines,
+                'flux_lines': flux_lines,
                 'altres_lines': altres_lines,
                 'iese_lines': iese_lines,
                 'iva_lines': iva_lines,

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-06-22 12:40+0000\n"
-"PO-Revision-Date: 2023-06-22 10:43+0000\n"
+"POT-Creation-Date: 2023-09-06 15:11+0000\n"
+"PO-Revision-Date: 2023-09-06 13:19+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2738
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -36,14 +36,14 @@ msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1931
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1933
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1939
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1941
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1935
 msgid "estimada"
 msgstr "estimada"
 
@@ -54,14 +54,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2744
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2768
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1966
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1974
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -72,7 +72,7 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1776
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1783
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
@@ -84,13 +84,13 @@ msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1929
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1937
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2650
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
@@ -103,18 +103,18 @@ msgid ""
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1730
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2656
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2680
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1774
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1781
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -124,13 +124,13 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2685
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2709
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1724
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1731
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
@@ -146,7 +146,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1778
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1785
 msgid "(real)"
 msgstr "(real)"
 
@@ -1254,7 +1254,7 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:42
@@ -1274,6 +1274,7 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:156
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:66
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:71
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:44
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:49
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:59
@@ -1494,7 +1495,7 @@ msgstr "Donativo voluntario (exento de IVA)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:30
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:42
 msgid "TOTAL IMPORT FACTURA"
 msgstr "TOTAL IMPORTE FACTURA"
 
@@ -1560,7 +1561,7 @@ msgstr "Detalle"
 msgid "Total conceptes"
 msgstr "Total conceptos"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:39
 msgid "TOTAL FACTURA"
 msgstr "TOTAL FACTURA"
 
@@ -1726,6 +1727,15 @@ msgstr "kW exceso x €/kW exceso x kp x (%.f/30) días (del %s al %s)"
 msgid "kW excés x €/kW excés x kp (del %s al %s)"
 msgstr "kW exceso x €/kW exceso x kp (del %s al %s)"
 
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:7
+msgid "Flux Solar"
+msgstr "Flux Solar"
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:8
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
+msgid "Descompte per Flux Solar"
+msgstr "Descuento por Flux Solar"
+
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:10
 msgid "Compensació per electricitat excedentària"
 msgstr "Compensación por electricidad excedentaria"
@@ -1754,7 +1764,7 @@ msgstr "Precio energía reactiva inductiva [€/kVArh]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:34
 msgid "Altres conceptes"
 msgstr "Otros conceptos"
 
@@ -1939,7 +1949,7 @@ msgid "Lloguer del comptador"
 msgstr "Alquiler del contador"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:28
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:40
 msgid "Donatiu voluntari (0,01 &euro;/kWh) (exempt d'IVA)"
 msgstr "Donativo voluntario (0,01 &euro;/kWh) (exento de IVA)"
 

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-06-22 12:40+0000\n"
-"PO-Revision-Date: 2023-06-22 12:40+0000\n"
+"POT-Creation-Date: 2023-09-06 15:11+0000\n"
+"PO-Revision-Date: 2023-09-06 15:11+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2714
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2738
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -29,14 +29,14 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:302
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1931
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1933
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1939
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1941
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1927
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1935
 msgid "estimada"
 msgstr ""
 
@@ -47,14 +47,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2744
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2768
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1966
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1974
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -65,7 +65,7 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1776
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1783
 msgid "(sense lectura)"
 msgstr ""
 
@@ -77,13 +77,13 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:295
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1929
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1937
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2626
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2650
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
@@ -96,18 +96,18 @@ msgid ""
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1723
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1730
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2656
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2680
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1774
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1781
 msgid "(estimada)"
 msgstr ""
 
@@ -117,13 +117,13 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2685
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2709
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1724
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1731
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1778
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1785
 msgid "(real)"
 msgstr ""
 
@@ -1242,7 +1242,7 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:42
@@ -1262,6 +1262,7 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:156
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:66
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:71
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:44
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:49
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:59
@@ -1484,7 +1485,7 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:30
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:39
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:42
 msgid "TOTAL IMPORT FACTURA"
 msgstr ""
 
@@ -1550,7 +1551,7 @@ msgstr ""
 msgid "Total conceptes"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:39
 msgid "TOTAL FACTURA"
 msgstr ""
 
@@ -1716,6 +1717,15 @@ msgstr ""
 msgid "kW excés x €/kW excés x kp (del %s al %s)"
 msgstr ""
 
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:7
+msgid "Flux Solar"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:8
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
+msgid "Descompte per Flux Solar"
+msgstr ""
+
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:10
 msgid "Compensació per electricitat excedentària"
 msgstr ""
@@ -1744,7 +1754,7 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:34
 msgid "Altres conceptes"
 msgstr ""
 
@@ -1929,7 +1939,7 @@ msgid "Lloguer del comptador"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:28
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:40
 msgid "Donatiu voluntari (0,01 &euro;/kWh) (exempt d'IVA)"
 msgstr ""
 

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
@@ -33,6 +33,7 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako" args="id=id.generation" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako" args="id=id.inductive" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako" args="id=id.capacitive" />
+    <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako" args="fs=id.flux_solar" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako" args="id=id.other_concepts" />
     <tr class="total_factura_row">
         <td class="total_factura_text" colspan="${len(id.showing_periods)+2}">${_(u"TOTAL FACTURA")}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako
@@ -4,8 +4,8 @@
 import locale
 %>
     <tr class="last_row">
-        <td class="td_first concepte_td">${_(u"Descompte per Flux Solar")}</td>
-        <td class="detall_td" colspan="${fs.number_of_columns}"></td>
+        <td class="td_first concepte_td">${_(u"Flux Solar")}</td>
+        <td class="detall_td" colspan="${fs.number_of_columns}">${_(u"Descompte per Flux Solar")}</td>
         <td class="subtotal">${_(u"%s €") % formatLang(fs.subtotal)}</td>
     </tr>
 %endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako
@@ -1,0 +1,11 @@
+<%page args="fs" />
+%if fs.is_visible:
+<%
+import locale
+%>
+    <tr class="last_row">
+        <td class="td_first concepte_td">${_(u"Descompte per Flux Solar")}</td>
+        <td class="detall_td" colspan="${fs.number_of_columns}"></td>
+        <td class="subtotal">${_(u"%s €") % formatLang(fs.subtotal)}</td>
+    </tr>
+%endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
@@ -3,16 +3,6 @@
 import locale
 first_pass = True
 %>
-% for l in id.flux_lines:
-    <tr class= "${'last_row' if id.last_row == 'flux' else ''}">
-        % if first_pass:
-            <td class="td_first concepte_td" rowspan="${id.header_multi}">${_(u"")}</td>
-            <%first_pass = False%>
-        % endif
-        <td class="detall_td" colspan="${id.number_of_columns}">${_(u"Descompte per Flux Solar")}</td>
-        <td class="subtotal">${_(u"%s €") % formatLang(l['price_subtotal'])}</td>
-    </tr>
-% endfor
 % for l in id.bosocial_lines:
     <tr class= "${'last_row' if id.last_row == 'bosocial' else ''}">
         % if first_pass:

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
@@ -3,6 +3,16 @@
 import locale
 first_pass = True
 %>
+% for l in id.flux_lines:
+    <tr class= "${'last_row' if id.last_row == 'flux' else ''}">
+        % if first_pass:
+            <td class="td_first concepte_td" rowspan="${id.header_multi}">${_(u"")}</td>
+            <%first_pass = False%>
+        % endif
+        <td class="detall_td" colspan="${id.number_of_columns}">${_(u"Descompte per Flux Solar")}</td>
+        <td class="subtotal">${_(u"%s €") % formatLang(l['price_subtotal'])}</td>
+    </tr>
+% endfor
 % for l in id.bosocial_lines:
     <tr class= "${'last_row' if id.last_row == 'bosocial' else ''}">
         % if first_pass:

--- a/giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako
@@ -27,6 +27,9 @@
     % if invs.total_boe17_2021 != 0:
         <tr><td>${_(u"Descompte sobre els càrrecs (RDL 17/2021)")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_boe17_2021)}</td></tr>
     % endif
+    % if invs.has_flux_solar_discount:
+        <tr><td>${_(u"Descompte per Flux Solar")}</td><td class="e">${"%s &euro;" % formatLang(invs.flux_solar_discount)}</td></tr>
+    % endif
     % if (invs.total_altres + invs.total_bosocial) != 0:
         <tr><td>${_(u"Altres conceptes")}</td><td class="e">${"%s &euro;" % formatLang(invs.total_altres + invs.total_bosocial)}</td></tr>
     % endif


### PR DESCRIPTION
## Objectiu
✨ Afegir Flux Solar parametres a factura PDF

## Targeta on es demana o Incidència 
https://trello.com/c/TXrO8szp/124-bateria-canviar-text-pdf-per-l%C3%ADnia-descompte-flux-i-del-resum-de-la-factura

## Comportament antic
No hi era

## Comportament nou
Hi és

## Comprovacions

- [x] Reiniciar serveis: ERP i workers d'impressió (inclou poweremail_render)
- [x] Actualitzar mòdul: giscedata facturacio_comer_som
- [x] Modifica traduccions
