### PR TITLE
desactivar script de migració que pot donar problemes

### DIFF
--- a/som_autoreclama/migrations/5.0.2.108.0/post-0001_set_inital_history_polissa_state.py
+++ b/som_autoreclama/migrations/5.0.2.108.0/post-0001_set_inital_history_polissa_state.py
@@ -27,6 +27,11 @@ def up(cursor, installed_version):
     if not installed_version:
         return
 
+    # do not execute, make the setup in phases, too many objects, see:
+    # PR https://github.com/Som-Energia/somenergia-scripts/pull/86
+    # PR https://github.com/Som-Energia/somenergia-scripts/pull/85
+    # PR https://github.com/Som-Energia/somenergia-scripts/pull/84
+    """
     uid = 1
     pool = pooler.get_pool(cursor.dbname)
 
@@ -100,7 +105,7 @@ def up(cursor, installed_version):
     logger.info("> Assignat estat bucle (polissa no ok amb R1 006 previa) -------> {}".format(len(assignat_loop)))               # noqa: E501
     logger.info("> Assignat estat correcte (polissa no ok sense R1 006 previa) --> {}".format(len(assignat_correct_no_previa)))  # noqa: E501
     logger.info("Estats inicials per les giscedata_polissa creats")
-
+    """
 
 def down(cursor, installed_version):
     pass

--- a/som_autoreclama/migrations/5.0.2.108.0/post-0001_set_inital_history_polissa_state.py
+++ b/som_autoreclama/migrations/5.0.2.108.0/post-0001_set_inital_history_polissa_state.py
@@ -27,11 +27,11 @@ def up(cursor, installed_version):
     if not installed_version:
         return
 
+    return
     # do not execute, make the setup in phases, too many objects, see:
     # PR https://github.com/Som-Energia/somenergia-scripts/pull/86
     # PR https://github.com/Som-Energia/somenergia-scripts/pull/85
     # PR https://github.com/Som-Energia/somenergia-scripts/pull/84
-    """
     uid = 1
     pool = pooler.get_pool(cursor.dbname)
 
@@ -105,7 +105,7 @@ def up(cursor, installed_version):
     logger.info("> Assignat estat bucle (polissa no ok amb R1 006 previa) -------> {}".format(len(assignat_loop)))               # noqa: E501
     logger.info("> Assignat estat correcte (polissa no ok sense R1 006 previa) --> {}".format(len(assignat_correct_no_previa)))  # noqa: E501
     logger.info("Estats inicials per les giscedata_polissa creats")
-    """
+
 
 def down(cursor, installed_version):
     pass


### PR DESCRIPTION
## Objectiu

Desactivar l'script de migració per evitar problemes

## Targeta on es demana o Incidència

Cap

## Comportament antic

La migració dona de alta totes les polisses en autoreclama i pot provocar un allau de reclamacions i l'equip de reclama no pugui fer-ne front

## Comportament nou

no es fa la migració, hi han scripts al scriptlauncher per tal de fer-ho en blocks.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
