### PR TITLE
Treure max_proc dels workers

### DIFF
--- a/som_infoenergia/som_enviament_massiu.py
+++ b/som_infoenergia/som_enviament_massiu.py
@@ -98,12 +98,7 @@ class SomEnviamentMassiu(osv.osv):
             "infoenergia.infoenergia_send",
             job_ids,
         )
-        amax_proc = int(
-            self.pool.get("res.config").get(cursor, uid, "infoenergia_send_tasks_max_procs", "0")
-        )
-        if not amax_proc:
-            amax_proc = None
-        aw = AutoWorker(queue="infoenergia_send", default_result_ttl=24 * 3600, max_procs=amax_proc)
+        aw = AutoWorker(queue="infoenergia_send", default_result_ttl=24 * 3600)
         aw.work()
 
     def send_single_report(self, cursor, uid, _id, context=None):

--- a/som_infoenergia/som_infoenergia_data.xml
+++ b/som_infoenergia/som_infoenergia_data.xml
@@ -360,16 +360,6 @@
         </record>
     </data>
     <data noupdate="1">
-        <record model="res.config" id="infoenergia_send_tasks_max_procs">
-            <field name="name">infoenergia_send_tasks_max_procs</field>
-            <field name="value">0</field>
-            <field name="description">Numero màxim de workers dedicats enviar informes d'Infoenergia en paral·lel. Si s'indica '0' (per defecte), no hi ha limit.</field>
-        </record>
-        <record model="res.config" id="infoenergia_create_enviaments_tasks_max_procs">
-            <field name="name">infoenergia_create_enviaments_tasks_max_procs</field>
-            <field name="value">0</field>
-            <field name="description">Numero màxim de workers dedicats a crear enviaments d'Infoenergia en paral·lel. Si s'indica '0' (per defecte), no hi ha limit.</field>
-        </record>
         <record model="res.config" id="som_conany_pdf_days_limit" >
             <field name="name">som_conany_pdf_days_limit</field>
             <field name="value">[355,375]</field>

--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -209,12 +209,7 @@ class SomInfoenergiaEnviament(osv.osv):
             "infoenergia.infoenergia_send",
             job_ids,
         )
-        amax_proc = int(
-            self.pool.get("res.config").get(cursor, uid, "infoenergia_send_tasks_max_procs", "0")
-        )
-        if not amax_proc:
-            amax_proc = None
-        aw = AutoWorker(queue="infoenergia_send", default_result_ttl=24 * 3600, max_procs=amax_proc)
+        aw = AutoWorker(queue="infoenergia_send", default_result_ttl=24 * 3600)
         aw.work()
 
     def send_single_report(self, cursor, uid, _id, context=None):

--- a/som_infoenergia/som_infoenergia_lot.py
+++ b/som_infoenergia/som_infoenergia_lot.py
@@ -126,16 +126,8 @@ class SomInfoenergiaLotEnviament(osv.osv):
             "infoenergia.create_enviaments",
             job_ids,
         )
-        amax_proc = int(
-            self.pool.get("res.config").get(
-                cursor, uid, "infoenergia_create_enviaments_tasks_max_procs", "0"
-            )
-        )
-        if not amax_proc:
-            amax_proc = None
         aw = AutoWorker(
-            queue="infoenergia_create_enviament", default_result_ttl=24 * 3600, max_procs=amax_proc
-        )
+            queue="infoenergia_create_enviament", default_result_ttl=24 * 3600)
         aw.work()
 
         return True


### PR DESCRIPTION
## Objectiu
Treure max_proc dels workers

## Targeta on es demana o Incidència
Xat

## Comportament antic
Podíem definir el màxim de workers que es creaven per enviar infoenergies en paralel.

## Comportament nou
Ja no el podem definir perquè GISCE ha limitat que el max_proc depengui del load average del servidor on es crida els autoworkers.
https://github.com/gisce/autoworker/pull/19/

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
