### PR TITLE
Cancel ATR instead of deleting, and refactor to avoid infinite loops

### DIFF
--- a/som_switching/giscedata_atc.py
+++ b/som_switching/giscedata_atc.py
@@ -48,14 +48,30 @@ class GiscedataAtc(osv.osv):
         return res
 
     def unlink(self, cursor, uid, ids, context=None):
-        return self.case_cancel(cursor, uid, ids, context)
+        return self.case_and_atrs_cancel(cursor, uid, ids, context)
+
+    def case_and_atrs_cancel(self, cursor, uid, ids, *args):
+        r101_obj = self.pool.get("giscedata.switching")
+        if not isinstance(ids, (list, tuple)):
+            ids = [ids]
+
+        self.case_cancel(cursor, uid, ids, *args)
+
+        cancel_r1_ids = []
+        for atc in self.browse(cursor, uid, ids):
+            ref = atc.ref if atc.ref else atc.ref2
+            if ref and 'giscedata.switching,' in ref:
+                cancel_r1_ids.append(int(ref.split(',')[1]))
+
+        if cancel_r1_ids:
+            r101_obj.case_cancel(cursor, uid, cancel_r1_ids, *args)
+        return True
 
     def case_cancel(self, cursor, uid, ids, *args):  # noqa: C901
         if not isinstance(ids, (list, tuple)):
             ids = [ids]
 
         cancel_ids = []
-        cancel_r1_ids = []
         for atc_id in ids:
             atc = self.browse(cursor, uid, atc_id)
 
@@ -174,13 +190,8 @@ class GiscedataAtc(osv.osv):
                 )
 
             cancel_ids.append(atc_id)
-            if atc.process_step == "01" and r1 and r1.enviament_pendent == True:  # noqa: E712
-                cancel_r1_ids.append(r1.id)
 
         if cancel_ids:
-            if cancel_r1_ids:
-                r101_obj = self.pool.get("giscedata.switching")
-                r101_obj.case_cancel(cursor, uid, cancel_r1_ids, *args)
             return super(GiscedataAtc, self).case_cancel(cursor, uid, cancel_ids, *args)
 
         return True

--- a/som_switching/giscedata_switching.py
+++ b/som_switching/giscedata_switching.py
@@ -338,7 +338,7 @@ class GiscedataSwitching(osv.osv):
 
         for switching in self.browse(cursor, uid, ids):
             step = switching.step_id and switching.step_id.name
-            if switching.enviament_pendent is False or step not in [None, '01']:
+            if not switching.enviament_pendent or step not in [None, '01']:
                 raise osv.except_osv(
                     _(u"Warning"),
                     _(

--- a/som_switching/migrations/5.0.24.5.1/post-0001-update-security.py
+++ b/som_switching/migrations/5.0.24.5.1/post-0001-update-security.py
@@ -1,0 +1,15 @@
+from oopgrade import oopgrade
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    module = 'som_switching'
+
+    oopgrade.load_data(
+        cursor, module, 'security/ir.model.access.csv', idref=None, mode='update'
+    )
+
+
+migrate = up

--- a/som_switching/security/ir.model.access.csv
+++ b/som_switching/security/ir.model.access.csv
@@ -4,3 +4,5 @@
 "access_giscedata_atc_tag_u","giscedata.atc.tag","model_giscedata_atc_tag","crm.group_crm_user",1,1,1,0
 "access_wizard_close_obsolete_cases_rcwd","wizard.close.obsolete.cases","model_wizard_close_obsolete_cases","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
 "access_wizard_giscedata_switching_log_reexport_rcwd","wizard.giscedata.switching.log.reexport","model_wizard_giscedata_switching_log_reexport","giscedata_switching.group_switching_manager",1,1,1,1
+"access_wizard_validate_d101_rcwd","wizard.validate.d101","model_wizard_validate_d101","giscedata_switching.group_switching_manager",1,1,1,1
+"access_wizard_validate_d101_rcwd","wizard.validate.d101","model_wizard_validate_d101","giscedata_switching.group_switching_user",1,1,1,1

--- a/som_switching/security/ir.model.access.csv
+++ b/som_switching/security/ir.model.access.csv
@@ -4,5 +4,4 @@
 "access_giscedata_atc_tag_u","giscedata.atc.tag","model_giscedata_atc_tag","crm.group_crm_user",1,1,1,0
 "access_wizard_close_obsolete_cases_rcwd","wizard.close.obsolete.cases","model_wizard_close_obsolete_cases","giscedata_facturacio.group_giscedata_facturacio_u",1,1,1,1
 "access_wizard_giscedata_switching_log_reexport_rcwd","wizard.giscedata.switching.log.reexport","model_wizard_giscedata_switching_log_reexport","giscedata_switching.group_switching_manager",1,1,1,1
-"access_wizard_validate_d101_rcwd","wizard.validate.d101","model_wizard_validate_d101","giscedata_switching.group_switching_manager",1,1,1,1
 "access_wizard_validate_d101_rcwd","wizard.validate.d101","model_wizard_validate_d101","giscedata_switching.group_switching_user",1,1,1,1

--- a/som_switching/tests/__init__.py
+++ b/som_switching/tests/__init__.py
@@ -8,5 +8,6 @@ from tests_wizard_comment_to_F1 import *
 from tests_wizard_switching_b1 import *
 from tests_wizard_import_atr_and_f1 import *
 from tests_unlink_atc import *
+from tests_unlink_switching import *
 from tests_wizard_validate_d101 import *
 from tests_wizard_reexport_log import *

--- a/som_switching/tests/tests_unlink_switching.py
+++ b/som_switching/tests/tests_unlink_switching.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from destral.transaction import Transaction
+from giscedata_switching.tests.common_tests import TestSwitchingImport
+
+
+class TestUnlinkSwitching(TestSwitchingImport):
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.pool = self.openerp.pool
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test_switching_and_atc_is_cancelled_on_unlink(self):
+        """
+        Test per comprovar que l'unlink no elimina sino que cancela el ATR
+        """
+        sw_obj = self.pool.get("giscedata.switching")
+        atc_obj = self.pool.get("giscedata.atc")
+        step_obj = self.openerp.pool.get("giscedata.switching.r1.01")
+        imd_obj = self.openerp.pool.get("ir.model.data")
+
+        atc_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_switching", "cas_atc_0001"
+        )[1]
+
+        # it needs enviament pendent
+        self.switch(self.txn, "comer")
+        contract_id = self.get_contract_id(self.txn)
+
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, "R1", "01")
+        r101 = step_obj.browse(self.cursor, self.uid, step_id)
+        r101.write({"enviament_pendent": True})
+
+        sw = sw_obj.browse(self.cursor, self.uid, r101.sw_id.id)
+        atc = atc_obj.browse(self.cursor, self.uid, atc_id)
+
+        sw_obj.write(
+            self.cursor, self.uid, sw.id, {"ref": "giscedata.atc," + str(atc_id)}
+        )
+
+        sw.unlink()
+
+        self.assertEqual(sw.state, "cancel")
+        self.assertEqual(atc.state, "cancel")
+
+    def test_switching_in_progress_cant_be_cancelled(self):
+        """
+        Test per comprovar que si esta en progres no es pot cancel·lar
+        """
+        sw_obj = self.pool.get("giscedata.switching")
+        imd_obj = self.openerp.pool.get("ir.model.data")
+
+        sw_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_switching", "sw_001"
+        )[1]
+        sw = sw_obj.browse(self.cursor, self.uid, sw_id)
+
+        sw_obj.write(self.cursor, self.uid, sw_id, {"state": "pending"})
+
+        try:
+            sw_obj.case_cancel(self.cursor, self.uid, sw_id)
+        except Exception as e:
+            sw_err = e
+
+        self.assertEqual(
+            sw_err.value,
+            "No es poden cancel·lar casos ATR en marxa, revisa els protocols o demana ajuda."
+        )
+
+        self.assertEqual(sw.state, "pending")

--- a/som_switching/wizard/__init__.py
+++ b/som_switching/wizard/__init__.py
@@ -12,3 +12,4 @@ import wizard_import_atr_and_f1
 import wizard_close_obsolete_cases
 import wizard_validate_d101
 import giscedata_switching_log_reexport_wizard
+import wizard_switching_multi_change

--- a/som_switching/wizard/wizard_switching_multi_change.py
+++ b/som_switching/wizard/wizard_switching_multi_change.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from osv import osv
+from tools.sql_utils import isolation
+
+
+class WizardSwitchingMultiChange(osv.osv_memory):
+    _name = 'wizard.switching.multi.change'
+    _inherit = 'wizard.switching.multi.change'
+
+    @isolation(readonly=True, isolation_level='repeatable_read')
+    def perform_atr_change(self, cursor, uid, ids, context=None):
+        if not context:
+            context = {}
+
+        wiz = self.browse(cursor, uid, ids[0], context=context)
+        new_state = context.get('new_state', wiz.new_state)
+
+        if new_state != 'cancel':
+            return super(WizardSwitchingMultiChange, self).perform_atr_change(
+                cursor, uid, ids, context=context
+            )
+
+        # We have some special conditions fot switching cancels
+        num_cases = len(context.get('active_ids', []))
+        updated = num_cases
+        output = ''
+
+        for sw_id in context.get('active_ids', []):
+            try:
+                # As the original wizard, we need to do this because it's in read only
+                # mode :/
+                osv.osv_pool().execute(
+                    cursor.dbname,
+                    uid,
+                    'giscedata.switching',
+                    'case_and_cacs_cancel',
+                    [sw_id]
+                )
+            except osv.except_osv as e:
+                updated -= 1
+                output += "\n- No s'ha pogut cancel·lar l'ATR {}: {}".format(
+                    sw_id, e.value
+                )
+
+        output = '{}/{} ATRs cancel·lats'.format(updated, num_cases) + output
+
+        self.write(cursor, uid, ids, {
+            'result': output,
+            'state': 'end'
+        })
+
+
+WizardSwitchingMultiChange()


### PR DESCRIPTION
## Objectiu
Capar que es puguin esborrar ATR vinculats a cacs (i ben pensat, que mai es borrin ATRs simplement :P)

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/90/

## Comportament antic
Es poden esborrar ATRs i per falta de referencies es lia parda

## Comportament nou
Ara es cancel·len, a més sota certes condicions, i cancel·lant tb CACs realcionats

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
