### PR TITLE
Fer que l'històric d'autoconsum sigui modificable

### DIFF
--- a/som_polissa/giscedata_cups_view.xml
+++ b/som_polissa/giscedata_cups_view.xml
@@ -14,5 +14,43 @@
                 </field>
             </field>
         </record>
+
+        <!-- Habilitem l'edició de l'històric d'autoconsums -->
+        <record model="ir.ui.view" id="view_cups_ps_hist_autoconsum_form_som">
+            <field name="name">view.cups.ps.hist.autoconsum.form.som</field>
+            <field name="model">giscedata.cups.ps</field>
+            <field name="inherit_id" ref="giscedata_cups.view_cups_ps_hist_autoconsum_form"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="hist_autoconsum" position="replace">
+                    <field name="hist_autoconsum" nolabel="1" context="{'default_cups_id': active_id}" readonly="0"/>
+                </field>
+            </field>
+        </record>
+
+        <!-- Habilitem la modificació dels camps de l'històric d'autoconsums -->
+        <record model="ir.ui.view" id="view_autoconsum_cups_form_som">
+            <field name="name">giscedata_autoconsum.cups.form.som</field>
+            <field name="model">giscedata.autoconsum.cups.autoconsum</field>
+            <field name="inherit_id" ref="giscedata_cups.view_autoconsum_cups_form"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="cups_id" position="replace">
+                    <field name="cups_id" colspan="4" readonly="0"/>
+                </field>
+                <field name="autoconsum_id" position="replace">
+                    <field name="autoconsum_id" colspan="4" readonly="0"/>
+                </field>
+                <field name="tipus_cups" position="replace">
+                    <field name="tipus_cups" colspan="4" readonly="0"/>
+                </field>
+                <field name="data_inici" position="replace">
+                    <field name="data_inici" colspan="4" readonly="0"/>
+                </field>
+                <field name="data_final" position="replace">
+                    <field name="data_final" colspan="4" readonly="0"/>
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/som_polissa/migrations/5.0.24.5.0/post-0001_makes_cups_autoconsum_not_read_only.py
+++ b/som_polissa/migrations/5.0.24.5.0/post-0001_makes_cups_autoconsum_not_read_only.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from oopgrade.oopgrade import load_data
+import logging
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Update giscedata_cups_view.xml")
+    load_data(
+        cursor, 'som_polissa', 'giscedata_cups_view.xml', idref=None, mode='update'
+    )
+    logger.info("End updating giscedata_cups_view.xml")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Fer que l'històric d'autoconsum sigui modificable

## Targeta on es demana o Incidència

https://trello.com/c/0LH8fgDE/6027-modificar-data-hist%C3%B2ric-autoconsum

## Comportament antic

Era readonly

## Comportament nou

Ja no és readonly

## Comprovacions

- [x] Reiniciar serveis
- [x] Actualitzar mòdul
    - som_polissa
- [x] Script de migració
    - post-0001_makes_cups_autoconsum_not_read_only.py
