### PR TITLE
Crear nou estat pendent per factures “Pèrdues FACT”.

### DIFF
--- a/som_account_invoice_pending/__init__.py
+++ b/som_account_invoice_pending/__init__.py
@@ -3,3 +3,4 @@ import norma57
 import wizard
 import account_invoice_pending_history
 import som_account_invoice_pending_exceptions
+import account_invoice

--- a/som_account_invoice_pending/account_invoice.py
+++ b/som_account_invoice_pending/account_invoice.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from osv import osv
+from datetime import date
+
+
+class AccountInvoice(osv.osv):
+
+    _name = "account.invoice"
+    _inherit = "account.invoice"
+
+    def set_pending(self, cursor, uid, ids, pending_id, context=None):
+        res = super(AccountInvoice, self).set_pending(
+            cursor, uid, ids, pending_id, context
+        )
+
+        ir_model_data = self.pool.get("ir.model.data")
+        perdues_fact_df = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_account_invoice_pending",
+            "perdues_fact_default_pending_state"
+        )[1]
+
+        perdues_fact_bs = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_account_invoice_pending",
+            "perdues_fact_bo_social_pending_state"
+        )[1]
+
+        fue_bs = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_account_invoice_pending",
+            "fue_bo_social_pending_state"
+        )[1]
+
+        fue_df = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_account_invoice_pending",
+            "fue_default_pending_state"
+        )[1]
+
+        r1_bs = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_account_invoice_pending",
+            "reclamacio_en_curs_pending_state"
+        )[1]
+
+        r1_df = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_account_invoice_pending",
+            "default_reclamacio_en_curs_pending_state"
+        )[1]
+
+        if pending_id in (perdues_fact_df, perdues_fact_bs, fue_bs, fue_df, r1_bs, r1_df):
+            pt_obj = self.pool.get("payment.type")
+            no_remesa_ids = pt_obj.search(
+                cursor, uid,
+                [('code', '=', 'NO_REMESA')],
+                context=context
+            )
+
+            pending_type = {
+                perdues_fact_df: u"Pèrdues",
+                perdues_fact_bs: u"Pèrdues",
+                fue_bs: u"FUE",
+                fue_df: u"FUE",
+                r1_bs: u"R1 Reclamació",
+                r1_df: u"R1 Reclamació",
+            }
+
+            today_str = date.today().strftime("%Y-%m-%d")
+            log_text = u"{} - Factura - {}".format(
+                today_str,
+                pending_type.get(pending_id, u"Error")
+            )
+
+            for invoice_id in ids:
+                inv_data = self.read(
+                    cursor, uid,
+                    invoice_id, ['comment'],
+                    context=context
+                )
+
+                if 'comment' in inv_data and inv_data['comment']:
+                    comment = log_text + "\n" + inv_data['comment']
+                else:
+                    comment = log_text
+                to_write = {
+                    'comment': comment
+                }
+                if len(no_remesa_ids) == 1:
+                    to_write['payment_type'] = no_remesa_ids[0]
+
+                self.write(
+                    cursor, uid,
+                    invoice_id, to_write,
+                    context=context
+                )
+
+        return res
+
+
+AccountInvoice()

--- a/som_account_invoice_pending/som_account_invoice_pending_data.xml
+++ b/som_account_invoice_pending/som_account_invoice_pending_data.xml
@@ -333,6 +333,20 @@
             <field name="process_id" ref="account_invoice_pending.default_pending_state_process"/>
             <field name="pending_days_type">natural</field>
         </record>
+        <record model="account.invoice.pending.state" id="som_account_invoice_pending.perdues_fact_bo_social_pending_state">
+            <field name="name">Pèrdues FACT (Bo Social)</field>
+            <field name="weight">1138</field>
+            <field name="pending_days">0</field>
+            <field name="process_id" ref="giscedata_facturacio_comer_bono_social.bono_social_pending_state_process"/>
+            <field name="pending_days_type">natural</field>
+        </record>
+        <record model="account.invoice.pending.state" id="som_account_invoice_pending.perdues_fact_default_pending_state">
+            <field name="name">Pèrdues FACT (Default Process)</field>
+            <field name="weight">1139</field>
+            <field name="pending_days">0</field>
+            <field name="process_id" ref="account_invoice_pending.default_pending_state_process"/>
+            <field name="pending_days_type">natural</field>
+        </record>
 
         <!-- Template de annex 2 Bo social -->
         <record model="poweremail.templates" id="email_impagats_annex2">

--- a/som_account_invoice_pending/tests/__init__.py
+++ b/som_account_invoice_pending/tests/__init__.py
@@ -3,3 +3,4 @@ from .wizard_returned_invoices_export_tests import *
 from .wizard_unlink_sms_pending_history_tests import *
 from .wizard_tugesto_invoices_export_tests import *
 from .wizard_pay_invoice_tests import *
+from .account_invoice_tests import *

--- a/som_account_invoice_pending/tests/account_invoice_tests.py
+++ b/som_account_invoice_pending/tests/account_invoice_tests.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+from datetime import date
+
+
+def get_today_str():
+    return date.today().strftime("%Y-%m-%d")
+
+
+def split_first(message, sepparator='\n'):
+    if sepparator not in message:
+        return message, False
+
+    idx = message.index(sepparator)
+    return message[:idx], message[idx + 1:]
+
+
+class TestAccountInvoiceSetPendingAutomations(testing.OOTestCase):
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.pool = self.openerp.pool
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def getref(self, module, reference):
+        IrModelData = self.pool.get("ir.model.data")
+        return IrModelData.get_object_reference(
+            self.cursor, self.uid,
+            module, reference
+        )[1]
+
+    def read_one(self, model_obj, model_id, field):
+        data = model_obj.read(self.cursor, self.uid, model_id, [field])
+        if field in data:
+            return data[field]
+        return None
+
+    def write_one(self, model_obj, model_id, field, value):
+        data = {
+            field: value
+        }
+        model_obj.write(self.cursor, self.uid, model_id, data)
+
+    def _load_data_unpaid_invoices(self, invoice_semid_list=[]):
+        imd_obj = self.pool.get("ir.model.data")
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        facts = []
+        invos = []
+
+        contract_name = ""
+        for index, res_id in enumerate(invoice_semid_list, start=1):
+            fact_id = imd_obj.get_object_reference(
+                self.cursor, self.uid, "giscedata_facturacio", "factura_000" + str(index)
+            )[1]
+            invoice_id = fact_obj.read(
+                self.cursor, self.uid, fact_id, ["invoice_id"]
+            )["invoice_id"][0]
+
+            if index == 1:
+                contract_name = inv_obj.read(
+                    self.cursor, self.uid,
+                    invoice_id, ["name"]
+                )["name"]
+
+            inv_obj.write(
+                self.cursor, self.uid,
+                invoice_id,
+                {
+                    "name": contract_name,
+                },
+            )
+            inv_obj.set_pending(
+                self.cursor, self.uid,
+                [invoice_id], res_id
+            )
+            invos.append(invoice_id)
+            facts.append(fact_id)
+        return facts, invos
+
+    def create_no_remesable(self):
+        pt_obj = self.pool.get("payment.type")
+        no_remesa_ids = pt_obj.search(
+            self.cursor, self.uid,
+            [('code', '=', 'NO_REMESA')]
+        )
+        if no_remesa_ids:
+            return no_remesa_ids[0]
+
+        return pt_obj.create(
+            self.cursor, self.uid,
+            {
+                'name': u'No remesables',
+                'code': 'NO_REMESA',
+                'note': u"Factures que no s'han de remesar",
+            }
+        )
+
+    def test_set_pending_FUE__one_invoice(self):
+        fue_bs_state_id = self.getref(
+            "som_account_invoice_pending", "fue_bo_social_pending_state"
+        )
+        fue_df_state_id = self.getref(
+            "som_account_invoice_pending", "fue_default_pending_state"
+        )
+        corr_state_id = self.getref(
+            "account_invoice_pending", "default_invoice_pending_state"
+        )
+
+        fact_ids, inv_ids = self._load_data_unpaid_invoices(
+            [corr_state_id, corr_state_id]
+        )
+
+        no_remesa_pt_id = self.create_no_remesable()
+
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        self.write_one(fact_obj, fact_ids[0], 'comment', u"2024-02-30 BlaBLaBLa")
+        previous_comment_1 = self.read_one(fact_obj, fact_ids[0], 'comment')
+        previous_comment_2 = self.read_one(fact_obj, fact_ids[1], 'comment')
+
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[0]], fue_bs_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[1]], fue_df_state_id)
+
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[0])
+        self.assertEqual(f_data.pending_state.id, fue_bs_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - FUE'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment_1)
+
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[1])
+        self.assertEqual(f_data.pending_state.id, fue_df_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - FUE'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment_2)
+
+    def test_set_pending_R1__one_invoice(self):
+        r1_bs_state_id = self.getref(
+            "som_account_invoice_pending", "reclamacio_en_curs_pending_state"
+        )
+        r1_df_state_id = self.getref(
+            "som_account_invoice_pending", "default_reclamacio_en_curs_pending_state"
+        )
+        corr_state_id = self.getref(
+            "account_invoice_pending", "default_invoice_pending_state"
+        )
+
+        fact_ids, inv_ids = self._load_data_unpaid_invoices(
+            [corr_state_id, corr_state_id]
+        )
+
+        no_remesa_pt_id = self.create_no_remesable()
+
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        self.write_one(fact_obj, fact_ids[0], 'comment', u"2021-02-15 BlaBLaBLa")
+        self.write_one(
+            fact_obj, fact_ids[0], 'comment',
+            u"2022-04-12 BlaBLaBLa\n2021-05-12 test multiline"
+        )
+        previous_comment_1 = self.read_one(fact_obj, fact_ids[0], 'comment')
+        previous_comment_2 = self.read_one(fact_obj, fact_ids[1], 'comment')
+
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[0]], r1_bs_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[1]], r1_df_state_id)
+
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[0])
+        self.assertEqual(f_data.pending_state.id, r1_bs_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - R1 Reclamació'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment_1)
+
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[1])
+        self.assertEqual(f_data.pending_state.id, r1_df_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - R1 Reclamació'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment_2)
+
+    def test_set_pending_PERDU__one_invoice(self):
+        perd_bs_state_id = self.getref(
+            "som_account_invoice_pending", "perdues_fact_bo_social_pending_state"
+        )
+        perd_df_state_id = self.getref(
+            "som_account_invoice_pending", "perdues_fact_default_pending_state"
+        )
+        corr_state_id = self.getref(
+            "account_invoice_pending", "default_invoice_pending_state"
+        )
+
+        fact_ids, inv_ids = self._load_data_unpaid_invoices(
+            [corr_state_id, corr_state_id]
+        )
+
+        no_remesa_pt_id = self.create_no_remesable()
+
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        self.write_one(fact_obj, fact_ids[0], 'comment', u"2024-05-30 BlaBLaBLa")
+        self.write_one(fact_obj, fact_ids[1], 'comment', u"1999-01-31 ????!")
+        previous_comment_1 = self.read_one(fact_obj, fact_ids[0], 'comment')
+        previous_comment_2 = self.read_one(fact_obj, fact_ids[1], 'comment')
+
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[0]], perd_bs_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[1]], perd_df_state_id)
+
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[0])
+        self.assertEqual(f_data.pending_state.id, perd_bs_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - Pèrdues'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment_1)
+
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[1])
+        self.assertEqual(f_data.pending_state.id, perd_df_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - Pèrdues'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment_2)
+
+    def test_set_pending_various__set_of_invoices(self):
+        fue_bs_state_id = self.getref(
+            "som_account_invoice_pending", "fue_bo_social_pending_state"
+        )
+        fue_df_state_id = self.getref(
+            "som_account_invoice_pending", "fue_default_pending_state"
+        )
+        r1_bs_state_id = self.getref(
+            "som_account_invoice_pending", "reclamacio_en_curs_pending_state"
+        )
+        r1_df_state_id = self.getref(
+            "som_account_invoice_pending", "default_reclamacio_en_curs_pending_state"
+        )
+        perd_bs_state_id = self.getref(
+            "som_account_invoice_pending", "perdues_fact_bo_social_pending_state"
+        )
+        perd_df_state_id = self.getref(
+            "som_account_invoice_pending", "perdues_fact_default_pending_state"
+        )
+        corr_state_id = self.getref(
+            "account_invoice_pending", "default_invoice_pending_state"
+        )
+        extra_df_state_id = self.getref(
+            "som_account_invoice_pending", "fracc_manual_default_pending_state"
+        )
+
+        fact_ids, inv_ids = self._load_data_unpaid_invoices(
+            [
+                corr_state_id,
+                corr_state_id,
+                corr_state_id,
+                corr_state_id,
+                corr_state_id,
+                corr_state_id,
+                corr_state_id,
+                corr_state_id,
+            ]
+        )
+
+        no_remesa_pt_id = self.create_no_remesable()
+
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        self.write_one(fact_obj, fact_ids[0], 'comment', u"2021-04-20 BlaBLaBLa...")
+        self.write_one(fact_obj, fact_ids[1], 'comment', u"2022-07-22 BlaBLaBLa!!!")
+        self.write_one(fact_obj, fact_ids[2], 'comment', u"2023-05-15 BlaBLaBLa???")
+        self.write_one(fact_obj, fact_ids[3], 'comment', u"2024-03-10 BlaBLaBLa¿¿¿")
+        self.write_one(fact_obj, fact_ids[4], 'comment', u"2011-10-09 BlaBLaBLa***")
+        self.write_one(fact_obj, fact_ids[5], 'comment', u"2012-11-03 BlaBLaBLaZZZ")
+        self.write_one(fact_obj, fact_ids[6], 'comment', u"2013-12-30 BlaBLaBLa+++")
+        self.write_one(fact_obj, fact_ids[7], 'comment', u"2014-06-05 BlaBLaBLa---")
+
+        previous_comment = []
+        previous_comment.append(self.read_one(fact_obj, fact_ids[0], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[1], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[2], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[3], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[4], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[5], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[6], 'comment'))
+        previous_comment.append(self.read_one(fact_obj, fact_ids[7], 'comment'))
+
+        previous_payment_type_6 = self.read_one(fact_obj, fact_ids[6], 'payment_type')[0]
+        previous_payment_type_7 = self.read_one(fact_obj, fact_ids[7], 'payment_type')[0]
+
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[0]], fue_bs_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[1]], fue_df_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[2]], r1_bs_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[3]], r1_df_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[4]], perd_bs_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[5]], perd_df_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[6]], corr_state_id)
+        inv_obj.set_pending(self.cursor, self.uid, [inv_ids[7]], extra_df_state_id)
+
+        idx = 0
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, fue_bs_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - FUE'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment[idx])
+
+        idx = 1
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, fue_df_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - FUE'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment[idx])
+
+        idx = 2
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, r1_bs_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - R1 Reclamació'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment[idx])
+
+        idx = 3
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, r1_df_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - R1 Reclamació'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment[idx])
+
+        idx = 4
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, perd_bs_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - Pèrdues'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment[idx])
+
+        idx = 5
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, perd_df_state_id)
+        self.assertEqual(f_data.payment_type.id, no_remesa_pt_id)
+        new_comment, old_comment = split_first(f_data.comment)
+        expected_comment = u'{} - Factura - Pèrdues'.format(get_today_str())
+        self.assertEqual(new_comment, expected_comment)
+        self.assertEqual(old_comment, previous_comment[idx])
+
+        idx = 6
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, corr_state_id)
+        self.assertEqual(f_data.payment_type.id, previous_payment_type_6)
+        self.assertEqual(f_data.comment, previous_comment[idx])
+
+        idx = 7
+        f_data = fact_obj.browse(self.cursor, self.uid, fact_ids[idx])
+        self.assertEqual(f_data.pending_state.id, extra_df_state_id)
+        self.assertEqual(f_data.payment_type.id, previous_payment_type_7)
+        self.assertEqual(f_data.comment, previous_comment[idx])
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
## Objectiu

Crear el nou estat pendent per marcar "pèrdues fact" i aplicar els automatismes demanats quan s'assigna l'estat a factures.

## Targeta on es demana o Incidència

https://trello.com/c/nHjKeOHG/295-get-etiqueta-factures-client-a-p%C3%A8rdues

## Comportament antic

No existia

## Comportament nou

L'estat pendent existeix

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
      som_account_invoice_pending
- [ ] Script de migració
- [ ] Modifica traduccions
