### PR TITLE
Mostrar els mútiples CAU's en la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1307,6 +1307,11 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             u"6.3TD": 5,
             u"6.4TD": 6,
         }
+
+        data["autoconsum_caus"] = []
+        for mcau in pol.p.autoconsum_cups_ids:
+            data["autoconsum_caus"].append(mcau.autoconsum_id.cau)
+
         data["segment_tariff"] = segment_tarif.get(pol.tarifa.name, "")
         return data
 

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1308,9 +1308,12 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             u"6.4TD": 6,
         }
 
-        data["autoconsum_caus"] = []
-        for mcau in pol.autoconsum_cups_ids:
-            data["autoconsum_caus"].append(mcau.autoconsum_id.cau)
+        if len(pol.autoconsum_cups_ids) == 0:
+            data["autoconsum_caus"] = [data["autoconsum_cau"]]
+        else:
+            data["autoconsum_caus"] = []
+            for mcau in pol.autoconsum_cups_ids:
+                data["autoconsum_caus"].append(mcau.autoconsum_id.cau)
 
         data["segment_tariff"] = segment_tarif.get(pol.tarifa.name, "")
         return data

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1309,7 +1309,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         }
 
         data["autoconsum_caus"] = []
-        for mcau in pol.p.autoconsum_cups_ids:
+        for mcau in pol.autoconsum_cups_ids:
             data["autoconsum_caus"].append(mcau.autoconsum_id.cau)
 
         data["segment_tariff"] = segment_tarif.get(pol.tarifa.name, "")

--- a/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
@@ -72,7 +72,7 @@ autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_di
                     %if cd.is_autoconsum:
                         ${_(u"Autoproducció tipus:")} <span style="font-weight: bold;">${autoconsum_text}</span> <br />
                         % for autoconsum_cau in cd.autoconsum_caus:
-                            ${_(u"CAU (Codi d'autoconsum unificat):")} <span style="font-weight: bold;">${autoconsum_cau}</span>
+                            ${_(u"CAU (Codi d'autoconsum unificat):")} <span style="font-weight: bold;">${autoconsum_cau}</span> <br />
                         % endfor
                     %endif
                 </p>

--- a/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
@@ -71,7 +71,9 @@ autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_di
                     ${_(u'Data final del contracte: <span style="font-weight: bold;">%s</span> %s') % (cd.renovation_date, _(u'sense condicions de permanència') if not cd.has_permanence else _(u"pròrroga automàtica per períodes d'un any"))} <br/>
                     %if cd.is_autoconsum:
                         ${_(u"Autoproducció tipus:")} <span style="font-weight: bold;">${autoconsum_text}</span> <br />
-                        ${_(u"CAU (Codi d'autoconsum unificat):")} <span style="font-weight: bold;">${cd.autoconsum_cau}</span>
+                        % for autoconsum_cau in cd.autoconsum_caus:
+                            ${_(u"CAU (Codi d'autoconsum unificat):")} <span style="font-weight: bold;">${autoconsum_cau}</span>
+                        % endfor
                     %endif
                 </p>
             </div>


### PR DESCRIPTION
## Objectiu

Amb l'arribada de la modificació de multi_CAU, hem de mostrar els diferents CAU's associats al contracte a la factura

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/309/activity

## Comportament antic

Només es mostrava 1

## Comportament nou

Es mostren les que estiguin relacionats

## Notes de desenvolupament

Fer rebase abans de fer traduccions i aplicar per evitar col·lisions amb:
https://github.com/Som-Energia/openerp_som_addons/pull/685
https://github.com/Som-Energia/openerp_som_addons/pull/678
https://github.com/Som-Energia/openerp_som_addons/pull/691

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
        giscedta_facturacio_comer_som
- [ ] Script de migració
- [x] Modifica traduccions
