### PR TITLE
Fer servir lazy en un camp one2many 

### DIFF
--- a/som_crawlers/views/som_crawlers_task_view.xml
+++ b/som_crawlers/views/som_crawlers_task_view.xml
@@ -21,7 +21,7 @@
                     </group>
                     <field name="ultima_tasca_executada"  select = '1'/>
                     <group colspan="6" col="2" string="Execucions realitzades per la tasca">
-                        <field name="run_ids" height="300" nolabel="1" widget="one2many_list"/>
+                        <field name="run_ids" height="300" nolabel="1" widget="one2many_list" widget_props="{'infinite': true}" />
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
## Objectiu

GISCE [ha desenvolupat](https://rfc.gisce.net/t/activar-lazy-loading-en-one2many-webclient/2087) una nova funcionalitat que permet que un camp one2many o many2many, els registres es vagin carregant dinàmicament, a mesura que es fa scroll avall, en comptes de quan s'obre la vista.


## Targeta on es demana o Incidència
https://rfc.gisce.net/t/activar-lazy-loading-en-one2many-webclient/2087

## Comportament antic
Es carregaven tots els elements del one2many (a GTK segueix passant)

## Comportament nou
Afegir paràmetre a one2many perquè carregui elements a mesura que es fa scroll del client web

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
