### PR TITLE
create the semantic id for the hidden flux solar category

### DIFF
--- a/som_polissa/migrations/5.0.2.108/pre-0002_put_hidden_flux_solar_polissa_category_as_semantic_id.py
+++ b/som_polissa/migrations/5.0.2.108/pre-0002_put_hidden_flux_solar_polissa_category_as_semantic_id.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from oopgrade.oopgrade import load_data_records
+import logging
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Starting 'Flux Solar ocult a la OV' semantic id creation migration script")
+    load_data_records(
+        cursor, 'som_polissa', 'som_polissa_data.xml',
+        ['categ_flux_solar_ocult_ov']
+    )
+    logger.info("Finishing 'Flux Solar ocult a la OV' semantic id creation migration script")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa/som_polissa_data.xml
+++ b/som_polissa/som_polissa_data.xml
@@ -32,6 +32,10 @@
             <field name="name">Tarifa Empresa</field>
             <field name="code">TE </field>
         </record>
+        <record id="categ_flux_solar_ocult_ov" model="giscedata.polissa.category">
+            <field name="name">Flux Solar ocult a la OV</field>
+            <field name="code">HIDEFLUXOV</field>
+        </record>
     </data>
     <data>
         <record id="giscedata_facturacio_bateria_virtual.categ_desestiment" model="giscedata.polissa.category">


### PR DESCRIPTION
 Co-authored-by: Daniel Estanyol i Torres <daniel.estanyol@somenergia.coop>
 Co-authored-by: Pau Boix <pau.boix@somenergia.coop>

## Objectiu

Crear una categoria de pòlissa per marcar les polisses amb incidència de lectures de generació per que a la OV no surtin els sols del flux solar fins que no s'arregli la cagada de distri.

## Targeta on es demana o Incidència 

https://trello.com/c/05gWxB1o/165-bateria-crear-categoria-flux-solar-ocult-ov

## Comportament antic

No existia

## Comportament nou

Existeix

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
        som_polissa - pre-0002_put_hidden_flux_solar_polissa_category_as_semantic_id
- [ ] Modifica traduccions
