### PR TITLE
Permetre importar Zips de distris quan estan plen amb zips mal-formats

### DIFF
--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -260,9 +260,13 @@ class SomCrawlersTaskStep(osv.osv):
         return output
 
     def recursive_extract_zip(self, zip_path, destination_path):
-        with zipfile.ZipFile(zip_path, "r") as zip_file:
-            zip_file.extractall(path=destination_path)
-        os.remove(zip_path)
+        try:
+            with zipfile.ZipFile(zip_path, "r") as zip_file:
+                zip_file.extractall(path=destination_path)
+        except:
+            pass
+        finally:
+            os.remove(zip_path)
 
         for root, dirs, files in os.walk(destination_path):
             for filename in files:

--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -260,13 +260,10 @@ class SomCrawlersTaskStep(osv.osv):
         return output
 
     def recursive_extract_zip(self, zip_path, destination_path):
-        try:
+        if os.path.getsize(zip_path) > 0:
             with zipfile.ZipFile(zip_path, "r") as zip_file:
                 zip_file.extractall(path=destination_path)
-        except:
-            pass
-        finally:
-            os.remove(zip_path)
+        os.remove(zip_path)
 
         for root, dirs, files in os.walk(destination_path):
             for filename in files:


### PR DESCRIPTION
## Objectiu

Permetre importar zips encara que els distris ens posin fitxers zip erronis o mal-formats dins P.Ex: zips amb mida 0

## Targeta on es demana o Incidència

Bugbusting diari, repàs de crawlers, distri pitarch

## Comportament antic

Fallava i no extreia els xml

## Comportament nou

Extreu els xml que pot

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
