### PR TITLE
🐛 Paràmetre per ctx de force_pricelist com a enter en comptes de browse

### DIFF
--- a/som_polissa_condicions_generals/report/condicions_particulars.mako
+++ b/som_polissa_condicions_generals/report/condicions_particulars.mako
@@ -598,7 +598,7 @@ CONTRACT_TYPES = dict(TABLA_9)
                             <% llista_preu = ultima_modcon.llista_preu if modcon_pendent_periodes else polissa.llista_preu %>
                             %for p in periodes_energia:
                                 %if llista_preu and not lead:
-                                    <% ctx['force_pricelist'] = llista_preu %>
+                                    <% ctx['force_pricelist'] = llista_preu.id %>
                                     <td class="center">
                                         <span class="">${formatLang(get_atr_price(cursor, uid, polissa, p, 'te', ctx, with_taxes=True)[0], digits=6)}</span>
                                     </td>


### PR DESCRIPTION
## Objectiu
Ens hem adonat que la variable force_pricelist que es passa per context al get_atr_price  ha de ser un enter, i no un browse. https://github.com/gisce/erp/pull/16759

## Targeta on es demana o Incidència
Fent la targeta del canvi de versió: https://trello.com/c/tUJH4zmT/5867-versi%C3%B3-nova-erp-previ?filter=member:oriolpiera
PR Origen: https://github.com/Som-Energia/openerp_som_addons/pull/391

## Comportament antic
No s'imprimien els contractes a pre-producció

## Comportament nou
S'imprimeixen els contractes

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
