### PR TITLE
Treure autoconsum_id de la vista de polissa

### DIFF
--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -249,7 +249,7 @@
                     <field name="potencia_generacio" select="1"/>
                 </xpath>
                 <xpath expr="//field[@name='autoconsum_cups_ids']" position="replace">
-                    <field name="autoconsum_cups_ids" colspan="8" height="200" nolabel="1" string="CAU" select="1"/>
+                    <field name="autoconsum_cups_ids" size="26" colspan="8" height="200" nolabel="1" string="CAU" select="1"/>
                 </xpath>
                 <xpath expr="//field[@name='is_autoconsum_collectiu']" position="replace">
                     <field name="is_autoconsum_collectiu" select="2"/>

--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -248,9 +248,6 @@
                 <xpath expr="//field[@name='potencia_generacio']" position="replace">
                     <field name="potencia_generacio" select="1"/>
                 </xpath>
-                <xpath expr="//field[@name='autoconsum_id']" position="replace">
-                    <field name="autoconsum_id" string="CAU" size="26" select="1" attrs="{'required':[('autoconsumo','!=','00'), ('state','in',['validar','modcontractual'])]}" on_change="onchange_autoconsum_id(autoconsum_id)"/>
-                </xpath>
                 <xpath expr="//field[@name='is_autoconsum_collectiu']" position="replace">
                     <field name="is_autoconsum_collectiu" select="2"/>
                 </xpath>

--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -248,6 +248,9 @@
                 <xpath expr="//field[@name='potencia_generacio']" position="replace">
                     <field name="potencia_generacio" select="1"/>
                 </xpath>
+                <xpath expr="//field[@name='autoconsum_cups_ids']" position="replace">
+                    <field name="autoconsum_cups_ids" colspan="8" height="200" nolabel="1" string="CAU" select="1"/>
+                </xpath>
                 <xpath expr="//field[@name='is_autoconsum_collectiu']" position="replace">
                     <field name="is_autoconsum_collectiu" select="2"/>
                 </xpath>

--- a/som_polissa/migrations/5.0.24.5.0/post-0002_remove_autoconsum_id_from_view.py
+++ b/som_polissa/migrations/5.0.24.5.0/post-0002_remove_autoconsum_id_from_view.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Updating XMLs")
+
+    list_of_records = ["view_giscedata_polissa_autoconsum_form_inherit"]
+    load_data_records(
+        cursor, 'som_polissa', 'giscedata_polissa_view.xml', list_of_records, mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu
La polissa ja no te el camp de autoconsum_id a la vista base de la polissa i es treu del modul personalitzat

## Targeta on es demana o Incidència
https://trello.com/c/6H6ATHED/5999-multicaus-gisce

## Relacionat
https://github.com/gisce/erp/pull/19697

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
    - som_polissa
- [x] Script de migració
    som_polissa, post-0002_remove_autoconsum_id_from_view, **v24.5.0**
- [ ] Modifica traduccions
