### PR TITLE
Eliminar Aportació voluntària i fraccionament de factures de la factura en PDF

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -93,26 +93,16 @@ def is_DHS(pol):
 def is_DHA(pol):
     return pol.tarifa.codi_ocsum in ('004', '006')
 
-dummy_td = False
-
 def is_TD(pol):
-    if dummy_td:
-        return True
     return pol.tarifa.codi_ocsum in ('018', '019', '020', '021', '022', '023', '024', '025')
 
 def is_2XTD(pol):
-    if dummy_td:
-        return is_2X(pol)
     return pol.tarifa.codi_ocsum in ('018')
 
 def is_3XTD(pol):
-    if dummy_td:
-        return is_3X(pol)
     return pol.tarifa.codi_ocsum in ('019', '024')
 
 def is_6XTD(pol):
-    if dummy_td:
-        return is_6X(pol)
     return pol.tarifa.codi_ocsum in ('020', '021', '022', '023', '025')
 
 def is_indexed(fact):


### PR DESCRIPTION
## Objectiu

Eliminar de la factura en pdf els següents termes:
- Aportació Voluntària
- Fraccionament de factures
- Frase d'autoconsum compartit
- Eliminar del total de la factura

Afegir a la factura en pdf els següents termes:
- Columna amb IVA desglossat per ìtems de factura
- Millores als texts

## Targeta on es demana o Incidència 

https://trello.com/c/EmLwJgAl/114-get-canvis-al-pdf-total-factura-i-columna-iva

## Comportament antic

Es mostraven

## Comportament nou

No es mostren

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
       - giscedata_facturacio_comer_som
- [ ] Script de migració
- [x] Modifica traduccions
