### PR TITLE
Pobresa state into impagament confirmat automatized

### DIFF
--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -15,12 +15,14 @@
         "www_som",
         "poweremail",
         "som_polissa",
+        "custom_search",
     ],
     "init_xml": [],
     "demo_xml": [
         "demo/som_account_invoice_pending_demo_data.xml",
     ],
     "update_xml": [
+        "data/custom_search_data.xml",
         "som_account_invoice_pending_data.xml",
         "wizard/wizard_returned_invoices_export.xml",
         "wizard/wizard_unlink_sms_pending_history_view.xml",

--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -14,6 +14,7 @@
         "giscedata_facturacio_impagat_comer",
         "www_som",
         "poweremail",
+        "som_polissa",
     ],
     "init_xml": [],
     "demo_xml": [

--- a/som_account_invoice_pending/data/custom_search_data.xml
+++ b/som_account_invoice_pending/data/custom_search_data.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+       <record id="consulta_factures_deute_pobresa" model="custom.search">
+            <field name="name">COB - Consulta factures pobresa</field>
+            <field name="query"><![CDATA[
+select 
+ gff.id as "IdFactura"
+--,ai.id as IdFacturaCont
+,ai."number" as "Numerofactura"
+,gp."name" as "Contracte"
+--,gp.cups as cups_id 
+,gcp."name" as "CUPS"
+--,ai.partner_id
+--,ai.pending_state  as "IdEstatPendent"
+,aips."name" as "EstatPendent"
+,ai.pending_state_date as "DataEstatPendent"
+--,gff.polissa_id as contracte_id
+,gp.state as "EstatAbonat"
+,gff.data_inici as "DataInici"
+,gff.data_final  as "DataFinal"
+,rp."name" as "Empresa"
+,ai.amount_untaxed as "Base"
+,ai.residual as "Pendent"
+,ai.amount_total as "Total"
+,ai.date_invoice as "DataFactura"
+,ai.date_due as "DataVenciment"
+,gff.potencia as "PotènciaContractada(kW)"
+,gff.energia_kwh as "EnegiaFacturada"
+,gff.dies as "DiesFacturats"
+,sq02.case_name as "CasDescripció"
+,sq02.date as "CasHistData"
+,sq02.user_name as "CasHistUsuariResponsable"
+,sq02.description as "CasHistDescripció"
+from giscedata_facturacio_factura gff 
+inner join account_invoice ai on ai.id = gff.invoice_id
+inner join account_invoice_pending_state aips on aips.id = ai.pending_state and aips.weight > 0
+inner join res_partner rp on rp.id = ai.partner_id 
+inner join giscedata_polissa gp on gp.id = gff.polissa_id 
+inner join giscedata_cups_ps gcp on gcp.id = gp.cups 
+left join 
+(
+	select *
+	from
+	(
+		select
+		ROW_NUMBER() OVER (
+		PARTITION BY ccl.case_id
+		ORDER BY ccl.date DESC
+		) as rn_aux
+		,ccl.case_id, cc.partner_id, cc."name" as case_name, cc.polissa_id, ccl."date", ccl.user_id, ru.name as user_name, cch.description
+		from crm_case_log ccl 
+		inner join crm_case_history cch on cch.log_id = ccl.id
+		inner join crm_case cc on cc.id = ccl.case_id 
+		inner join crm_case_section ccs on ccs.id = cc.section_id 
+		left join res_users ru on ru.id = ccl.user_id 
+		where cc.state = 'open'
+		and ccs.id = (select res_id from ir_model_data imd 
+				  	  where "module" = 'giscedata_facturacio_comer_bono_social' and "name" = 'crm_section_bono_social_consulta_pobresa')
+	) sql01 
+	where sql01.rn_aux = 1
+)sq02 on sq02.polissa_id = gff.polissa_id 
+where ai.type = 'out_invoice' 
+and ai.pending_state = (select res_id from ir_model_data imd 
+   				        where "module" = 'som_account_invoice_pending' and "name" = 'pendent_consulta_probresa_pending_state')
+            ]]>
+            </field>
+        </record>
+        <!--Columns-->
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_0">
+            <field name="sequence" eval="0"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">IdFactura</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_10">
+            <field name="sequence" eval="10"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">NumeroFactura</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_20">
+            <field name="sequence" eval="20"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">Contracte</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_30">
+            <field name="sequence" eval="30"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">CUPS</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_40">
+            <field name="sequence" eval="40"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">EstatPendent</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_50">
+            <field name="sequence" eval="50"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">DataEstatPendent</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_60">
+            <field name="sequence" eval="60"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">EstatAbonat</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_70">
+            <field name="sequence" eval="70"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">DataInici</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_80">
+            <field name="sequence" eval="80"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">DataFinal</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_90">
+            <field name="sequence" eval="90"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">Empresa</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_100">
+            <field name="sequence" eval="100"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">Base</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_110">
+            <field name="sequence" eval="110"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">Pendent</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_120">
+            <field name="sequence" eval="120"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">Total</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_130">
+            <field name="sequence" eval="130"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">DataFactura</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_140">
+            <field name="sequence" eval="140"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">DataVenciment</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_150">
+            <field name="sequence" eval="150"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">PotenciaContractada(kW)</field>
+        </record>
+
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_160">
+            <field name="sequence" eval="160"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">EnegiaFacturada</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_170">
+            <field name="sequence" eval="170"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">DiesFacturats</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_180">
+            <field name="sequence" eval="180"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">CasDescripcio</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_190">
+            <field name="sequence" eval="190"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">CasHistData</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_200">
+            <field name="sequence" eval="200"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">CasHistUsuariResponsable</field>
+        </record>
+        <record model="custom.search.column" id="consulta_factures_deute_pobresa_210">
+            <field name="sequence" eval="210"/>
+            <field name="search_id" ref="consulta_factures_deute_pobresa"/>
+            <field name="name">CasHistDescripcio</field>
+        </record>
+    </data>
+</openerp>

--- a/som_account_invoice_pending/data/custom_search_data.xml
+++ b/som_account_invoice_pending/data/custom_search_data.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <openerp>
-    <data>
+    <data noupdate="0">
        <record id="consulta_factures_deute_pobresa" model="custom.search">
             <field name="name">COB - Consulta factures pobresa</field>
             <field name="query"><![CDATA[
-select 
+select
  gff.id as "IdFactura"
 --,ai.id as IdFacturaCont
-,ai."number" as "Numerofactura"
+,ai."number" as "NumeroFactura"
 ,gp."name" as "Contracte"
---,gp.cups as cups_id 
+--,gp.cups as cups_id
 ,gcp."name" as "CUPS"
 --,ai.partner_id
 --,ai.pending_state  as "IdEstatPendent"
@@ -32,13 +32,13 @@ select
 ,sq02.date as "CasHistData"
 ,sq02.user_name as "CasHistUsuariResponsable"
 ,sq02.description as "CasHistDescripció"
-from giscedata_facturacio_factura gff 
+from giscedata_facturacio_factura gff
 inner join account_invoice ai on ai.id = gff.invoice_id
 inner join account_invoice_pending_state aips on aips.id = ai.pending_state and aips.weight > 0
-inner join res_partner rp on rp.id = ai.partner_id 
-inner join giscedata_polissa gp on gp.id = gff.polissa_id 
-inner join giscedata_cups_ps gcp on gcp.id = gp.cups 
-left join 
+inner join res_partner rp on rp.id = ai.partner_id
+inner join giscedata_polissa gp on gp.id = gff.polissa_id
+inner join giscedata_cups_ps gcp on gcp.id = gp.cups
+left join
 (
 	select *
 	from
@@ -49,19 +49,19 @@ left join
 		ORDER BY ccl.date DESC
 		) as rn_aux
 		,ccl.case_id, cc.partner_id, cc."name" as case_name, cc.polissa_id, ccl."date", ccl.user_id, ru.name as user_name, cch.description
-		from crm_case_log ccl 
+		from crm_case_log ccl
 		inner join crm_case_history cch on cch.log_id = ccl.id
-		inner join crm_case cc on cc.id = ccl.case_id 
-		inner join crm_case_section ccs on ccs.id = cc.section_id 
-		left join res_users ru on ru.id = ccl.user_id 
+		inner join crm_case cc on cc.id = ccl.case_id
+		inner join crm_case_section ccs on ccs.id = cc.section_id
+		left join res_users ru on ru.id = ccl.user_id
 		where cc.state = 'open'
-		and ccs.id = (select res_id from ir_model_data imd 
+		and ccs.id = (select res_id from ir_model_data imd
 				  	  where "module" = 'giscedata_facturacio_comer_bono_social' and "name" = 'crm_section_bono_social_consulta_pobresa')
-	) sql01 
+	) sql01
 	where sql01.rn_aux = 1
-)sq02 on sq02.polissa_id = gff.polissa_id 
-where ai.type = 'out_invoice' 
-and ai.pending_state = (select res_id from ir_model_data imd 
+)sq02 on sq02.polissa_id = gff.polissa_id
+where ai.type = 'out_invoice'
+and ai.pending_state = (select res_id from ir_model_data imd
    				        where "module" = 'som_account_invoice_pending' and "name" = 'pendent_consulta_probresa_pending_state')
             ]]>
             </field>

--- a/som_account_invoice_pending/data/custom_search_data.xml
+++ b/som_account_invoice_pending/data/custom_search_data.xml
@@ -4,6 +4,9 @@
        <record id="consulta_factures_deute_pobresa" model="custom.search">
             <field name="name">COB - Consulta factures pobresa</field>
             <field name="query"><![CDATA[
+/* ATENCIÓ: Aquesta query està pensada per ser modificada per codi.
+ * Per tant, si es modifica a l'ERP i després s'actualitza el mòdul, els canvis seran sobreescrits.
+ * */
 select
  gff.id as "IdFactura"
 --,ai.id as IdFacturaCont

--- a/som_account_invoice_pending/update_pending_states.py
+++ b/som_account_invoice_pending/update_pending_states.py
@@ -916,7 +916,7 @@ class UpdatePendingStates(osv.osv_memory):
 
     def poverty_eligible(self, cursor, uid, polissa_id):
         pol_obj = self.pool.get("giscedata.polissa")
-        polissa_state = pol_obj.read(cursor, uid, polissa_id, ["cups_np"])["cups_np"]
+        polissa_state = pol_obj.read(cursor, uid, [polissa_id], ["cups_np"])[0]["cups_np"]
         return True if polissa_state in ['Barcelona', 'Girona', 'Lleida', 'Tarragona'] else False
 
     def update_pending_ask_poverty(self, cursor, uid, context=None):
@@ -935,6 +935,7 @@ class UpdatePendingStates(osv.osv_memory):
 
         for factura_id in factura_ids:
             invoice = fact_obj.read(cursor, uid, factura_id)
+
             polissa_id = invoice["polissa_id"][0]
             if not self.poverty_eligible(cursor, uid, polissa_id):
                 fact_obj.set_pending(cursor, uid, [factura_id], warning_cut_off_state)


### PR DESCRIPTION
## Objectiu
Automatizar l'avançament d'estat a avís impagament confirmat de les factures en estat consulta pobresa que no compleixen els requisits

## Targeta on es demana o Incidència 
https://trello.com/c/GpYXKCTM/138-automatitzar-procediments-i-c%C3%A0rrega-de-dades-a-factures-client-amb-deute-per-facilitar-gestions-de-pobresa-energ%C3%A8tica

## Comportament antic
S'havien d'avançar manualment les factures que estaven en estat pendent consulta pobresa

## Comportament nou
Es passen les factures que no compleixen els requisits de consulta pobresa al següent estat

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
