### PR TITLE
Afegir la capacitat d'executar una validació de factura en esborrany isolada sobre una factura qualsevol

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_validation.py
+++ b/som_facturacio_comer/giscedata_facturacio_validation.py
@@ -183,23 +183,15 @@ class GiscedataFacturacioValidationValidator(osv.osv):
         return super(GiscedataFacturacioValidationValidator,
             self).check_consume_by_amount(cursor, uid, fact, parameters)
 
-    def test_one_validation_invoice(self, cursor, uid, fact_id, validation_code, context=None):
+    def validate_one_invoice(self, cursor, uid, fact_id, validation_id, context=None):
         if context is None:
             context = {}
 
         fact_obj = self.pool.get('giscedata.facturacio.factura')
         tmpl_obj = self.pool.get('giscedata.facturacio.validation.warning.template')
 
-        search_parameters = [('code', '=', validation_code)]
-        tmpl_ids = tmpl_obj.search(cursor, uid,
-                                   search_parameters,
-                                   context={'active_test': False})
-
-        if len(tmpl_ids) != 1:
-            return {'error': 'No validation found for code {}'.format(validation_code)}
-
         tmpl_fields = ['code', 'method', 'parameters', 'description', 'active']
-        template_vals = tmpl_obj.read(cursor, uid, tmpl_ids[0], tmpl_fields, context)
+        template_vals = tmpl_obj.read(cursor, uid, validation_id, tmpl_fields, context)
 
         fact = fact_obj.browse(cursor, uid, fact_id)
         vals = getattr(self, template_vals['method'])(


### PR DESCRIPTION
## Objectiu

En el marc de la targeta https://trello.com/c/1IuYsmUo/113-gea-validaci%C3%B3-retroactiva-excedent-vs-pot%C3%A8ncia-generaci%C3%B3-en-contractes-dauto , cal afegir la capacitat d'executar una validació de factura en esborrany aïllada sobre una factura qualsevol.

## Targeta on es demana o Incidència 

https://trello.com/c/1IuYsmUo/113-gea-validaci%C3%B3-retroactiva-excedent-vs-pot%C3%A8ncia-generaci%C3%B3-en-contractes-dauto

## Comportament antic

No es poden executar validacions de factures en esborrany aïllades des de script

## Comportament nou

Es permet executar una validació qualsevol sobre una factura qualsevol obtenint-ne el resultat.

## Comprovacions

- [x] Reiniciar serveis
