### PR TITLE
Millorar rendiment de camp funció a la pòlissa

### DIFF
--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -494,7 +494,7 @@ class GiscedataPolissa(osv.osv):
         cups_ids = cups_obj.search(
             cursor, uid, [('polissa_polissa', 'in', ids)], context=context
         )
-        provincies = cups_obj.read(cursor, uid, cups_ids, ['id_provincia'])
+        provincies = cups_obj.read(cursor, uid, cups_ids, ['polissa_polissa','id_provincia'])
 
         for provincia in provincies:
             res[provincia['polissa_polissa'][0]]=provincia["id_provincia"][1]

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -494,10 +494,10 @@ class GiscedataPolissa(osv.osv):
         cups_ids = cups_obj.search(
             cursor, uid, [('polissa_polissa', 'in', ids)], context=context
         )
-        provincies = cups_obj.read(cursor, uid, cups_ids, ['polissa_polissa','id_provincia'])
+        provincies = cups_obj.read(cursor, uid, cups_ids, ['polissa_polissa', 'id_provincia'])
 
         for provincia in provincies:
-            res[provincia['polissa_polissa'][0]]=provincia["id_provincia"][1]
+            res[provincia['polissa_polissa'][0]] = provincia["id_provincia"][1]
 
         return res
 

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -491,15 +491,13 @@ class GiscedataPolissa(osv.osv):
         cups_obj = self.pool.get("giscedata.cups.ps")
         res = dict.fromkeys(ids, False)
 
-        for pol_id in ids:
-            provincia = (
-                cups_obj.q(cursor, uid)
-                .read(["id_provincia"])
-                .where([("polissa_polissa", "=", pol_id)])
-            )
-            if provincia:
-                provincia = provincia[0]["id_provincia"][1]
-                res[pol_id] = provincia
+        cups_ids = cups_obj.search(
+            cursor, uid, [('polissa_polissa', 'in', ids)], context=context
+        )
+        provincies = cups_obj.read(cursor, uid, cups_ids, ['id_provincia'])
+
+        for provincia in provincies:
+            res[provincia['id']] = provincia["id_provincia"][1]
 
         return res
 

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -497,7 +497,7 @@ class GiscedataPolissa(osv.osv):
         provincies = cups_obj.read(cursor, uid, cups_ids, ['id_provincia'])
 
         for provincia in provincies:
-            res[provincia['id']] = provincia["id_provincia"][1]
+            res[provincia['polissa_polissa'][0]]=provincia["id_provincia"][1]
 
         return res
 


### PR DESCRIPTION
## Objectiu
Reduir el canvi d'una query per valor a només 2 queries

## Targeta on es demana o Incidència
Canal ERP va lent

## Comportament antic
Cada vegada que es volia consultar el llistat de pòlisses es feia una query extra per pòlissa consultada. 
Trigava **70 segons**.


## Comportament nou
Ara només se'n fan 2 independentment de les pòlisses que hi hagi. 
Ara triga **4 segons**.