### PR TITLE
Afegir els identificadors per les noves posicions fiscals de canaries al wizard de canvi cap a indexada

### DIFF
--- a/som_indexada/wizard/wizard_change_to_indexada.py
+++ b/som_indexada/wizard/wizard_change_to_indexada.py
@@ -52,7 +52,7 @@ CHANGE_AUX_VALUES = {
     },
 }
 
-FISCAL_POSITIONS_CANARIES = [19, 25, 33, 34, 38, 39]
+FISCAL_POSITIONS_CANARIES = [19, 25, 33, 34, 38, 39, 47, 48, 52, 53]
 
 
 class WizardChangeToIndexada(osv.osv_memory):


### PR DESCRIPTION
## Objectiu

Que quan es faci un canvi a indexada amb una de les posicions fiscals noves de canaries (les del 2.5) es realitzi correctament al selecció de tarifa desitjada.

## Targeta on es demana o Incidència

https://secure.helpscout.net/conversation/2506145314/16467991

## Comportament antic

Realitzava el canvi de tarifa malament, es genera una mod contractual apuntant a una tarifa incorrecta

## Comportament nou

Es realitza correctament

## Comprovacions

- [ ] Hi ha testos
- [X] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
