### PR TITLE
Afegir onchange a origin de factures account_invoice per emplenar si cal el camp reference

### DIFF
--- a/account_invoice_som/account_invoice_view.xml
+++ b/account_invoice_som/account_invoice_view.xml
@@ -11,7 +11,7 @@
                     <field name="payment_type" on_change="onchange_payment_type(payment_type, partner_id)" select="2" required="1"/>
                 </field>
                 <field name="origin" position="replace">
-                     <field name="origin" select="2" required="1"/>
+                     <field name="origin" select="2" required="1" on_change="onchange_origin(origin,reference)"/>
                 </field>
                 <field name="origin_date_invoice" position="replace">
                     <field name="origin_date_invoice" select="2" required="1"/>


### PR DESCRIPTION
## Objectiu

Afegir onchange a origin de factures account_invoice per emplenar si cal el camp reference

## Targeta on es demana o Incidència 

SAC 231014

## Comportament nou

Si s'emplena l'origin de factures account_invoice i no està informat el camp reference 

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul (account_invoice_som)
- [ ] Script de migració
- [ ] Modifica traduccions
