### PR TITLE
Fix bank details error in contract report

### DIFF
--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -677,9 +677,11 @@ CONTRACT_TYPES = dict(TABLA_9)
         <div class="styled_box">
             <h5> ${_("DADES DE PAGAMENT")} </h5>
             <% iban = polissa.bank and polissa.bank.printable_iban[5:] or '' %>
+            % if polissa.bank:
             <div class="dades_pagament">
                 <div class="iban"><b>${_(u"Nº de compte bancari (IBAN): **** **** **** ****")}</b> &nbsp ${iban[-4:]}</div>
             </div>
+            % endif
         </div>
         <div class="modi_condicions">
             <p>

--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -670,21 +670,6 @@ CONTRACT_TYPES = dict(TABLA_9)
                 &nbsp;${_(u"inclouen l'impost elèctric i l'IVA (IGIC a Canàries), amb el tipus impositiu vigent en cada moment per a cada tipus de contracte sense perjudici de les exempcions o bonificacions que puguin ser d'aplicació.")}
             </div>
         </div>
-            <%
-                if pas01:
-                    bank = pas01.pas_id.bank if pas01.pas_id.bank else polissa.bank
-                else:
-                    bank = polissa.bank
-
-                owner_b = polissa.bank.partner_id.name
-                nif = polissa.bank.partner_id.vat
-                pol_bank = bank.read(['owner_id'])
-                if 'owner_id' in pol_bank and bank.owner_name:
-                    owner_b = bank.owner_name
-                    if bank.owner_id:
-                        nif = bank.owner_id.vat
-                nif = nif.replace('ES', '')
-            %>
             %if text_vigencia:
                 <p style="page-break-after: always"></p>
                 <br><br><br>

--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -674,15 +674,15 @@ CONTRACT_TYPES = dict(TABLA_9)
                 <p style="page-break-after: always"></p>
                 <br><br><br>
             %endif
+        % if polissa.bank:
         <div class="styled_box">
             <h5> ${_("DADES DE PAGAMENT")} </h5>
             <% iban = polissa.bank and polissa.bank.printable_iban[5:] or '' %>
-            % if polissa.bank:
             <div class="dades_pagament">
                 <div class="iban"><b>${_(u"Nº de compte bancari (IBAN): **** **** **** ****")}</b> &nbsp ${iban[-4:]}</div>
             </div>
-            % endif
         </div>
+        % endif
         <div class="modi_condicions">
             <p>
                ${_(u"Al contractar s’accepten aquestes ")}


### PR DESCRIPTION
## Objectiu

Arreglar error que no permetia imprimir el contracte en alguns casos on el mètode de pagament no és per domiciliació bancària.

## Targeta on es demana o Incidència 

Incidència detectada en l'enviament massiu de les noves condicions pel Flux Solar.

## Comportament antic

- Hi havia codi que provocava errors que no es fa servir des de la següent PR:  #411 
- S'intenta obtenir l'IBAN en casos on no existeix

## Comportament nou

- S'elimina codi antic
- S'afegeix condicional per evitar mostrar el bloc de pagament quan no hi ha les dades

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
