### PR TITLE
Change unit measure for excedent compensation: MWh -> kWh

### DIFF
--- a/www_som/som_indexada_webforms_helpers.py
+++ b/www_som/som_indexada_webforms_helpers.py
@@ -225,7 +225,7 @@ class SomIndexadaWebformsHelpers(osv.osv_memory):
                         geom_zone,
                         tarifa_id,
                         CASE
-                            WHEN %(tariff_id)s IS NULL THEN prm_diari
+                            WHEN %(tariff_id)s IS NULL THEN prm_diari / 1000
                             ELSE initial_price
                         END AS price,
                         maturity,

--- a/www_som/tests/tests_indexada_helpers.py
+++ b/www_som/tests/tests_indexada_helpers.py
@@ -185,7 +185,7 @@ class TestIndexadaHelpers(TestChangeToIndexada):
                 "maturity": ["C3", "C3", "C3", "C3", "C3", None, None, None, None, None,
                              None, None, None, None, None, None, None, None, None, None,
                              None, None, None, None],
-                "compensation_euros_kwh": [1.2, 1.3, 1.4, 1.5, 1.6, None, None, None, None,
+                "compensation_euros_kwh": [0.0012, 0.0013, 0.0014, 0.0015, 0.0016, None, None, None, None,
                                            None, None, None, None, None, None, None, None,
                                            None, None, None, None, None, None, None]
             }

--- a/www_som/tests/tests_indexada_helpers.py
+++ b/www_som/tests/tests_indexada_helpers.py
@@ -186,7 +186,7 @@ class TestIndexadaHelpers(TestChangeToIndexada):
                              None, None, None, None, None, None, None, None, None, None,
                              None, None, None, None],
                 "compensation_euros_kwh": [0.0012, 0.0013, 0.0014, 0.0015, 0.0016,
-					   None, None, None, None, None, None, None,
+                                           None, None, None, None, None, None, None,
                                            None, None, None, None, None, None, None,
                                            None, None, None, None, None]
             }

--- a/www_som/tests/tests_indexada_helpers.py
+++ b/www_som/tests/tests_indexada_helpers.py
@@ -185,9 +185,10 @@ class TestIndexadaHelpers(TestChangeToIndexada):
                 "maturity": ["C3", "C3", "C3", "C3", "C3", None, None, None, None, None,
                              None, None, None, None, None, None, None, None, None, None,
                              None, None, None, None],
-                "compensation_euros_kwh": [0.0012, 0.0013, 0.0014, 0.0015, 0.0016, None, None, None, None,
-                                           None, None, None, None, None, None, None, None,
-                                           None, None, None, None, None, None, None]
+                "compensation_euros_kwh": [0.0012, 0.0013, 0.0014, 0.0015, 0.0016,
+					   None, None, None, None, None, None, None,
+                                           None, None, None, None, None, None, None,
+                                           None, None, None, None, None]
             }
         }
         self.assertDictEqual(json.loads(result), expected)


### PR DESCRIPTION
## Objectiu

Retrieve from database excedent compensation measure in `kWh`

## Targeta on es demana o Incidència

https://trello.com/c/Xv0KIdg1/6104-6md-tancament-preus-indexada

## Comportament antic

`MWh` as unit measure

## Comportament nou

`kWh` as unit measure

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
