### PR TITLE
OP#131 [#131] Corregir script de migració de adjunts de mongo pel comportament estrany de datas_ mongo

### DIFF
--- a/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
+++ b/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
@@ -11,10 +11,12 @@ def up(cursor, installed_version):
     uid = 1
     pool = pooler.get_pool(cursor.dbname)
 
+    # Això hauria d'anar en un altre script de migració
     logger.info("Updating table table: giscedata.polissa")
     scp_obj = pool.get('som.consulta.pobresa')
     scp_obj._auto_init(cursor, context={"module": "som_account_invoice_pending"})
 
+    # Comença aqui:
     crm_obj = pool.get('crm.case')
     imd_obj = pool.get('ir.model.data')
     att_obj = pool.get('ir.attachment')
@@ -46,6 +48,18 @@ def up(cursor, installed_version):
         for att_id in attachment_list:
             if scp_id:
                 att = att_obj.browse(cursor, uid, att_id)
+
+                # Obtenim el datas_mongo per SQL perquè l'ORM modifica coses
+                sql_select = '''
+                    SELECT datas_mongo
+                    FROM ir_attachment
+                    WHERE id = %s
+                '''
+                cursor.execute(sql_select, (att_id,))
+                for data in cursor.dictfetchall():
+                    print data
+                    datas_mongo = data['datas_mongo']
+
                 search_vals = [
                     ("res_model", '=', "som.consulta.pobresa"),
                     ("res_id", '=', scp_id[0]),
@@ -54,17 +68,19 @@ def up(cursor, installed_version):
                     ("create_date", '<', '2024-05-21 16:00:00'),
                 ]
                 att_ids = att_obj.search(cursor, uid, search_vals)
+                if not isinstance(att_ids, (list, tuple)):
+                    att_ids = [att_ids]
 
+                # Guardem el datas_mongo per SQL perquè l'ORM modifica coses
                 sql = '''
                     UPDATE ir_attachment
-                    SET datas_mongo = %{datas_mongo}
-                    WHERE id IN %(ids);
+                    SET datas_mongo = '%s'
+                    WHERE id = %s;
                 '''
-                cursor.execute(sql,
-                               {'ids': tuple(att_ids[0]),
-                                'datas_mongo': AsIs(att.datas_mongo)})
-
-                logger.info('Attachments actualitzat de pobresa energètica {}.'.format(scp_id[0]))
+                if att_ids:
+                    cursor.execute(sql, (AsIs(datas_mongo), att_ids[0]))
+                    logger.info(
+                        'Attachments actualitzat de pobresa energètica {}.'.format(scp_id[0]))
 
     logger.info('S\'han creat els adjunts')
 


### PR DESCRIPTION
## Objectiu
Corregir script de migració de adjunts de mongo pel comportament estrany de datas_ mongo

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/boards/15/details/131/overview

## Comportament antic
Si intentes modificar el datas_mongo des del ORM, es fan coses estranyes. S'ha de fer per SQL.

## Comportament nou
Es fa des de SQL
