### PR TITLE
Resetejar la data baixa autoconsum quan es dona d'alta un de nou

### DIFF
--- a/som_switching/giscedata_polissa.py
+++ b/som_switching/giscedata_polissa.py
@@ -52,6 +52,10 @@ class GiscedataPolissaModcontractual(osv.osv):
         fields_to_read = ["autoconsumo", "data_inici", "modcontractual_ant", "polissa_id"]
 
         modcon_info = self.read(cursor, uid, mod_id, fields_to_read)
+
+        polissa_obj = self.pool.get("giscedata.polissa")
+        polissa_id = modcon_info["polissa_id"][0]
+
         auto_vals = {}
         if modcon_info.get("modcontractual_ant"):
             modcon_ant_info = self.read(
@@ -62,6 +66,13 @@ class GiscedataPolissaModcontractual(osv.osv):
                 and modcon_ant_info["autoconsumo"] == "00"
             ):
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
+
+                auto_data_baixa = polissa_obj.read(cursor, uid, polissa_id, ['data_baixa_autoconsum'])['data_baixa_autoconsum']
+                if (
+                        auto_data_baixa
+                        and auto_data_baixa <= modcon_info['data_inici']
+                ):
+                    auto_vals.update({'data_baixa_autoconsum': False})
             elif (
                 modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
                 and modcon_info["autoconsumo"] == "00"
@@ -72,11 +83,10 @@ class GiscedataPolissaModcontractual(osv.osv):
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
 
         if auto_vals:
-            polissa_obj = self.pool.get("giscedata.polissa")
             polissa_obj.write(
                 cursor,
                 uid,
-                [modcon_info["polissa_id"][0]],
+                [polissa_id],
                 auto_vals,
                 context={"skip_cnt_llista_preu_compatible": True},
             )


### PR DESCRIPTION
## Objectiu

Modificar comportament per tal que quan donem d'alta un autoconsum en un contracte que ja n'ha tingut previament pero s'ha donat de baixa, el camp que ens indica la data de baixa del autoconsum anterior es torni a mostrar buit.

## Targeta on es demana o Incidència

https://trello.com/c/cA36I4Dt

## Comportament antic
La data de baixa del autoconsum es mantenia amb el valor de l'autoconsum original.

## Comportament nou
La data de baixa es buida quan donem d'alta un autoconsum a una data posterior o igual a la baixa de l'anterior.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
