### PR TITLE
Mostar el qr de la factura sempre que sigui possible

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2891,9 +2891,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data = {
             'is_visible': True,
             'lang': fact.lang_partner.lower(),
-            'link_qr': qr_data['url'] if max_potencies_demandades else 'https://comparador.cnmc.gob.es/',
+            'link_qr': qr_data['url'] if qr_data['url'] else 'https://comparador.cnmc.gob.es/',
             'has_gkwh': te_gkwh(fact),
-            'qr_image': qr_data['qr'] if max_potencies_demandades else '',
+            'qr_image': qr_data['qr'],
         }
         return data
 


### PR DESCRIPTION
## Objectiu

Es detecta una casuística per la qual un QR de la factura no es mostrava tot i que que es podia generar

## Targeta on es demana o Incidència 

Iniciativa pròpia

## Comportament antic

S'amagava el QR si no hi havien lectures de maxìmetre tot i que no son obligatòries per generar-ho

## Comportament nou

Es mostra el QR sempre que es generi

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
