### PR TITLE
Automatisme per la creació automàtica de reclamacions 006 quan no arriben els F1 de les pòlisses

### DIFF
--- a/som_autoreclama/giscedata_atc.py
+++ b/som_autoreclama/giscedata_atc.py
@@ -122,8 +122,10 @@ class GiscedataAtc(osv.osv):
             generate_r1_wiz = r1atcw_obj.generate_r1(
                 cursor, uid, [r1atcw_id], r1atcw_ctx
             )  # Generates the R1 for the ATC case
-
-            r1w_ctx = eval(generate_r1_wiz["context"])
+            if type(generate_r1_wiz["context"]) == dict:
+                r1w_ctx = generate_r1_wiz["context"]
+            else:
+                r1w_ctx = eval(generate_r1_wiz["context"])
             r1w_obj = self.pool.get(generate_r1_wiz["res_model"])  # "wizard.create.r1"
             r1w_id = r1w_obj.create(cursor, uid, {}, r1w_ctx)
             subtype_r1_wiz = r1w_obj.action_subtype_fields_view(


### PR DESCRIPTION
## Objectiu

Generar l'automatisme per tal de que a partir de les pòlisses i el camp de "dates últimes lectures facturades" "De F1" es generin reclamacions tipus 006 amb un automatisme similar al emprat per generar les 029 dels casos ATC.

## Targeta on es demana o Incidència 

https://trello.com/c/fKhkY0GB/178-get-reclamaci%C3%B3-autom%C3%A0tica-per-006

## Comportament antic

Només es feien les reclamacions 029

## Comportament nou

Es fan les reclamacions 006 a partir de pòlissa

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
        som_autoreclama
- [ ] Script de migració
- [ ] Modifica traduccions
