### PR TITLE
Nova condició d'autoreclama per sortir del estat "Revisar"

### DIFF
--- a/som_autoreclama/migrations/5.0.24.6.0/post-0001_reload_atc_states.py
+++ b/som_autoreclama/migrations/5.0.24.6.0/post-0001_reload_atc_states.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML som_autoreclama_state_data.xml")
+    load_data_records(
+        cursor, 'som_autoreclama', 'som_autoreclama_state_data.xml',
+        [
+            'review_state_workflow_polissa',
+            'conditions_revisar_to_correct_state_workflow_polissa',
+        ],
+        mode='init'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_autoreclama/som_autoreclama_state_data.xml
+++ b/som_autoreclama/som_autoreclama_state_data.xml
@@ -683,7 +683,7 @@
             <field name="active" eval="True"/>
         </record>
         <record model="som.autoreclama.state.condition" id="conditions_revisar_to_correct_state_workflow_polissa">
-            <field name="days">60</field>
+            <field name="days">61</field>
             <field name="condition_code">F1ok</field>
             <field name="state_id" ref="review_state_workflow_polissa"/>
             <field name="next_state_id" ref="correct_state_workflow_polissa"/>

--- a/som_autoreclama/som_autoreclama_state_data.xml
+++ b/som_autoreclama/som_autoreclama_state_data.xml
@@ -613,7 +613,7 @@
         <record model="som.autoreclama.state" id="review_state_workflow_polissa">
             <field name="name">Revisar</field>
             <field name="priority">30</field>
-            <field name="is_last" eval="True"/>
+            <field name="is_last" eval="False"/>
             <field name="workflow_id" ref="workflow_polissa"/>
             <field name="active" eval="True"/>
             <field name="generate_atc_parameters_text">{"model": "giscedata.polissa", "method": "som_autoreclama_add_to_info_gestio_endarrerida", "params": {"message": "Autoreclama passat a estat 'Revisar'"}}</field>
@@ -680,6 +680,14 @@
             <field name="state_id" ref="loop_state_workflow_polissa"/>
             <field name="next_state_id" ref="review_state_workflow_polissa"/>
             <field name="priority">25</field>
+            <field name="active" eval="True"/>
+        </record>
+        <record model="som.autoreclama.state.condition" id="conditions_revisar_to_correct_state_workflow_polissa">
+            <field name="days">60</field>
+            <field name="condition_code">F1ok</field>
+            <field name="state_id" ref="review_state_workflow_polissa"/>
+            <field name="next_state_id" ref="correct_state_workflow_polissa"/>
+            <field name="priority">10</field>
             <field name="active" eval="True"/>
         </record>
         <record id="ir_cron_autoreclama_states_updater" model="ir.cron" forcecreate="1">


### PR DESCRIPTION
## Objectiu

Crear una nova condició per tal que una pòlissa en estat d'autoreclama "Revisar" surti cap a l'estat "Correcte" si arriben F1's que permeten que la "Dates últimes lectures facturades De F1" estigui a menys de (60?) dies

## Targeta on es demana o Incidència

https://hs.somenergia.coop/conversation/10945?folder_id=259

## Comportament antic

Les pòlisses en estat "Revisar" s'hi quedaven per sempre fins que manualment algú les revisés

## Comportament nou

Si entren F1's que permeten que la "Dates últimes lectures facturades De F1" estigui a menys de (60?) dies canvien l'estat a "Correcte"

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions
