### PR TITLE
Afegim som_addons al GA per reusabilitat

### DIFF
--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -89,6 +89,9 @@ jobs:
           export ROOT_DIR_SRC=${{github.workspace}}/..
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/Som-Energia/erp.git -b ${{ inputs.erpbranch }} $ROOT_DIR_SRC/erp
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/Som-Energia/libFacturacioATR.git $ROOT_DIR_SRC/libFacturacioATR
+          if [ ! -d "$ROOT_DIR_SRC/openerp_som_addons" ]; then
+                  git clone --depth 1 https://github.com/Som-Energia/openerp_som_addons.git $ROOT_DIR_SRC/openerp_som_addons
+          fi
           if [ ! -d "$ROOT_DIR_SRC/somenergia-generationkwh" ]; then
                   git clone --depth 1 https://github.com/Som-Energia/somenergia-generationkwh.git $ROOT_DIR_SRC/somenergia-generationkwh
           fi


### PR DESCRIPTION
## Objectiu
Afegim el repo openerp_som_addons al workflow reusable de GA per reusabilitat des de repos de mòduls del ERP que necessiten a la vegada mòduls de som_addons.

## Targeta on es demana o Incidència
https://github.com/Som-Energia/somenergia-generationkwh/pull/152
https://github.com/Som-Energia/somenergia-generationkwh/pull/153

## Comportament antic
Quan es cridava el reusable_workflow des d'un altre repo, no es comprovaba que aquest repo estava clonat.

## Comportament nou
Es comprova sempre si aquest repo està clonat i sinó ho està, el clona.


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
