### PR TITLE
Arreglar el calcul dels kWh per al donatiu voluntari

### DIFF
--- a/som_polissa_soci/giscedata_facturacio.py
+++ b/som_polissa_soci/giscedata_facturacio.py
@@ -78,7 +78,6 @@ class GiscedataFacturacioFacturador(osv.osv):
                                 if x.tipus == "energia" and x.product_id.code != "RMAG"
                             ]
                         )
-                        kwh = max(kwh, 0.0)
                         vals = {
                             "data_desde": fact.data_inici,
                             "data_fins": fact.data_final,

--- a/som_polissa_soci/giscedata_facturacio.py
+++ b/som_polissa_soci/giscedata_facturacio.py
@@ -73,11 +73,12 @@ class GiscedataFacturacioFacturador(osv.osv):
                         # identificar la línia d'energia excloent el preu del MAG (RD 10/2022)
                         kwh = sum(
                             [
-                                x.quantity
+                                x.quantity if x.price_unit >= 0 else -x.quantity
                                 for x in fact.linia_ids
                                 if x.tipus == "energia" and x.product_id.code != "RMAG"
                             ]
                         )
+                        kwh = max(kwh, 0.0)
                         vals = {
                             "data_desde": fact.data_inici,
                             "data_fins": fact.data_final,


### PR DESCRIPTION
## Objectiu

El càlcul del donatiu voluntari es veu afectat per extralines negatives que aporten energia a diverses factures

## Targeta on es demana o Incidència

https://secure.helpscout.net/conversation/2549959038/16796689

## Comportament antic

comptava com a positius kWh negatius.

## Comportament nou

realitza el càlcul correctament

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
