### PR TITLE
Posar el camp procés de tall de la pòlissa a Default process si nou titular es empresa

### DIFF
--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -437,20 +437,6 @@ class GiscedataPolissa(osv.osv):
         payment_mode_id = payment_mode_o.search(cursor, uid, [("name", "=", "ENGINYERS")])
         self.write(cursor, uid, ids, {"payment_mode_id": payment_mode_id[0]})
 
-        imd_obj = self.pool.get("ir.model.data")
-        default_process = imd_obj.get_object_reference(
-            cursor, uid, "account_invoice_pending", "default_pending_state_process"
-        )[1]
-        bo_social_process = imd_obj.get_object_reference(
-            cursor, uid, 'giscedata_facturacio_comer_bono_social',
-            'bono_social_pending_state_process'
-        )[1]
-        for id in ids:
-            if self._is_enterprise(cursor, uid, id):
-                self.write(cursor, uid, id, {"process_id": default_process})
-            else:
-                self.write(cursor, uid, id, {"process_id": bo_social_process})
-
         return super(GiscedataPolissa, self).wkf_activa(cursor, uid, ids)
 
     def copy_data(self, cursor, uid, id, default=None, context=None):

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -411,6 +411,21 @@ class GiscedataPolissa(osv.osv):
 
         return res
 
+    def _is_enterprise(self, cursor, uid, id, context=None):
+        pol = self.browse(cursor, uid, id, context)
+        if pol.cnae.name not in ["9810", "9820"]:
+            return True
+
+        partner_obj = self.pool.get("res.partner")
+        if partner_obj.is_enterprise_vat(pol.titular.vat):
+            return True
+
+        for pot in pol.potencies_periode:
+            if pot.potencia > 10.0:
+                return True
+
+        return False
+
     def wkf_activa(self, cursor, uid, ids):
         if not isinstance(ids, list):
             ids = [ids]
@@ -418,6 +433,14 @@ class GiscedataPolissa(osv.osv):
         payment_mode_o = self.pool.get("payment.mode")
         payment_mode_id = payment_mode_o.search(cursor, uid, [("name", "=", "ENGINYERS")])
         self.write(cursor, uid, ids, {"payment_mode_id": payment_mode_id[0]})
+
+        for id in ids:
+            if self._is_enterprise(cursor, uid, id):
+                imd_obj = self.pool.get("ir.model.data")
+                default_process = imd_obj.get_object_reference(
+                    cursor, uid, "account_invoice_pending", "default_pending_state_process"
+                )[1]
+                self.write(cursor, uid, id, {"process_id": default_process})
 
         return super(GiscedataPolissa, self).wkf_activa(cursor, uid, ids)
 
@@ -431,6 +454,14 @@ class GiscedataPolissa(osv.osv):
         payment_mode_o = self.pool.get("payment.mode")
         payment_mode_id = payment_mode_o.search(cursor, uid, [("name", "=", "ENGINYERS")])
         default.update({"payment_mode_id": payment_mode_id[0]})
+
+        if self._is_enterprise(cursor, uid, id, context=context):
+            imd_obj = self.pool.get("ir.model.data")
+            default_process = imd_obj.get_object_reference(
+                cursor, uid, "account_invoice_pending", "default_pending_state_process"
+            )[1]
+            default.update({"process_id": default_process})
+
         return super(GiscedataPolissa, self).copy_data(cursor, uid, id, default, context=context)
 
     def _ff_search_ssaa(self, cursor, uid, ids, field_name, args, context=None):

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -412,6 +412,9 @@ class GiscedataPolissa(osv.osv):
         return res
 
     def _is_enterprise(self, cursor, uid, id, context=None):
+        if isinstance(id, list):
+            id = id[0]
+
         pol = self.browse(cursor, uid, id, context)
         if pol.cnae.name not in ["9810", "9820"]:
             return True

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -461,19 +461,6 @@ class GiscedataPolissa(osv.osv):
         payment_mode_id = payment_mode_o.search(cursor, uid, [("name", "=", "ENGINYERS")])
         default.update({"payment_mode_id": payment_mode_id[0]})
 
-        imd_obj = self.pool.get("ir.model.data")
-        if self._is_enterprise(cursor, uid, id, context=context):
-            default_process = imd_obj.get_object_reference(
-                cursor, uid, "account_invoice_pending", "default_pending_state_process"
-            )[1]
-            default.update({"process_id": default_process})
-        else:
-            bo_social_process = imd_obj.get_object_reference(
-                cursor, uid, 'giscedata_facturacio_comer_bono_social',
-                'bono_social_pending_state_process'
-            )[1]
-            default.update({"process_id": bo_social_process})
-
         return super(GiscedataPolissa, self).copy_data(cursor, uid, id, default, context=context)
 
     def _ff_search_ssaa(self, cursor, uid, ids, field_name, args, context=None):

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -434,13 +434,19 @@ class GiscedataPolissa(osv.osv):
         payment_mode_id = payment_mode_o.search(cursor, uid, [("name", "=", "ENGINYERS")])
         self.write(cursor, uid, ids, {"payment_mode_id": payment_mode_id[0]})
 
+        imd_obj = self.pool.get("ir.model.data")
+        default_process = imd_obj.get_object_reference(
+            cursor, uid, "account_invoice_pending", "default_pending_state_process"
+        )[1]
+        bo_social_process = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_facturacio_comer_bono_social',
+            'bono_social_pending_state_process'
+        )[1]
         for id in ids:
             if self._is_enterprise(cursor, uid, id):
-                imd_obj = self.pool.get("ir.model.data")
-                default_process = imd_obj.get_object_reference(
-                    cursor, uid, "account_invoice_pending", "default_pending_state_process"
-                )[1]
                 self.write(cursor, uid, id, {"process_id": default_process})
+            else:
+                self.write(cursor, uid, id, {"process_id": bo_social_process})
 
         return super(GiscedataPolissa, self).wkf_activa(cursor, uid, ids)
 
@@ -455,12 +461,18 @@ class GiscedataPolissa(osv.osv):
         payment_mode_id = payment_mode_o.search(cursor, uid, [("name", "=", "ENGINYERS")])
         default.update({"payment_mode_id": payment_mode_id[0]})
 
+        imd_obj = self.pool.get("ir.model.data")
         if self._is_enterprise(cursor, uid, id, context=context):
-            imd_obj = self.pool.get("ir.model.data")
             default_process = imd_obj.get_object_reference(
                 cursor, uid, "account_invoice_pending", "default_pending_state_process"
             )[1]
             default.update({"process_id": default_process})
+        else:
+            bo_social_process = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_facturacio_comer_bono_social',
+                'bono_social_pending_state_process'
+            )[1]
+            default.update({"process_id": bo_social_process})
 
         return super(GiscedataPolissa, self).copy_data(cursor, uid, id, default, context=context)
 

--- a/som_polissa/giscedata_switching_helpers.py
+++ b/som_polissa/giscedata_switching_helpers.py
@@ -36,5 +36,22 @@ class GiscedataSwitchingHelpers(osv.osv):
 
         return True
 
+    def activar_polissa_from_m1_canvi_titular_subrogacio(self, cursor, uid, sw_id, old_polissa=None, context=None):  # noqa: E501
+        res = super(
+            GiscedataSwitchingHelpers, self
+        ).activar_polissa_from_m1_canvi_titular_subrogacio(
+            cursor, uid, sw_id, old_polissa=old_polissa, context=context)
+
+        sw_obj = self.pool.get("giscedata.switching")
+        sw = sw_obj.browse(cursor, uid, sw_id, context=context)
+        if sw.cups_polissa_id._is_enterprise():
+            imd_obj = self.pool.get("ir.model.data")
+            default_process = imd_obj.get_object_reference(
+                cursor, uid, "account_invoice_pending", "default_pending_state_process"
+            )[1]
+            sw.cups_polissa_id.write({"process_id": default_process})
+
+        return res
+
 
 GiscedataSwitchingHelpers()

--- a/som_polissa/giscedata_switching_helpers.py
+++ b/som_polissa/giscedata_switching_helpers.py
@@ -43,9 +43,10 @@ class GiscedataSwitchingHelpers(osv.osv):
             cursor, uid, sw_id, old_polissa=old_polissa, context=context)
 
         imd_obj = self.pool.get("ir.model.data")
+        pol_obj = self.pool.get("giscedata.polissa")
         sw_obj = self.pool.get("giscedata.switching")
         sw = sw_obj.browse(cursor, uid, sw_id, context=context)
-        if sw.cups_polissa_id._is_enterprise():
+        if pol_obj._is_enterprise(cursor, uid, sw.cups_polissa_id.id, context=context):
             default_process = imd_obj.get_object_reference(
                 cursor, uid, "account_invoice_pending", "default_pending_state_process"
             )[1]

--- a/som_polissa/giscedata_switching_helpers.py
+++ b/som_polissa/giscedata_switching_helpers.py
@@ -42,14 +42,20 @@ class GiscedataSwitchingHelpers(osv.osv):
         ).activar_polissa_from_m1_canvi_titular_subrogacio(
             cursor, uid, sw_id, old_polissa=old_polissa, context=context)
 
+        imd_obj = self.pool.get("ir.model.data")
         sw_obj = self.pool.get("giscedata.switching")
         sw = sw_obj.browse(cursor, uid, sw_id, context=context)
         if sw.cups_polissa_id._is_enterprise():
-            imd_obj = self.pool.get("ir.model.data")
             default_process = imd_obj.get_object_reference(
                 cursor, uid, "account_invoice_pending", "default_pending_state_process"
             )[1]
             sw.cups_polissa_id.write({"process_id": default_process})
+        else:
+            bo_social_process = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_facturacio_comer_bono_social',
+                'bono_social_pending_state_process'
+            )[1]
+            sw.cups_polissa_id.write({"process_id": bo_social_process})
 
         return res
 

--- a/som_polissa/tests/som_polissa_tests.py
+++ b/som_polissa/tests/som_polissa_tests.py
@@ -145,28 +145,3 @@ class TestSomPolissa(testing.OOTestCase):
         self.crea_potencia(12.0, self.contract3_id)
         ent = self.polissa_obj._is_enterprise(self.cursor, self.uid, self.contract3_id)
         self.assertEqual(ent, True)  # power
-
-    def test__copy_data_enterprise(self):
-        data = {}
-        self.crea_potencia(4.4, self.contract1_id)
-        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract1_id, data)
-        self.assertTrue('process_id' in data)
-        self.assertEqual(data['process_id'], self.default_process)
-
-        data = {}
-        self.crea_potencia(5.4, self.contract2_id)
-        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract2_id, data)
-        self.assertTrue('process_id' in data)
-        self.assertEqual(data['process_id'], self.default_process)
-
-        data = {}
-        self.crea_potencia(6.4, self.contract3_id)
-        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract3_id, data)
-        self.assertTrue('process_id' in data)
-        self.assertEqual(data['process_id'], self.bo_social_process)
-
-        data = {}
-        self.crea_potencia(12.0, self.contract3_id)
-        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract3_id, data)
-        self.assertTrue('process_id' in data)
-        self.assertEqual(data['process_id'], self.default_process)

--- a/som_polissa/tests/som_polissa_tests.py
+++ b/som_polissa/tests/som_polissa_tests.py
@@ -25,6 +25,18 @@ class TestSomPolissa(testing.OOTestCase):
         self.eie_vat_id = self.get_ref("som_polissa", "categ_eie_persona_juridic")
         self.eie_cnae_vat_id = self.get_ref("som_polissa", "categ_eie_CNAE_CIF")
 
+        self.potencia_obj = self.openerp.pool.get("giscedata.polissa.potencia.contractada.periode")
+        self.periodes_obj = self.openerp.pool.get("giscedata.polissa.tarifa.periodes")
+        self.imd_obj = self.openerp.pool.get("ir.model.data")
+        self.default_process = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "account_invoice_pending",
+            "default_pending_state_process"
+        )[1]
+        self.bo_social_process = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'giscedata_facturacio_comer_bono_social',
+            'bono_social_pending_state_process'
+        )[1]
+
     def tearDown(self):
         self.txn.stop()
 
@@ -108,3 +120,53 @@ class TestSomPolissa(testing.OOTestCase):
         self.polissa_obj.create(self.cursor, self.uid, vals)
 
         self.assertEqual(mock_func.call_count, 1)
+
+    def crea_potencia(self, potencia, polissa_id):
+        vals = {
+            'potencia': potencia,
+            'polissa_id': polissa_id,
+            'periode_id': self.periodes_obj.search(self.cursor, self.uid, [])[0]
+        }
+        return self.potencia_obj.create(self.cursor, self.uid, vals)
+
+    def test__is_enterprise(self):
+        self.crea_potencia(4.4, self.contract1_id)
+        ent = self.polissa_obj._is_enterprise(self.cursor, self.uid, self.contract1_id)
+        self.assertEqual(ent, True)  # CNAE
+
+        self.crea_potencia(5.4, self.contract2_id)
+        ent = self.polissa_obj._is_enterprise(self.cursor, self.uid, self.contract2_id)
+        self.assertEqual(ent, True)  # VAT
+
+        self.crea_potencia(6.4, self.contract3_id)
+        ent = self.polissa_obj._is_enterprise(self.cursor, self.uid, self.contract3_id)
+        self.assertEqual(ent, False)  # nothing
+
+        self.crea_potencia(12.0, self.contract3_id)
+        ent = self.polissa_obj._is_enterprise(self.cursor, self.uid, self.contract3_id)
+        self.assertEqual(ent, True)  # power
+
+    def test__copy_data_enterprise(self):
+        data = {}
+        self.crea_potencia(4.4, self.contract1_id)
+        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract1_id, data)
+        self.assertTrue('process_id' in data)
+        self.assertEqual(data['process_id'], self.default_process)
+
+        data = {}
+        self.crea_potencia(5.4, self.contract2_id)
+        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract2_id, data)
+        self.assertTrue('process_id' in data)
+        self.assertEqual(data['process_id'], self.default_process)
+
+        data = {}
+        self.crea_potencia(6.4, self.contract3_id)
+        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract3_id, data)
+        self.assertTrue('process_id' in data)
+        self.assertEqual(data['process_id'], self.bo_social_process)
+
+        data = {}
+        self.crea_potencia(12.0, self.contract3_id)
+        self.polissa_obj.copy_data(self.cursor, self.uid, self.contract3_id, data)
+        self.assertTrue('process_id' in data)
+        self.assertEqual(data['process_id'], self.default_process)

--- a/som_switching/giscedata_switching_m1.py
+++ b/som_switching/giscedata_switching_m1.py
@@ -15,24 +15,31 @@ class GiscedataSwitchingM1_01(osv.osv):
                     "category_id": [(6, 0, [])],
                 }
             )
-            titular_id = new_contract_values.get('titular')
-            if titular_id:
-                imd_obj = self.pool.get("ir.model.data")
-                partner_obj = self.pool.get("res.partner")
-                vat = partner_obj.read(cursor, uid, titular_id, ['vat'])['vat']
-                if partner_obj.is_enterprise_vat(vat):
-                    default_process = imd_obj.get_object_reference(
-                        cursor, uid, "account_invoice_pending", "default_pending_state_process"
-                    )[1]
-                    new_contract_values.update({"process_id": default_process})
-                else:
-                    bo_social_process = imd_obj.get_object_reference(
-                        cursor, uid, 'giscedata_facturacio_comer_bono_social',
-                        'bono_social_pending_state_process'
-                    )[1]
-                    new_contract_values.update({"process_id": bo_social_process})
 
         res = super(GiscedataSwitchingM1_01, self).config_step(cursor, uid, ids, vals, context)
+
+        titular_id = new_contract_values.get('titular')
+        if titular_id:
+
+            m1 = self.browse(cursor, uid, ids, context=context)
+            new_polissa_id = m1.sw_id.polissa_ref_id.id
+
+            imd_obj = self.pool.get("ir.model.data")
+            partner_obj = self.pool.get("res.partner")
+            pol_obj = self.pool.get("giscedata.polissa")
+            vat = partner_obj.read(cursor, uid, titular_id, ['vat'])['vat']
+            if partner_obj.is_enterprise_vat(vat):
+                new_process = imd_obj.get_object_reference(
+                    cursor, uid, "account_invoice_pending", "default_pending_state_process"
+                )[1]
+
+            else:
+                new_process = imd_obj.get_object_reference(
+                    cursor, uid, 'giscedata_facturacio_comer_bono_social',
+                    'bono_social_pending_state_process'
+                )[1]
+            pol_obj.write(cursor, uid, new_polissa_id, {'process_id': new_process}, context=context)
+
         return res
 
 

--- a/som_switching/giscedata_switching_m1.py
+++ b/som_switching/giscedata_switching_m1.py
@@ -18,27 +18,27 @@ class GiscedataSwitchingM1_01(osv.osv):
 
         res = super(GiscedataSwitchingM1_01, self).config_step(cursor, uid, ids, vals, context)
 
-        titular_id = new_contract_values.get('titular')
-        if titular_id:
+        if new_contract_values:
+            titular_id = new_contract_values.get('titular')
+            if titular_id:
+                m1 = self.browse(cursor, uid, ids, context=context)
+                new_polissa_id = m1.sw_id.polissa_ref_id.id
 
-            m1 = self.browse(cursor, uid, ids, context=context)
-            new_polissa_id = m1.sw_id.polissa_ref_id.id
-
-            imd_obj = self.pool.get("ir.model.data")
-            partner_obj = self.pool.get("res.partner")
-            pol_obj = self.pool.get("giscedata.polissa")
-            vat = partner_obj.read(cursor, uid, titular_id, ['vat'])['vat']
-            if partner_obj.is_enterprise_vat(vat):
-                new_process = imd_obj.get_object_reference(
-                    cursor, uid, "account_invoice_pending", "default_pending_state_process"
-                )[1]
-
-            else:
-                new_process = imd_obj.get_object_reference(
-                    cursor, uid, 'giscedata_facturacio_comer_bono_social',
-                    'bono_social_pending_state_process'
-                )[1]
-            pol_obj.write(cursor, uid, new_polissa_id, {'process_id': new_process}, context=context)
+                imd_obj = self.pool.get("ir.model.data")
+                partner_obj = self.pool.get("res.partner")
+                pol_obj = self.pool.get("giscedata.polissa")
+                vat = partner_obj.read(cursor, uid, titular_id, ['vat'])['vat']
+                if partner_obj.is_enterprise_vat(vat):
+                    new_process = imd_obj.get_object_reference(
+                        cursor, uid, "account_invoice_pending", "default_pending_state_process"
+                    )[1]
+                else:
+                    new_process = imd_obj.get_object_reference(
+                        cursor, uid, 'giscedata_facturacio_comer_bono_social',
+                        'bono_social_pending_state_process'
+                    )[1]
+                pol_obj.write(cursor, uid, new_polissa_id, {
+                              'process_id': new_process}, context=context)
 
         return res
 

--- a/som_switching/giscedata_switching_m1.py
+++ b/som_switching/giscedata_switching_m1.py
@@ -15,8 +15,25 @@ class GiscedataSwitchingM1_01(osv.osv):
                     "category_id": [(6, 0, [])],
                 }
             )
+            titular_id = new_contract_values.get('titular')
+            if titular_id:
+                imd_obj = self.pool.get("ir.model.data")
+                partner_obj = self.pool.get("res.partner")
+                vat = partner_obj.read(cursor, uid, titular_id, ['vat'])['vat']
+                if partner_obj.is_enterprise_vat(vat):
+                    default_process = imd_obj.get_object_reference(
+                        cursor, uid, "account_invoice_pending", "default_pending_state_process"
+                    )[1]
+                    new_contract_values.update({"process_id": default_process})
+                else:
+                    bo_social_process = imd_obj.get_object_reference(
+                        cursor, uid, 'giscedata_facturacio_comer_bono_social',
+                        'bono_social_pending_state_process'
+                    )[1]
+                    new_contract_values.update({"process_id": bo_social_process})
 
-        super(GiscedataSwitchingM1_01, self).config_step(cursor, uid, ids, vals, context)
+        res = super(GiscedataSwitchingM1_01, self).config_step(cursor, uid, ids, vals, context)
+        return res
 
 
 GiscedataSwitchingM1_01()


### PR DESCRIPTION
## Objectiu

Quan es fa un canvi de titular de la pòlissa, posar el camp "procés de tall" aka 'process_id' de la pòlissa a "Default process" si el nou titular es empresa de forma automàtica.

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/278/activity

## Comportament antic

Deixava el proces_id antic i generava problemes en el workflow de l'equip de cobraments

## Comportament nou

Es seteja correctament

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
