### PR TITLE
Update destino to 2024 BOE and fix FS

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2704,7 +2704,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             lines_data[block]["date_to_d"] = (
                 val(l.data_fins)
                 if "date_to_d" not in lines_data[block]
-                or lines_data[block]["date_to_d"] < val(l.data_fins)
+                or lines_data[block]["date_to_d"] > val(l.data_fins)
                 else lines_data[block]["date_to_d"]
             )
             lines_data[block]["date_to"] = dateformat(lines_data[block]["date_to_d"])

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3395,6 +3395,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             if line.tipus in ("altres", "cobrament") and line.product_id.code == "PBV":
                 flux_solar += line.price_subtotal
 
+        has_flux = flux_solar > 0
         amount_total = fact.amount_total - flux_solar
 
         # Repartiment segons BOE
@@ -3456,6 +3457,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "pie_energy": pie_energy,
             "pie_total": pie_total,
             "rep_BOE": rep_BOE,
+            "has_flux": has_flux,
         }
         return data
 

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3389,10 +3389,18 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         if not is_TD(pol):
             return {"is_visible": False}
 
+        # Remove the discounts from the amount total
+        flux_solar = 0
+        for line in fact.linia_ids:
+            if line.tipus in ("altres", "cobrament") and line.product_id.code == "PBV":
+                flux_solar += line.price_subtotal
+
+        amount_total = fact.amount_total + flux_solar
+
         # Repartiment segons BOE
         rep_BOE = {"r": 0.76, "d": 71.0, "t": 27.58, "o": 0.66}
 
-        pie_total = round(fact.amount_total, 2)
+        pie_total = round(amount_total, 2)
         pie_renting = round(fact.total_lloguers, 2)
         pie_taxes = round(float(fact.amount_tax), 2)
         pie_tolls = round(fact.total_atr, 2)
@@ -3440,7 +3448,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data = {
             "is_visible": is_TD(pol),
             "factura_id": fact.id,
-            "amount_total": fact.amount_total,
+            "amount_total": amount_total,
             "pie_renting": pie_renting,
             "pie_taxes": pie_taxes,
             "pie_tolls": pie_tolls,

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3390,7 +3390,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             return {"is_visible": False}
 
         # Repartiment segons BOE
-        rep_BOE = {"r": 0.0, "d": 81.0, "t": 18.0, "o": 1.0}
+        rep_BOE = {"r": 0.76, "d": 71.0, "t": 27.58, "o": 0.66}
 
         pie_total = round(fact.amount_total, 2)
         pie_renting = round(fact.total_lloguers, 2)

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3395,7 +3395,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             if line.tipus in ("altres", "cobrament") and line.product_id.code == "PBV":
                 flux_solar += line.price_subtotal
 
-        amount_total = fact.amount_total + flux_solar
+        amount_total = fact.amount_total - flux_solar
 
         # Repartiment segons BOE
         rep_BOE = {"r": 0.76, "d": 71.0, "t": 27.58, "o": 0.66}

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -1,7 +1,7 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
 # * giscedata_facturacio_comer_som
-# 
+#
 # Translators:
 #   <>, 2017, 2018, 2019, 2020.
 # Agustí Fita <afita@gisce.net>, 2018.

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2024-03-08 13:16+0000\n"
-"PO-Revision-Date: 2024-03-08 12:18+0000\n"
+"POT-Creation-Date: 2024-03-15 12:29+0000\n"
+"PO-Revision-Date: 2024-03-15 11:33+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3637
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3647
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -54,7 +54,7 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3667
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3677
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
@@ -90,7 +90,7 @@ msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3541
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3551
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
@@ -108,7 +108,7 @@ msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3573
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3583
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
@@ -124,7 +124,7 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3606
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3616
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
@@ -259,7 +259,7 @@ msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
 msgstr "DESTINO DEL IMPORTE DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:52
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
 msgstr "El destino del importe de tu factura, %s euros, es el siguiente:"
@@ -272,12 +272,12 @@ msgid ""
 msgstr "A los importes indicados en el diagrama debe añadirse, en su caso, el alquiler de los equipos de medida y control: %s €."
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
-msgid "RECORE: retribució a les renovables, cogeneració i residus"
-msgstr "RECORE: retribución a las renovables, cogeneración y residuos"
-
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
 msgid "Anualitat del dèficit"
 msgstr "Anualidad del déficit"
+
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
+msgid "RECORE: retribució a les renovables, cogeneració i residus"
+msgstr "RECORE: retribución a las renovables, cogeneración y residuos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
 msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
@@ -306,6 +306,13 @@ msgstr "Cargos"
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
 msgid "Energia"
 msgstr "Energía"
+
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:50
+#, python-format
+msgid ""
+"El destí de l'import de la teva factura sense flux solar, %s euros, és el "
+"següent:"
+msgstr "El destino del importe de tu factura sin flux solar, %s euros, es el siguiente:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:10
 msgid "COMPARADOR DE PREUS DE LA CNMC"

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -1,7 +1,7 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
 # * giscedata_facturacio_comer_som
-#
+# 
 # Translators:
 #   <>, 2017, 2018, 2019, 2020.
 # Agustí Fita <afita@gisce.net>, 2018.
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2024-01-11 15:57+0000\n"
-"PO-Revision-Date: 2024-01-11 14:58+0000\n"
+"POT-Creation-Date: 2024-03-08 13:16+0000\n"
+"PO-Revision-Date: 2024-03-08 12:18+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2814
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3637
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -35,15 +35,15 @@ msgid "Signar Factures"
 msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:311
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1977
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1979
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:340
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2652
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2656
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1973
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2646
 msgid "estimada"
 msgstr "estimada"
 
@@ -54,14 +54,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2844
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3667
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2012
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2696
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -72,49 +72,49 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1817
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2463
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:309
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:338
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:304
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1975
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:333
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2648
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2726
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3541
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:783
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1078
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1764
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2394
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2756
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3573
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1815
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2461
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -124,18 +124,18 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2785
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3606
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1765
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2395
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:307
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:336
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr "calculada por Som Energía"
@@ -146,7 +146,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1819
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2465
 msgid "(real)"
 msgstr "(real)"
 
@@ -245,7 +245,7 @@ msgid "Costos regulats"
 msgstr "Costes regulados"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:27
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:35
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
 msgid "Impostos aplicats"
 msgstr "Impuestos aplicados"
 
@@ -254,12 +254,12 @@ msgid "Costos de producció electricitat"
 msgstr "Costes de producción de electricidad"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:36
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:48
 msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
 msgstr "DESTINO DEL IMPORTE DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:47
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:49
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
 msgstr "El destino del importe de tu factura, %s euros, es el siguiente:"
@@ -271,35 +271,39 @@ msgid ""
 "dels equips de mesura i control: %s €."
 msgstr "A los importes indicados en el diagrama debe añadirse, en su caso, el alquiler de los equipos de medida y control: %s €."
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
+msgid "RECORE: retribució a les renovables, cogeneració i residus"
+msgstr "RECORE: retribución a las renovables, cogeneración y residuos"
+
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
 msgid "Anualitat del dèficit"
 msgstr "Anualidad del déficit"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
 msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
 msgstr "Sobrecoste de generación en territorios no peninsulares (TNP)"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:24
 msgid "Altres costos regulats"
 msgstr "Otros costes regulados"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:34
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:112
 msgid "Lloguer de comptador"
 msgstr "Alquiler de contador"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
 msgid "Peatges de transport i distribució"
 msgstr "Peajes de transporte y distribución"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:39
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:4
 msgid "Càrrecs"
 msgstr "Cargos"
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
 msgid "Energia"
 msgstr "Energía"
 

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -2267,4 +2267,3 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:110
 msgid "Més informació sobre l'origen de la seva electricitat a"
 msgstr ""
-

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2024-03-08 13:16+0000\n"
-"PO-Revision-Date: 2024-03-08 13:16+0000\n"
+"POT-Creation-Date: 2024-03-15 12:29+0000\n"
+"PO-Revision-Date: 2024-03-15 12:29+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3637
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3647
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -47,7 +47,7 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3667
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3677
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
@@ -83,7 +83,7 @@ msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3541
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3551
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
@@ -101,7 +101,7 @@ msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3573
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3583
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
@@ -117,7 +117,7 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3606
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3616
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
@@ -252,7 +252,7 @@ msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:52
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
 msgstr ""
@@ -265,11 +265,11 @@ msgid ""
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
-msgid "RECORE: retribució a les renovables, cogeneració i residus"
+msgid "Anualitat del dèficit"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
-msgid "Anualitat del dèficit"
+msgid "RECORE: retribució a les renovables, cogeneració i residus"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
@@ -298,6 +298,13 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
 msgid "Energia"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:50
+#, python-format
+msgid ""
+"El destí de l'import de la teva factura sense flux solar, %s euros, és el"
+" següent:"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:10

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2024-01-11 15:57+0000\n"
-"PO-Revision-Date: 2024-01-11 15:57+0000\n"
+"POT-Creation-Date: 2024-03-08 13:16+0000\n"
+"PO-Revision-Date: 2024-03-08 13:16+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2814
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3637
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -28,15 +28,15 @@ msgid "Signar Factures"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:311
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1977
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1979
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:340
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2652
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2656
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1973
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2646
 msgid "estimada"
 msgstr ""
 
@@ -47,14 +47,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2844
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3667
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2012
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2696
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -65,49 +65,49 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1817
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2463
 msgid "(sense lectura)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:309
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:338
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:304
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1975
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:333
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2648
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2726
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3541
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:783
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1078
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1764
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2394
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2756
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3573
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1815
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2461
 msgid "(estimada)"
 msgstr ""
 
@@ -117,18 +117,18 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2785
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3606
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1765
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2395
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:307
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:336
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr ""
@@ -139,7 +139,7 @@ msgid "Error ! No pots crear categories recursives."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1819
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2465
 msgid "(real)"
 msgstr ""
 
@@ -238,7 +238,7 @@ msgid "Costos regulats"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:27
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:35
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
 msgid "Impostos aplicats"
 msgstr ""
 
@@ -247,12 +247,12 @@ msgid "Costos de producció electricitat"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:36
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:48
 msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:47
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:49
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
 msgstr ""
@@ -264,35 +264,39 @@ msgid ""
 " dels equips de mesura i control: %s €."
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:20
-msgid "Anualitat del dèficit"
-msgstr ""
-
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
-msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
+msgid "RECORE: retribució a les renovables, cogeneració i residus"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
+msgid "Anualitat del dèficit"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
+msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:24
 msgid "Altres costos regulats"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:34
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:112
 msgid "Lloguer de comptador"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
 msgid "Peatges de transport i distribució"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:39
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:4
 msgid "Càrrecs"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
 msgid "Energia"
 msgstr ""
 
@@ -2256,3 +2260,4 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:110
 msgid "Més informació sobre l'origen de la seva electricitat a"
 msgstr ""
+

--- a/giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako
@@ -46,7 +46,11 @@ var dades_reparto = ${json.dumps(dades_reparto)}
     % if ad.is_visible:
         <div class="destination">
             <h1>${_(u"DESTÍ DE L'IMPORT DE LA FACTURA")}</h1>
-            <p>${_(u"El destí de l'import de la teva factura, %s euros, és el següent:") % formatLang(ad.amount_total)}</p>
+            % if ad.has_flux:
+                <p>${_(u"El destí de l'import de la teva factura sense flux solar, %s euros, és el següent:") % formatLang(ad.amount_total)}</p>
+            % else:
+                <p>${_(u"El destí de l'import de la teva factura, %s euros, és el següent:") % formatLang(ad.amount_total)}</p>
+            %endif
             <div class="chart_desti" id="chart_desti_${ad.factura_id}"></div>
         </div>
     % endif

--- a/giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako
@@ -5,7 +5,8 @@
 <%
 import json
 
-reparto = { 'd': float((ad.pie_charges * ad.rep_BOE['d'])/100),
+reparto = { 'r': float((ad.pie_charges * ad.rep_BOE['r'])/100),
+            'd': float((ad.pie_charges * ad.rep_BOE['d'])/100),
             't': float((ad.pie_charges * ad.rep_BOE['t'])/100),
             'o': float((ad.pie_charges * ad.rep_BOE['o'])/100)
             }
@@ -17,6 +18,7 @@ def add_reparto(l, percent, increment, tag, text, value, y_offset):
 
 percent = 0.0
 dades_reparto = []
+percent = add_reparto(dades_reparto, percent, ad.rep_BOE['r'], 'r', _(u"RECORE: retribució a les renovables, cogeneració i residus"), reparto['r'], 15)
 percent = add_reparto(dades_reparto, percent, ad.rep_BOE['d'], 'd', _(u"Anualitat del dèficit"), reparto['d'], 15)
 percent = add_reparto(dades_reparto, percent, ad.rep_BOE['t'], 't', _(u"Sobrecost de generació a territoris no peninsulars (TNP)"), reparto['t'], 15)
 percent = add_reparto(dades_reparto, percent, ad.rep_BOE['o'], 'o', _(u"Altres costos regulats"), reparto['o'], 7)

--- a/giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako
@@ -18,8 +18,8 @@ def add_reparto(l, percent, increment, tag, text, value, y_offset):
 
 percent = 0.0
 dades_reparto = []
-percent = add_reparto(dades_reparto, percent, ad.rep_BOE['r'], 'r', _(u"RECORE: retribució a les renovables, cogeneració i residus"), reparto['r'], 15)
 percent = add_reparto(dades_reparto, percent, ad.rep_BOE['d'], 'd', _(u"Anualitat del dèficit"), reparto['d'], 15)
+percent = add_reparto(dades_reparto, percent, ad.rep_BOE['r'], 'r', _(u"RECORE: retribució a les renovables, cogeneració i residus"), reparto['r'], 17)
 percent = add_reparto(dades_reparto, percent, ad.rep_BOE['t'], 't', _(u"Sobrecost de generació a territoris no peninsulars (TNP)"), reparto['t'], 15)
 percent = add_reparto(dades_reparto, percent, ad.rep_BOE['o'], 'o', _(u"Altres costos regulats"), reparto['o'], 7)
 %>

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -2591,8 +2591,8 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         "data": "2021-05-01",
                         "days": 61,
                         "date_from": "01/05/2021",
-                        "date_to": "30/06/2021",
-                        "date_to_d": "2021-06-30",
+                        "date_to": "31/05/2021",
+                        "date_to_d": "2021-05-31",
                         "iva": "",
                     },
                     {
@@ -2752,8 +2752,8 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                         "data": "2021-05-01",
                         "days": 61,
                         "date_from": "01/05/2021",
-                        "date_to": "30/06/2021",
-                        "date_to_d": "2021-06-30",
+                        "date_to": "31/05/2021",
+                        "date_to_d": "2021-05-31",
                         "iva": "",
                     },
                     {


### PR DESCRIPTION
## Objectiu
Actualitzar l'apartat destí de la factura al BOE 2024

## Targeta on es demana o Incidència
https://trello.com/c/lX56NS0i/334-actualitzar-pdf-amb-el-de-c%C3%A0rrecs-a-cada-partida-segons-boe-2024

## Comportament antic
percentatges BOE 2023 

## Comportament nou
percentatges BOE 2024

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [x] Modifica traduccions
