### PR TITLE
👔 Remove contract categories on owner change

### DIFF
--- a/som_switching/__init__.py
+++ b/som_switching/__init__.py
@@ -5,3 +5,4 @@ import giscedata_switching
 import giscedata_atc
 import giscedata_polissa
 import giscedata_switching_b1
+import giscedata_switching_m1

--- a/som_switching/giscedata_switching_m1.py
+++ b/som_switching/giscedata_switching_m1.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from osv import osv
+
+
+class GiscedataSwitchingM1_01(osv.osv):
+
+    _name = 'giscedata.switching.m1.01'
+    _inherit = 'giscedata.switching.m1.01'
+
+    def config_step(self, cursor, uid, ids, vals, context=None):
+        new_contract_values = vals.get("new_contract_values")
+        if new_contract_values:
+            new_contract_values.update({
+                'category_id': [],
+            })
+
+        super(GiscedataSwitchingM1_01, self).config_step(
+            self, cursor, uid, ids, vals, context
+        )
+
+
+GiscedataSwitchingM1_01()

--- a/som_switching/giscedata_switching_m1.py
+++ b/som_switching/giscedata_switching_m1.py
@@ -15,7 +15,7 @@ class GiscedataSwitchingM1_01(osv.osv):
             })
 
         super(GiscedataSwitchingM1_01, self).config_step(
-            self, cursor, uid, ids, vals, context
+            cursor, uid, ids, vals, context
         )
 
 

--- a/som_switching/giscedata_switching_m1.py
+++ b/som_switching/giscedata_switching_m1.py
@@ -11,7 +11,7 @@ class GiscedataSwitchingM1_01(osv.osv):
         new_contract_values = vals.get("new_contract_values")
         if new_contract_values:
             new_contract_values.update({
-                'category_id': [],
+                'category_id': [(6, 0, [])],
             })
 
         super(GiscedataSwitchingM1_01, self).config_step(


### PR DESCRIPTION
## Objectiu

Evitar copiar la categoria "Pobresa energètica" i aquelles que estiguin vinculades al titular en concret a la nova pòlissa en fer un canvi de titular.

## Targeta on es demana o Incidència 

https://trello.com/c/mQ5avx60/139-canvi-de-titular-contractes-categoria-pobresa-energ%C3%A8tica-que-el-nou-contracte-no-agafi-la-categoria

## Comportament antic

Es copiaven totes les categories.

## Comportament nou

No es copia cap categoria i llavors s'assignen les d'EiE.

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
