### PR TITLE
FIX Vista heretada de contracte lot a v.23.9

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot_view.xml
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot_view.xml
@@ -43,10 +43,10 @@
                     <field name="te_generation_polissa" select="2"/>
                     <field name="data_alta_auto" select="2"/>
                 </field>
-                <field name="status" position="before">
+                <field name="status_tree" position="before">
                     <field name="import_factures" select="2" />
                 </field>
-                <field name="status" position="after">
+                <field name="status_tree" position="after">
                     <field name="info_gestions_massives" select="2" />
                 </field>
             </field>

--- a/som_facturacio_comer/migrations/5.0.24.5.0/post-0001_load_views_contracte_lot_tree.py
+++ b/som_facturacio_comer/migrations/5.0.24.5.0/post-0001_load_views_contracte_lot_tree.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+
+    logger.info("Updating XML record for view polisses.facturacio.contracte.lot.som.tree")
+    load_data_records(
+        cursor, "som_facturacio_comer", "giscedata_facturacio_contracte_lot_view.xml",
+        ["view_giscedata_facturacio_contracte_lot_som_tree"], idref=None, mode="update"
+    )
+
+    logger.info("XML record succesfully updatd.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Corretgir herència de vista tree de contracte lot per substitució del camp status a la v23.9
Requereix v23.9 o tenir aplicada la PR de Gisce https://github.com/gisce/erp/pull/16838

## Targeta on es demana o Incidència

https://trello.com/c/tUJH4zmT/5867-versi%C3%B3-nova-erp-previ

## Comportament antic

Raise per mala herència de vistes

## Comportament nou

Correcció de camp referenciat

## Comprovacions

- [x] Actualitzar mòdul
    - som_facturacio_comer
- [x] Script de migració
    - post-0001_load_views_contracte_lot_tree
