### PR TITLE
Arreglar bug execució crawlers en dies festius

### DIFF
--- a/som_crawlers/models/som_crawlers_holiday.py
+++ b/som_crawlers/models/som_crawlers_holiday.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from osv import osv, fields
-
+from enerdata.calendars import REECalendar
+from datetime import datetime
 
 class SomCrawlersHoliday(osv.osv):
 
@@ -8,12 +9,19 @@ class SomCrawlersHoliday(osv.osv):
     _order = "date desc"
 
     def is_working_day(self, cursor, uid, date):
-        res = self.search(cursor, uid, [("date", "=", date)])
-        return not res
+        if isinstance(date, datetime):
+            date = date.strftime("%Y-%m-%d")
+        sch_obj = self.pool.get("som.crawlers.holiday")
+        ree_calendar = REECalendar()
+
+        return (
+            ree_calendar.is_working_day(date)
+            and date.weekday() in [0, 1, 2, 3, 4]
+            and not self.search(cursor, uid, [("date", "=", date)])
+        )
 
     def is_leaving_day(self, cursor, uid, date):
-        res = self.search(cursor, uid, [("date", "=", date)])
-        return res
+        return not self.is_working_day(cursor, uid, date)
 
     _columns = {
         "description": fields.char("Descripcio", size=100),

--- a/som_crawlers/models/som_crawlers_task.py
+++ b/som_crawlers/models/som_crawlers_task.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from osv import osv, fields
 from tools.translate import _
 from oorq.decorators import job
-from enerdata.calendars import REECalendar
 from . import exceptions
 
 
@@ -130,6 +129,10 @@ class SomCrawlersTask(osv.osv):
     def executar_tasca(self, cursor, uid, id, context=None):
         classresult = self.pool.get("som.crawlers.result")
         classTaskStep = self.pool.get("som.crawlers.task.step")
+        sch_obj = self.pool.get("som.crawlers.holiday")
+
+        if sch_obj.is_leaving_day(cursor, uid, datetime.today()):
+            self.schedule_next_execution(cursor, uid, id, context)
         task_obj = self.browse(cursor, uid, id)
         task_steps_list = task_obj.task_step_ids
         task_steps_list.sort(key=lambda x: x.sequence)
@@ -182,14 +185,6 @@ class SomCrawlersTask(osv.osv):
     def get_next_execution_date(self, cursor, uid, prev_date, context=None):
 
         sch_obj = self.pool.get("som.crawlers.holiday")
-        ree_calendar = REECalendar()
-
-        def workable_day(date):
-            return (
-                ree_calendar.is_working_day(date)
-                and date.weekday() in [0, 1, 2, 3, 4]
-                and sch_obj.is_working_day(cursor, uid, date.strftime("%Y-%m-%d"))
-            )
 
         if context and "datetime_now" in context:
             now = context["datetime_now"]
@@ -197,7 +192,7 @@ class SomCrawlersTask(osv.osv):
             now = datetime.now()
         date = now + timedelta(days=1)
 
-        while not workable_day(date):
+        while not sch_obj.is_working_day(cursor,uid, date):
             date += timedelta(days=1)
 
         date_proxima_exec = prev_date.replace(


### PR DESCRIPTION
## Objectiu
Assegurar que els crawlers no s'executen en dies festius

## Targeta on es demana o Incidència 
https://secure.helpscout.net/conversation/2445489759/16134390?folderId=3063374

## Comportament antic
Els crawlers es podien executar en dies festius, en cas de que els dies previs hagués fallat.

## Comportament nou

- S'ha canviat el model de `som.crawlers.holidays` perquè retorni dia festiu o no festiu en funció dels dies del model i també del calendari de REE.
- En cas de que s'intenti executar un crawler en dia festiu, no s'executarà, i es saltarà al següent dia laborable.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
