### PR TITLE
allow tags for contracts cobraments and reclama

### DIFF
--- a/som_switching/wizard/wizard_create_atc_from_polissa.py
+++ b/som_switching/wizard/wizard_create_atc_from_polissa.py
@@ -24,22 +24,34 @@ class WizardCreateAtc(osv.osv_memory):
         section_id = res['value']['section_id']
         seccio = False
         mostrar_tag = False
+        factura_tag = False
 
         section_obj = self.pool.get('crm.case.section')
         if section_id:
             seccio = section_obj.read(cursor, uid, section_id, ['code'])['code']
         if seccio:
-            mostrar_tag = True if seccio == 'ATCF' else False
+            if seccio == 'ATCF' or seccio == 'ATCC' or seccio == 'ATCR' or seccio == 'ATCCB':
+                mostrar_tag = True
+            else:
+                 mostrar_tag = False
+            factura_tag = True if seccio == 'ATCF' else False
         res['value']['mostrar_tag'] = mostrar_tag
+        res['value']['factura_tag'] = factura_tag
         return res
 
     def onchange_section(self, cursor, uid, ids, section_id):
         res = False
+        mostrar_tag = False
+        factura_tag = False
         section_obj = self.pool.get('crm.case.section')
         seccio = section_obj.read(cursor, uid, section_id, ['code'])['code']
         if seccio:
-            mostrar_tag = True if seccio == 'ATCF' else False
-        return {'value': {'mostrar_tag': mostrar_tag},
+            if seccio == 'ATCF' or seccio == 'ATCC' or seccio == 'ATCR' or seccio == 'ATCCB':
+                mostrar_tag = True
+            else:
+                mostrar_tag = False
+            factura_tag = True if seccio == 'ATCF' else False
+        return {'value': {'mostrar_tag': mostrar_tag, 'factura_tag': factura_tag},
                 'domain': {},
                 'warning': {},
                 }
@@ -47,6 +59,7 @@ class WizardCreateAtc(osv.osv_memory):
     _columns = {
         'tag': fields.many2one('giscedata.atc.tag', "Etiqueta"),
         'mostrar_tag': fields.boolean(u'Mostrar_tag'),
+        'factura_tag': fields.boolean(u'factura_tag'),
     }
     _defaults = {
         'mostrar_tag': lambda *a: False,

--- a/som_switching/wizard/wizard_create_atc_from_polissa.xml
+++ b/som_switching/wizard/wizard_create_atc_from_polissa.xml
@@ -10,8 +10,9 @@
                     <field name="section_id" position="replace">
                         <field name="section_id" on_change="onchange_section(section_id)"/>
                         <field name="mostrar_tag" invisible="1"/>
+                        <field name="factura_tag" invisible="1"/>
                             <group colspan="15"  attrs="{'invisible': [('mostrar_tag','!=',True)]}" >
-                                <field name="tag" attrs="{'required': [('mostrar_tag','==',True)]}" domain="[('active','=',True)]"/>
+                                <field name="tag" attrs="{'required': [('factura_tag','==',True)]}" domain="[('active','=',True)]"/>
                             </group>
                     </field>
                 </field>


### PR DESCRIPTION
## Objectiu
Afegir l'opció d'etiquetes per contractes cobraments i reclama

## Targeta on es demana o Incidència 
https://trello.com/c/hc1UqZwv/267-fer-visible-camp-i-model-per-etiquetatge-de-cacs-per-contractes-cobraments-i-reclama

## Comportament antic
Només podia utilitzar factura les etiquetes

## Comportament nou
També contractes cobraments i reclama

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
