### PR TITLE
Correcció de vista de Contractes en CAU per a multicaus.

### DIFF
--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -190,7 +190,6 @@
                     <field name="llista_preu"/>
                     <field name="data_alta"/>
                     <field name="data_alta_autoconsum"/>
-                    <field name="ac_state" string="Estat de l'auto"/>
                     <field name="data_baixa_autoconsum"/>
                     <field name="data_baixa"/>
                     <field name="facturacio_suspesa"/>

--- a/som_polissa/migrations/5.0.24.9.0/post-0001_reload_polissa_cau_view_for_multicau.py
+++ b/som_polissa/migrations/5.0.24.9.0/post-0001_reload_polissa_cau_view_for_multicau.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating view_giscedata_polissa_cau_tree view")
+    data_records = ["view_giscedata_polissa_cau_tree"]
+    load_data_records(
+        cursor, 'som_polissa', 'giscedata_polissa_view.xml', data_records,
+        mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Corretgir la vista de tree de Contractes en CAU per adaptar-se al nou estat dels autoconsums (multiCAU)

## Targeta on es demana o Incidència

https://somenergia.openproject.com/work_packages/156

## Comportament antic

Es disposava d'un camp ac_state per a veure l'estat de l'únic auto associat

## Comportament nou

Ara poden haver varis CAUs associats i cadascun pot tenir un estat diferent per tant no es pot mostrar tal qual en un camp.

## Comprovacions

- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [x] Script de migració

