### PR TITLE
FIX d'script de migració per a som_polissa

### DIFF
--- a/som_polissa/migrations/5.0.23.9.0/post-0001_rename_category_desestiment.py
+++ b/som_polissa/migrations/5.0.23.9.0/post-0001_rename_category_desestiment.py
@@ -19,7 +19,7 @@ def up(cursor, installed_version):
         "giscedata_facturacio_bateria_virtual.categ_desestiment",
     ]
     load_data_records(
-        cursor, 'giscedata_facturacio_bateria_virtual', 'som_polissa_data.xml', list_of_records, mode='update'
+        cursor, 'som_polissa', 'som_polissa_data.xml', list_of_records, mode='update'
     )
     logger.info("XMLs succesfully updated.")
 


### PR DESCRIPTION
## Objectiu

Corretgir un script de migració de som_polissa que carregava un data del mòdul que no tocava. Introduït a la pr #421 

## Targeta on es demana o Incidència 
N/A

## Comportament antic
 No passava el script

## Comportament nou
Ara passa el script

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
    - som_polissa 
- [ ] Modifica traduccions
