### PR TITLE
El valor del preu de generació es mostra en notació científica quan preus negatius amb indexada a la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako
@@ -28,7 +28,7 @@ count = 1
             <td class="td_bold detall_td">${_(u"Preu energia [€/kWh]")}</td>
             % for p in id.showing_periods:
                 % if p in generation_lines_data:
-                    <td>${_(u"%s") %(locale.str(locale.atof(formatLang(generation_lines_data[p]["price_unit_multi"], digits=6))))}</td>
+                    <td>${_(u"%s") %(formatLang(generation_lines_data[p]["price_unit_multi"], digits=6).rstrip("0"))}</td>
                 % else:
                     <td></td>
                 % endif


### PR DESCRIPTION
## Objectiu

Mostrar correctament els preus a la factura en pdf

## Targeta on es demana o Incidència

https://hs.somenergia.coop/conversation/1547?folder_id=259

## Comportament antic

![image](https://github.com/Som-Energia/openerp_som_addons/assets/26924515/874eb085-e942-4ad1-ba82-c6689fefd861)

## Comportament nou

![image](https://github.com/Som-Energia/openerp_som_addons/assets/26924515/4ada1954-a253-4f74-9332-dd543f1ce873)

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
