### PR TITLE
Càlcul de la data del consum anual de la factura en pdf de forma mes ràpida

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1489,7 +1489,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         return data
 
-
     def get_conany_kwh_energy_consumption_graphic_td_data(self, cursor, uid, fact_id, context=None):
         """
         Simplification to avoid generate all the invoice data to get the year's kwh
@@ -1497,7 +1496,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         fac_obj = self.pool.get('giscedata.facturacio.factura')
         fact = fac_obj.browse(cursor, uid, fact_id, context)
         (historic, historic_js) = self.get_historic_data(fact)
-        mes_any_inicial = (datetime.strptime(fact.data_inici,'%Y-%m-%d') - timedelta(days=365)).strftime("%Y/%m")
+
+        data_inici_any = datetime.strptime(fact.data_inici, '%Y-%m-%d') - timedelta(days=365)
+        mes_any_inicial = data_inici_any.strftime("%Y/%m")
 
         conany_kwh = 0.0
         conany_kwh_p1 = 0.0
@@ -1533,7 +1534,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             'conany_kwh_p6': conany_kwh_p6,
         }
         return data
-
 
     def get_component_energy_consumption_graphic_td_data(self, fact, pol):
         """

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1530,7 +1530,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     conany_kwh_p6 += h['consum']
                 if data_ini is None or data_ini > h["data_ini"]:
                     data_ini = h["data_ini"]
-                if data_fin is None or data_fin > h["data_fin"]:
+                if data_fin is None or data_fin < h["data_fin"]:
                     data_fin = h["data_fin"]
 
         if data_ini and data_fin:
@@ -1540,12 +1540,12 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         data = {
             'consum': conany_kwh,
-            'p1': conany_kwh_p1,
-            'p2': conany_kwh_p2,
-            'p3': conany_kwh_p3,
-            'p4': conany_kwh_p4,
-            'p5': conany_kwh_p5,
-            'p6': conany_kwh_p6,
+            'P1': conany_kwh_p1,
+            'P2': conany_kwh_p2,
+            'P3': conany_kwh_p3,
+            'P4': conany_kwh_p4,
+            'P5': conany_kwh_p5,
+            'P6': conany_kwh_p6,
             'days': historic_dies,
         }
         return data

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1489,6 +1489,52 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         return data
 
+
+    def get_conany_kwh_energy_consumption_graphic_td_data(self, cursor, uid, fact_id, context=None):
+        """
+        Simplification to avoid generate all the invoice data to get the year's kwh
+        """
+        fac_obj = self.pool.get('giscedata.facturacio.factura')
+        fact = fac_obj.browse(cursor, uid, fact_id, context)
+        (historic, historic_js) = self.get_historic_data(fact)
+        mes_any_inicial = (datetime.strptime(fact.data_inici,'%Y-%m-%d') - timedelta(days=365)).strftime("%Y/%m")
+
+        conany_kwh = 0.0
+        conany_kwh_p1 = 0.0
+        conany_kwh_p2 = 0.0
+        conany_kwh_p3 = 0.0
+        conany_kwh_p4 = 0.0
+        conany_kwh_p5 = 0.0
+        conany_kwh_p6 = 0.0
+
+        for h in historic:
+            if h['mes'] > mes_any_inicial:
+                conany_kwh += h['consum']
+                if h['periode'] == 'P1':
+                    conany_kwh_p1 += h['consum']
+                elif h['periode'] == 'P2':
+                    conany_kwh_p2 += h['consum']
+                elif h['periode'] == 'P3':
+                    conany_kwh_p3 += h['consum']
+                elif h['periode'] == 'P4':
+                    conany_kwh_p4 += h['consum']
+                elif h['periode'] == 'P5':
+                    conany_kwh_p5 += h['consum']
+                elif h['periode'] == 'P6':
+                    conany_kwh_p7 += h['consum']
+
+        data = {
+            'conany_kwh': conany_kwh,
+            'conany_kwh_p1': conany_kwh_p1,
+            'conany_kwh_p2': conany_kwh_p2,
+            'conany_kwh_p3': conany_kwh_p3,
+            'conany_kwh_p4': conany_kwh_p4,
+            'conany_kwh_p5': conany_kwh_p5,
+            'conany_kwh_p6': conany_kwh_p6,
+        }
+        return data
+
+
     def get_component_energy_consumption_graphic_td_data(self, fact, pol):
         """
         return a dictionary with data needes for the consumption graphic and related text

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1521,7 +1521,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 elif h['periode'] == 'P5':
                     conany_kwh_p5 += h['consum']
                 elif h['periode'] == 'P6':
-                    conany_kwh_p7 += h['consum']
+                    conany_kwh_p6 += h['consum']
 
         data = {
             'conany_kwh': conany_kwh,

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1497,7 +1497,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         fact = fac_obj.browse(cursor, uid, fact_id, context)
         (historic, historic_js) = self.get_historic_data(fact)
 
-        data_inici_any = datetime.strptime(fact.data_inici, '%Y-%m-%d') - timedelta(days=365)
+        def get_as_time(text):
+            return datetime.strptime(text, '%Y-%m-%d')
+
+        data_inici_any = get_as_time(fact.data_inici) - timedelta(days=365)
         mes_any_inicial = data_inici_any.strftime("%Y/%m")
 
         conany_kwh = 0.0
@@ -1507,6 +1510,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         conany_kwh_p4 = 0.0
         conany_kwh_p5 = 0.0
         conany_kwh_p6 = 0.0
+        data_ini = None
+        data_fin = None
 
         for h in historic:
             if h['mes'] > mes_any_inicial:
@@ -1523,15 +1528,25 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     conany_kwh_p5 += h['consum']
                 elif h['periode'] == 'P6':
                     conany_kwh_p6 += h['consum']
+                if data_ini is None or data_ini > h["data_ini"]:
+                    data_ini = h["data_ini"]
+                if data_fin is None or data_fin > h["data_fin"]:
+                    data_fin = h["data_fin"]
+
+        if data_ini and data_fin:
+            historic_dies = (get_as_time(data_fin) - get_as_time(data_ini)).days
+        else:
+            historic_dies = 0
 
         data = {
-            'conany_kwh': conany_kwh,
-            'conany_kwh_p1': conany_kwh_p1,
-            'conany_kwh_p2': conany_kwh_p2,
-            'conany_kwh_p3': conany_kwh_p3,
-            'conany_kwh_p4': conany_kwh_p4,
-            'conany_kwh_p5': conany_kwh_p5,
-            'conany_kwh_p6': conany_kwh_p6,
+            'consum': conany_kwh,
+            'p1': conany_kwh_p1,
+            'p2': conany_kwh_p2,
+            'p3': conany_kwh_p3,
+            'p4': conany_kwh_p4,
+            'p5': conany_kwh_p5,
+            'p6': conany_kwh_p6,
+            'days': historic_dies,
         }
         return data
 

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -1636,7 +1636,7 @@ class Tests_FacturacioFacturaReport_invoice_details_reactive(Tests_FacturacioFac
                         "quantity": 60.0,
                     }
                 ],
-                "is_visible": False,
+                "is_visible": True,
             },
         )
 
@@ -1869,11 +1869,11 @@ class Tests_FacturacioFacturaReport_amount_destination(Tests_FacturacioFacturaRe
                 "is_visible": True,
                 "factura_id": 14,
                 "amount_total": 547.36,
-                "total_lloguers": 3.0,
-                "pie_total": 544.36,
+                "total_lloguers": 0.0,
+                "pie_total": 547.36,
                 "pie_regulats": 3.0,
                 "pie_impostos": 0.0,
-                "pie_costos": 541.36,
+                "pie_costos": 544.36,
                 "rep_BOE": {"i": 39.44, "c": 40.33, "o": 20.23},
             },
         )

--- a/som_infoenergia/giscedata_polissa.py
+++ b/som_infoenergia/giscedata_polissa.py
@@ -144,8 +144,8 @@ class GiscedataPolissaInfoenergia(osv.osv):
 
         conany = False
         try:
-            data = rprt_obj.get_components_data(cursor, uid, [ids[0]])
-            conany = data[data.keys()[0]].energy_consumption_graphic_td.total_any
+            data = rprt_obj.get_conany_kwh_energy_consumption_graphic_td_data(cursor, uid, ids[0])
+            conany = data['conany_kwh']
         except Exception:
             pass
 

--- a/som_infoenergia/giscedata_polissa.py
+++ b/som_infoenergia/giscedata_polissa.py
@@ -142,14 +142,22 @@ class GiscedataPolissaInfoenergia(osv.osv):
         if not ids:
             return False
 
-        conany = False
         try:
             data = rprt_obj.get_conany_kwh_energy_consumption_graphic_td_data(cursor, uid, ids[0])
-            conany = data['conany_kwh']
         except Exception:
-            pass
+            return False
 
-        return conany
+        limit_days = eval(self.pool.get("res.config").get(
+            cursor, uid, "som_conany_pdf_days_limit", "[355,375]"
+        ))
+        min_days = min(limit_days)
+        max_days = max(limit_days)
+        if min_days > data['days'] or data['days'] > max_days:
+            return False
+
+        data.pop('days')
+        data.pop('consum')
+        return data
 
     def _conany_updater(self, cursor, uid, context=None):
         cups_obj = self.pool.get("giscedata.cups.ps")

--- a/som_infoenergia/migrations/5.0.24.5.0/post-0001_reload_to_create_a_new_configuration_variable.py
+++ b/som_infoenergia/migrations/5.0.24.5.0/post-0001_reload_to_create_a_new_configuration_variable.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Creating pooler")
+
+    # UPATAR UN XML SENCER##
+    logger.info("Updating XML som_infoenergia_data.xml")
+    load_data(
+        cursor, 'som_infoenergia', 'som_infoenergia_data.xml', idref=None,
+        mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_infoenergia/som_infoenergia_data.xml
+++ b/som_infoenergia/som_infoenergia_data.xml
@@ -370,5 +370,10 @@
             <field name="value">0</field>
             <field name="description">Numero màxim de workers dedicats a crear enviaments d'Infoenergia en paral·lel. Si s'indica '0' (per defecte), no hi ha limit.</field>
         </record>
+        <record model="res.config" id="som_conany_pdf_days_limit" >
+            <field name="name">som_conany_pdf_days_limit</field>
+            <field name="value">[355,375]</field>
+            <field name="description">Dies minim i maxim per considerar que el consum anual calculat via pdf és correcte.</field>
+        </record>
     </data>
 </openerp>

--- a/som_polissa/giscedata_cups.py
+++ b/som_polissa/giscedata_cups.py
@@ -10,13 +10,13 @@ class GiscedataCupsPs(osv.osv):
     _inherit = "giscedata.cups.ps"
 
     _NEW_ORIGENS_CONANY = [
-        ("consums", _(u"Historic consums")),
-        ("factures", _(u"Historic factures")),
-        ("pdf", _(u"Consum 12 factures")),
-        ("consums_periods", _(u"> 12 factures: Historic consums per periodes")),
-        ("estadistic", _(u"< 3 factures: Estadística SOM")),
-        ("usuari", _(u"usuari (webforms)")),
-        ("cnmc", _(u"Entre 3 i 12 factures: Estadística CNMC")),
+        ("consums", _(u"5_Historic consums")),
+        ("factures", _(u"4_Historic factures")),
+        ("pdf", _(u"1_Consum 12 factures")),
+        ("consums_periods", _(u"3_> 12 factures: Historic consums per periodes")),
+        ("estadistic", _(u"1000_< 3 factures: Estadística SOM")),
+        ("usuari", _(u"100_usuari (webforms)")),
+        ("cnmc", _(u"500_Entre 3 i 12 factures: Estadística CNMC")),
     ]
 
     def __init__(self, pool, cursor):

--- a/som_polissa/giscedata_cups.py
+++ b/som_polissa/giscedata_cups.py
@@ -12,7 +12,7 @@ class GiscedataCupsPs(osv.osv):
     _NEW_ORIGENS_CONANY = [
         ("consums", _(u"Historic consums")),
         ("factures", _(u"Historic factures")),
-        ("pdf", _(u"Pdf última factura")),
+        ("pdf", _(u"Consum 12 factures")),
         ("consums_periods", _(u"> 12 factures: Historic consums per periodes")),
         ("estadistic", _(u"< 3 factures: Estadística SOM")),
         ("usuari", _(u"usuari (webforms)")),
@@ -55,10 +55,11 @@ class GiscedataCupsPs(osv.osv):
                 "origen": "factures",
             },
             {
-                "priority": 3,
+                "priority": 1,
                 "model": "giscedata.polissa",
                 "func": "get_consum_anual_pdf",
                 "origen": "pdf",
+                "periods": True,
             },
             {
                 "priority": 100,

--- a/som_polissa/giscedata_cups.py
+++ b/som_polissa/giscedata_cups.py
@@ -12,7 +12,7 @@ class GiscedataCupsPs(osv.osv):
     _NEW_ORIGENS_CONANY = [
         ("consums", _(u"5_Historic consums")),
         ("factures", _(u"4_Historic factures")),
-        ("pdf", _(u"1_Consum 12 factures")),
+        ("pdf", _(u"1_Consum 12 mesos")),
         ("consums_periods", _(u"3_> 12 factures: Historic consums per periodes")),
         ("estadistic", _(u"1000_< 3 factures: Estadística SOM")),
         ("usuari", _(u"100_usuari (webforms)")),

--- a/som_polissa/giscedata_cups.py
+++ b/som_polissa/giscedata_cups.py
@@ -71,7 +71,7 @@ class GiscedataCupsPs(osv.osv):
                 "priority": 3,
                 "model": "giscedata.polissa",
                 "func": "get_consum_anual_backend_gisce",
-                "origen": "consums",
+                "origen": "consums_periods",
                 "periods": True,
             },
             {

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -744,7 +744,7 @@ class GiscedataPolissa(osv.osv):
 
         return factura_backend_obj.get_grafica_historic_consum_14_mesos(
             cursor, uid, last_inv[0], context=context
-        )[0]
+        )
 
     def get_consum_anual_backend_gisce(self, cursor, uid, polissa_id, context=None):
         """Consum anual segons query de del backend de la factura de GISCE"""

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -744,7 +744,7 @@ class GiscedataPolissa(osv.osv):
 
         return factura_backend_obj.get_grafica_historic_consum_14_mesos(
             cursor, uid, last_inv[0], context=context
-        )
+        )[0]
 
     def get_consum_anual_backend_gisce(self, cursor, uid, polissa_id, context=None):
         """Consum anual segons query de del backend de la factura de GISCE"""

--- a/som_polissa/tests/giscedata_polissa_tests.py
+++ b/som_polissa/tests/giscedata_polissa_tests.py
@@ -29,7 +29,7 @@ class TestGisceDataCups(testing.OOTestCase):
         "giscedata_facturacio_comer.giscedata_facturacio_report_v2.GiscedataFacturacioFacturaReportV2.get_grafica_historic_consum_14_mesos"  # noqa: E501
     )
     def test__get_consum_anual_backend_gisce__lessThan12(self, mock_function):
-        mock_function.return_value = {
+        mock_function.return_value = [{
             u"historic": {
                 u"average_consumption": u"23,35",
                 u"average_cost": u"4,95",
@@ -45,7 +45,10 @@ class TestGisceDataCups(testing.OOTestCase):
                 {u"P1": u"132,00", u"P2": u"92,00", u"P3": u"194,00", u"mes": u"2023/07"},
                 {u"P1": u"183,00", u"P2": u"99,00", u"P3": u"256,00", u"mes": u"2023/08"},
             ],
-        }
+        }, {
+            'columns': [['P1'], ['P2'], ['P3'], ['P4'], ['P5'], ['P6']],
+            'x_labels': [u"2023/07", u"2023/08"],
+        }]
 
         result = self.pol_obj.get_consum_anual_backend_gisce(
             self.cursor, self.uid, self.contract_20TD_id
@@ -57,7 +60,7 @@ class TestGisceDataCups(testing.OOTestCase):
         "giscedata_facturacio_comer.giscedata_facturacio_report_v2.GiscedataFacturacioFacturaReportV2.get_grafica_historic_consum_14_mesos"  # noqa: E501
     )
     def test__get_consum_anual_backend_gisce__noInvoices(self, mock_function):
-        mock_function.return_value = {}
+        mock_function.return_value = [{}, {}]
 
         result = self.pol_obj.get_consum_anual_backend_gisce(
             self.cursor, self.uid, self.contract_20TD_id
@@ -69,7 +72,7 @@ class TestGisceDataCups(testing.OOTestCase):
         "giscedata_facturacio_comer.giscedata_facturacio_report_v2.GiscedataFacturacioFacturaReportV2.get_grafica_historic_consum_14_mesos"  # noqa: E501
     )
     def test__get_consum_anual_backend_gisce__moreThan12(self, mock_function):
-        mock_function.return_value = {
+        mock_function.return_value = [{
             u"historic": {
                 u"average_consumption": u"23,35",
                 u"average_cost": u"4,95",
@@ -97,7 +100,12 @@ class TestGisceDataCups(testing.OOTestCase):
                 {u"P1": u"132,00", u"P2": u"92,00", u"P3": u"194,00", u"mes": u"2023/07"},
                 {u"P1": u"183,00", u"P2": u"99,00", u"P3": u"256,00", u"mes": u"2023/08"},
             ],
-        }
+        }, {
+            'columns': [['P1'], ['P2'], ['P3'], ['P4'], ['P5'], ['P6']],
+            'x_labels': [
+                u"2022/07", u"2022/08", u"2022/09"
+            ],
+        }]
 
         result = self.pol_obj.get_consum_anual_backend_gisce(
             self.cursor, self.uid, self.contract1_id
@@ -109,7 +117,7 @@ class TestGisceDataCups(testing.OOTestCase):
         "giscedata_facturacio_comer.giscedata_facturacio_report_v2.GiscedataFacturacioFacturaReportV2.get_grafica_historic_consum_14_mesos"  # noqa: E501
     )
     def test__get_consum_prorrageig_cnmc__lessThan2(self, mock_function):
-        mock_function.return_value = {
+        mock_function.return_value = [{
             u"historic": {
                 u"average_consumption": u"23,35",
                 u"average_cost": u"4,95",
@@ -125,7 +133,10 @@ class TestGisceDataCups(testing.OOTestCase):
                 {u"P1": u"132,00", u"P2": u"92,00", u"P3": u"194,00", u"mes": u"2023/07"},
                 {u"P1": u"183,00", u"P2": u"99,00", u"P3": u"256,00", u"mes": u"2023/08"},
             ],
-        }
+        }, {
+            'columns': [['P1'], ['P2'], ['P3'], ['P4'], ['P5'], ['P6']],
+            'x_labels': [u"2023/07", u"2023/08"],
+        }]
 
         result = self.pol_obj.get_consum_prorrageig_cnmc(
             self.cursor, self.uid, self.contract_20TD_id
@@ -137,7 +148,7 @@ class TestGisceDataCups(testing.OOTestCase):
         "giscedata_facturacio_comer.giscedata_facturacio_report_v2.GiscedataFacturacioFacturaReportV2.get_grafica_historic_consum_14_mesos"  # noqa: E501
     )
     def test__get_consum_prorrageig_cnmc__noInvoices(self, mock_function):
-        mock_function.return_value = {}
+        mock_function.return_value = [{}, {}]
 
         result = self.pol_obj.get_consum_prorrageig_cnmc(
             self.cursor, self.uid, self.contract_20TD_id
@@ -149,7 +160,7 @@ class TestGisceDataCups(testing.OOTestCase):
         "giscedata_facturacio_comer.giscedata_facturacio_report_v2.GiscedataFacturacioFacturaReportV2.get_grafica_historic_consum_14_mesos"  # noqa: E501
     )
     def test__get_consum_prorrageig_cnmc__moreThan2(self, mock_function):
-        mock_function.return_value = {
+        mock_function.return_value = [{
             u"historic": {
                 u"average_consumption": u"23,35",
                 u"average_cost": u"4,95",
@@ -170,7 +181,12 @@ class TestGisceDataCups(testing.OOTestCase):
                 {u"P1": u"93,00", u"P2": u"67,00", u"P3": u"234,00", u"mes": u"2023/05"},
                 {u"P1": u"88,00", u"P2": u"66,00", u"P3": u"172,00", u"mes": u"2023/06"},
             ],
-        }
+        }, {
+            'columns': [['P1'], ['P2'], ['P3'], ['P4'], ['P5'], ['P6']],
+            'x_labels': [
+                u"2022/07", u"2022/08", u"2023/02", u"2023/03", u"2023/04", u"2023/05", u"2023/06"
+            ],
+        }]
 
         result = self.pol_obj.get_consum_prorrageig_cnmc(self.cursor, self.uid, self.contract1_id)
 


### PR DESCRIPTION
## Objectiu

Cal extreure la data del consum anual de forma mes ràpida que l'actual per tal de que sigui utilitzada per scripts d'update. 

## Targeta on es demana o Incidència 

https://trello.com/c/QfkXlelQ/309-ajustos-i-prioritzaci%C3%B3-m%C3%A8todes-de-c%C3%A0lcul-del-consum-anual-%C3%A0lies-conany

## Comportament antic

molt lent del ordre de 5 segons per petició

## Comportament nou

molt ràpid del ordre de 0.01 segons per petició amb menys overhead de memória

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
