### PR TITLE
Creació de factures d'inscripció de GURB

### DIFF
--- a/account_invoice_som/report/account_invoice_som.mako
+++ b/account_invoice_som/report/account_invoice_som.mako
@@ -168,7 +168,7 @@
                     <div class="quantity_section">
                         %for i in sorted(altres_lines):
                             <div class="preu_concepte center">
-                                ${formatLang(i.quantity, 0)}
+                                ${formatLang(i.quantity, 2)}
                             </div>
                         %endfor
                     </div>

--- a/som_gurb/__terp__.py
+++ b/som_gurb/__terp__.py
@@ -28,6 +28,7 @@
         "workflow/som_gurb_workflow.xml",
         "security/ir.model.access.csv",
         "wizard/wizard_gurb_create_new_beta_view.xml",
+        "wizard/wizard_gurb_create_initial_invoice_view.xml",
         "reports/som_gurb_reports.xml",
     ],
     "init_xml": [],

--- a/som_gurb/data/som_gurb_data.xml
+++ b/som_gurb/data/som_gurb_data.xml
@@ -23,7 +23,7 @@
             <field name="list_price">10</field>
             <field name="supply_method">buy</field>
             <field model="account.tax" name="taxes_id" search="[('name','=','IVA 21%')]"/>
-            <field name="description">Cost adhesió</field>
+            <field model="account.account" name="property_account_income" search="[('code','=','705000')]"/>
         </record>
         <record model="product.product" id="product_owner_gurb">
             <field name="name">Producte GURB persona propietària</field>
@@ -33,15 +33,18 @@
             <field name="list_price">0</field>
             <field name="supply_method">buy</field>
             <field model="account.tax" name="taxes_id" search="[('name','=','IVA 21%')]"/>
+            <field model="account.account" name="property_account_income" search="[('code','=','705000')]"/>
         </record>
         <record model="product.product" id="initial_quota_gurb">
             <field name="name">Quota inicial del GURB</field>
+            <field name="description">Cost adhesió</field>
             <field name="categ_id" ref="categ_product_gurb"/>
             <field name="type">service</field>
             <field name="procure_method">make_to_stock</field>
             <field name="standard_price">0</field>
             <field name="supply_method">buy</field>
             <field model="account.tax" name="taxes_id" search="[('name','=','IVA 21%')]"/>
+            <field model="account.account" name="property_account_income" search="[('code','=','705000')]"/>
         </record>
         <record id="ir_attachment_gurb_ritsic_attachment_category" model="ir.attachment.category">
             <field name="code">gurb_ritsic_attachment_category</field>

--- a/som_gurb/data/som_gurb_data.xml
+++ b/som_gurb/data/som_gurb_data.xml
@@ -23,6 +23,7 @@
             <field name="list_price">10</field>
             <field name="supply_method">buy</field>
             <field model="account.tax" name="taxes_id" search="[('name','=','IVA 21%')]"/>
+            <field name="description">Cost adhesió</field>
         </record>
         <record model="product.product" id="product_owner_gurb">
             <field name="name">Producte GURB persona propietària</field>

--- a/som_gurb/models/som_gurb_cups.py
+++ b/som_gurb/models/som_gurb_cups.py
@@ -191,9 +191,8 @@ class SomGurbCups(osv.osv):
         gurb_cups_br = self.browse(cursor, uid, gurb_cups_id, context=context)
 
         if gurb_cups_br.initial_invoice_id:
-            error = "[GURB CUPS ID {}]: La factura d'inscripció {} ja existeix.".format(
+            error = "[GURB CUPS ID {}]: La factura d'inscripció ja existeix.".format(
                 gurb_cups_br.id,
-                gurb_cups_br.initial_invoice_id.number,
             )
             return (False, error)
 

--- a/som_gurb/models/som_gurb_cups.py
+++ b/som_gurb/models/som_gurb_cups.py
@@ -264,7 +264,9 @@ class SomGurbCups(osv.osv):
         invoice_vals.update(invoice_o.onchange_partner_id(  # Get invoice default values
             cursor, uid, [], "out_invoice", partner_id).get("value", {})
         )
+
         invoice_id = invoice_o.create(cursor, uid, invoice_vals, context=context)
+        invoice_o.button_reset_taxes(cursor, uid, [invoice_id])
 
         # Update reference
         write_vals = {

--- a/som_gurb/models/som_gurb_cups.py
+++ b/som_gurb/models/som_gurb_cups.py
@@ -253,6 +253,7 @@ class SomGurbCups(osv.osv):
             "partner_id": partner_id,
             "type": "out_invoice",
             "invoice_line": invoice_lines,
+            "origin": "GURBCUPSID{}".format(gurb_cups_br.id),
         }
         invoice_vals.update(invoice_o.onchange_partner_id(  # Get invoice default values
             cursor, uid, [], "out_invoice", partner_id).get("value", {})

--- a/som_gurb/models/som_gurb_cups.py
+++ b/som_gurb/models/som_gurb_cups.py
@@ -253,17 +253,16 @@ class SomGurbCups(osv.osv):
             "partner_id": partner_id,
             "type": "out_invoice",
             "invoice_line": invoice_lines,
-            "payment_type": payment_type_id,
         }
+        invoice_vals.update(invoice_o.onchange_partner_id(  # Get invoice default values
+            cursor, uid, [], "out_invoice", partner_id).get("value", {})
+        )
+        invoice_vals.update({"payment_type": payment_type_id})
 
         if invoice_account_ids:
             invoice_vals.update({"account_id": invoice_account_ids[0]})
         if journal_ids:
             invoice_vals.update({"journal_id": journal_ids[0]})
-
-        invoice_vals.update(invoice_o.onchange_partner_id(  # Get invoice default values
-            cursor, uid, [], "out_invoice", partner_id).get("value", {})
-        )
 
         invoice_id = invoice_o.create(cursor, uid, invoice_vals, context=context)
         invoice_o.button_reset_taxes(cursor, uid, [invoice_id])

--- a/som_gurb/security/ir.model.access.csv
+++ b/som_gurb/security/ir.model.access.csv
@@ -19,3 +19,6 @@
 "access_som_gurb_general_conditions_u","som.gurb.general.conditions","model_som_gurb_general_conditions","giscedata_polissa.group_giscedata_polissa_u",1,1,1,1
 "access_som_gurb_general_conditions_r","som.gurb.general.conditions","model_som_gurb_general_conditions","giscedata_polissa.group_giscedata_polissa_r",1,0,0,0
 "access_som_gurb_general_conditions_w","som.gurb.general.conditions","model_som_gurb_general_conditions","giscedata_polissa.group_giscedata_polissa_w",1,1,1,0
+"access_wizard_gurb_create_initial_invoice_u","wizard.gurb.create.initial.invoice","model_wizard_gurb_create_initial_invoice","giscedata_polissa.group_giscedata_polissa_u",1,1,1,1
+"access_wizard_gurb_create_initial_invoice_r","wizard.gurb.create.initial.invoice","model_wizard_gurb_create_initial_invoice","giscedata_polissa.group_giscedata_polissa_r",0,0,0,0
+"access_wizard_gurb_create_initial_invoice_w","wizard.gurb.create.initial.invoice","model_wizard_gurb_create_initial_invoice","giscedata_polissa.group_giscedata_polissa_w",1,1,1,1

--- a/som_gurb/tests/tests_gurb_initial_quota.py
+++ b/som_gurb/tests/tests_gurb_initial_quota.py
@@ -13,20 +13,24 @@ class TestsGurbInitialQuota(TestsGurbBase):
         references = self.get_references()
         gurb_cups_id = references["owner_gurb_cups_id"]
         self.activar_polissa_CUPS(context={"polissa_xml_id": "polissa_0001"})
-        gurb_cups_o.create_initial_invoices(self.cursor, self.uid, gurb_cups_id, context=context)
+        invoice_ids, errors = gurb_cups_o.create_initial_invoices(
+            self.cursor, self.uid, gurb_cups_id, context=context
+        )
         invoice_id = gurb_cups_o.read(
-            self.cursor, self.uid, gurb_cups_id, ["invoice_ref"], context=context
-        )["invoice_ref"].split(",")[1]
+            self.cursor, self.uid, gurb_cups_id, ["initial_invoice_id"], context=context
+        )["initial_invoice_id"][0]
 
         pol_id = references["owner_pol_id"]
         pol_br = pol_o.browse(self.cursor, self.uid, pol_id, context=context)
-        invoice_br = invoice_o.browse(self.cursor, self.uid, int(invoice_id), context=context)
+        invoice_br = invoice_o.browse(self.cursor, self.uid, invoice_id, context=context)
 
         iva_21_tax_id = imd_o.get_object_reference(
             self.cursor, self.uid, "l10n_chart_ES", "iva_rep_21"
         )[1]
 
-        # TODO: account_id, address_invoice_id, journal_id, reference_type
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(len(invoice_ids), 1)
+        self.assertEqual(invoice_ids[0], invoice_id)
         self.assertEqual(invoice_br.partner_id.id, pol_br.titular.id)
         self.assertEqual(len(invoice_br.invoice_line), 1)
         self.assertEqual(invoice_br.invoice_line[0].quantity, 2.5)
@@ -34,3 +38,31 @@ class TestsGurbInitialQuota(TestsGurbBase):
         self.assertEqual(invoice_br.invoice_line[0].price_subtotal, 9.38)
         self.assertEqual(len(invoice_br.invoice_line[0].invoice_line_tax_id), 1)
         self.assertEqual(invoice_br.invoice_line[0].invoice_line_tax_id[0].id, iva_21_tax_id)
+
+    def test_gurb_cups_initial_invoice_already_exists(self):
+        context = {}
+
+        gurb_cups_o = self.openerp.pool.get("som.gurb.cups")
+
+        references = self.get_references()
+        gurb_cups_id = references["owner_gurb_cups_id"]
+        self.activar_polissa_CUPS(context={"polissa_xml_id": "polissa_0001"})
+        gurb_cups_o.create_initial_invoices(self.cursor, self.uid, gurb_cups_id, context=context)
+        invoice_id = gurb_cups_o.read(
+            self.cursor, self.uid, gurb_cups_id, ["initial_invoice_id"], context=context
+        )["initial_invoice_id"][0]
+
+        gurb_cups_br = gurb_cups_o.browse(self.cursor, self.uid, gurb_cups_id, context=context)
+
+        self.assertEqual(gurb_cups_br.initial_invoice_id.id, invoice_id)
+
+        invoice_ids, errors = gurb_cups_o.create_initial_invoices(
+            self.cursor, self.uid, gurb_cups_id, context=context
+        )
+
+        self.assertEqual(len(invoice_ids), 0)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(
+            errors[0],
+            "[GURB CUPS ID 1]: La factura d'inscripci\xc3\xb3 ja existeix."
+        )

--- a/som_gurb/views/som_gurb_cups_view.xml
+++ b/som_gurb/views/som_gurb_cups_view.xml
@@ -10,6 +10,7 @@
                 <form string="GURB">
                     <group col="4" colspan="4" string="General">
                         <field name="active" />
+                        <field name="id" />
                         <field name="cups_id" />
                         <field name="start_date" />
                         <field name="end_date" />
@@ -59,6 +60,22 @@
                     <field name="end_date" select="1" />
                 </tree>
             </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_invoices_from_gurb_cups">
+            <field name="name">Factures del GURB CUPS</field>
+            <field name="res_model">account.invoice</field>
+            <field name="src_model">som.gurb.cups</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('origin', '=', 'GURBCUPS'+id)]</field>
+        </record>
+        <record id="value_action_invoices_from_gurb_cups" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Factures del GURB CUPS</field>
+            <field name="key2">client_action_relate</field>
+            <field name="key">action</field>
+            <field name="model">som.gurb.cups</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_invoices_from_gurb_cups'))" />
         </record>
     </data>
 </openerp>

--- a/som_gurb/views/som_gurb_cups_view.xml
+++ b/som_gurb/views/som_gurb_cups_view.xml
@@ -18,7 +18,7 @@
                         <field name="extra_beta_kw" />
                         <field name="beta_percentage" />
                         <field name="owner_cups" />
-                        <field name="invoice_ref" />
+                        <field name="initial_invoice_id" />
                         <field name="general_conditions_id" />
                     </group>
                     <field name="betas_ids" nolabel="1" colspan="4" readonly="1" />

--- a/som_gurb/wizard/__init__.py
+++ b/som_gurb/wizard/__init__.py
@@ -1,2 +1,3 @@
 import wizard_create_distribution_agreement_file
 import wizard_gurb_create_new_beta
+import wizard_gurb_create_initial_invoice

--- a/som_gurb/wizard/wizard_gurb_create_initial_invoice.py
+++ b/som_gurb/wizard/wizard_gurb_create_initial_invoice.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+from tools.translate import _
+
+
+class WizardGurbCreateInitialInvoice(osv.osv_memory):
+
+    _name = "wizard.gurb.create.initial.invoice"
+
+    def _get_default_info(self, cursor, uid, context=None):
+        if context is None:
+            context = {}
+        gurb_cups_ids = context.get("active_ids", [])
+        return _(u"Es crearan {} factures d'inscripció.".format(len(gurb_cups_ids)))
+
+    def get_created_invoices(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+
+        wiz_br = self.browse(cursor, uid, ids[0], context=context)
+
+        invoice_ids = list(set(wiz_br.invoice_ids))
+
+        res = {
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'account.invoice',
+            'view_id': False,
+            'type': 'ir.actions.act_window',
+            'domain': "[('id', 'in', %s)]" % invoice_ids,
+        }
+
+        return res
+
+    def create_initial_invoices(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+
+        gurb_cups_o = self.pool.get("som.gurb.cups")
+        gurb_cups_ids = context.get("active_ids", [])
+        wiz_br = self.browse(cursor, uid, ids[0], context=context)
+
+        if not gurb_cups_ids:
+            raise osv.except_osv("Error", _("No s'han seleccionat IDs"))
+
+        invoice_ids, errors = gurb_cups_o.create_initial_invoices(cursor, uid, gurb_cups_ids)
+
+        errors = "\n".join(errors) if errors else "No hi ha hagut errors."
+        res = "S'han creat {} factures d'inscripció.".format(len(invoice_ids))
+
+        wiz_br.write(
+            {
+                "state": "end",
+                "info": res,
+                "errors": errors,
+                "invoice_ids": invoice_ids
+            },
+            context=context,
+        )
+
+    _columns = {
+        "state": fields.selection([("init", "Init"), ("end", "End")], "State"),
+        "invoice_ids": fields.text("IDs de les factures"),
+        "info": fields.text("Informació"),
+        "errors": fields.text("Errors"),
+    }
+
+    _defaults = {
+        "state": lambda *a: "init",
+        "info": _get_default_info,
+    }
+
+
+WizardGurbCreateInitialInvoice()

--- a/som_gurb/wizard/wizard_gurb_create_initial_invoice_view.xml
+++ b/som_gurb/wizard/wizard_gurb_create_initial_invoice_view.xml
@@ -15,11 +15,11 @@
                         <field name="errors" nolabel="1" readonly="1" height="200" width="800" />
                     </group>
                     <group colspan="4" attrs="{'invisible': [('state', '!=', 'init')]}">
-                        <button string="Cancel·lar" special="cancel" icon="gtk-close" colspan="2"/>
                         <button string="Crear factures" name="create_initial_invoices" type="object" icon="gtk-go-forward" colspan="2" />
+                        <button string="Cancel·lar" special="cancel" icon="gtk-close" colspan="2"/>
                     </group>
                     <group colspan="4" attrs="{'invisible': [('state', '=', 'init')]}">
-                        <button string="Veure factures" name="get_created_invoices" type="object" colspan="2"/>
+                        <button string="Veure factures" name="get_created_invoices" type="object" icon="gtk-go-forward" colspan="2"/>
                         <button string="Sortir" special="cancel" icon="gtk-close" colspan="2"/>
                     </group>
                 </form>

--- a/som_gurb/wizard/wizard_gurb_create_initial_invoice_view.xml
+++ b/som_gurb/wizard/wizard_gurb_create_initial_invoice_view.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_wizard_gurb_create_initial_invoice_form">
+            <field name="name">Creació factures inscripció</field>
+            <field name="model">wizard.gurb.create.initial.invoice</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Creació factures inscripció">
+                    <field name="state" invisible="1"/>
+                    <group colspan="4" string="Informació">
+                        <field name="info" nolabel="1" readonly="1" height="50" width="800"/>
+                    </group>
+                    <group colspan="4" string="Errors">
+                        <field name="errors" nolabel="1" readonly="1" height="200" width="800" />
+                    </group>
+                    <group colspan="4" attrs="{'invisible': [('state', '!=', 'init')]}">
+                        <button string="Cancel·lar" special="cancel" icon="gtk-close" colspan="2"/>
+                        <button string="Crear factures" name="create_initial_invoices" type="object" icon="gtk-go-forward" colspan="2" />
+                    </group>
+                    <group colspan="4" attrs="{'invisible': [('state', '=', 'init')]}">
+                        <button string="Veure factures" name="get_created_invoices" type="object" colspan="2"/>
+                        <button string="Sortir" special="cancel" icon="gtk-close" colspan="2"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_wizard_gurb_create_initial_invoice_form">
+            <field name="name">Crear factura inscripció GURB</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.gurb.create.initial.invoice</field>
+            <field name="view_type">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="view_wizard_gurb_create_initial_invoice_form" />
+        </record>
+        <record id="values_wizard_gurb_create_initial_invoice_form" model="ir.values">
+            <field name="object" eval="1" />
+            <field name="name">Crear factura inscripció GURB</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">som.gurb.cups</field>
+            <field name="value"
+                eval="'ir.actions.act_window,'+str(ref('action_wizard_gurb_create_initial_invoice_form'))" />
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu

Permetre a les usuàries la creació de factures d'inscripció de GURB. 

## Targeta on es demana o Incidència

https://somenergia.openproject.com/work_packages/250

## Comportament antic

- La lògica de creació de les factures no estava acabada.
- No hi havia cap `wizard` per cridar aquesta lògica.
- En el _report_ de la factura de comptabilitat s'arrodonien les unitats de les línies.

## Comportament nou

- Nou `wizard` a `som.gurb.cups` per crear factures d'inscripció.
- La creació de les factures ja funciona segons els requisits demanats.
- Millora en la gestió d'errors.
- En el _report_ de la factura de comptabilitat es mostren dos decimals de les unitats de les línies.

## Comprovacions

- [X] Hi ha testos
- [X] Reiniciar serveis
- [X] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
