### PR TITLE
🦺 DNI Attachments 

### DIFF
--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -998,37 +998,6 @@ class GiscedataPolissa(osv.osv):
 
         return posicio_id
 
-    def _related_attachments(self, cursor, uid, ids, field_name, arg, context=None):
-        if context is None:
-            context = {}
-        ctx = context.copy()
-        ctx['active_test'] = False
-        ir_model_obj = self.pool.get("ir.model.data")
-        attach_obj = self.pool.get("ir.attachment")
-        pol_obj = self.pool.get("giscedata.polissa")
-
-        dni_categ_id = ir_model_obj.get_object_reference(
-            cursor, uid, "som_polissa", "ir_attachment_vat_dni_category"
-        )[1]
-
-        res = super(GiscedataPolissa, self)._related_attachments(
-            cursor, uid, ids, field_name, arg, context=ctx
-        )
-
-        polisses = pol_obj.read(cursor, uid, ids, ["titular"], context=ctx)
-        for polissa in polisses:
-            if polissa["titular"]:
-                polissa_id = polissa["id"]
-                titular_id = polissa["titular"][0]
-
-                attachment_ids = attach_obj.search(cursor, uid, [
-                    ("res_model", "=", "res.partner"),
-                    ("res_id", "=", titular_id),
-                    ("category_id", "=", dni_categ_id)
-                ])
-                if attachment_ids:
-                    res[polissa_id].extend(attachment_ids)
-
     _columns = {
         "info_gestio_endarrerida": fields.text("Informació gestió endarrerida"),
         "info_gestio_endarrerida_curta": fields.function(

--- a/som_polissa/giscedata_polissa.py
+++ b/som_polissa/giscedata_polissa.py
@@ -998,6 +998,37 @@ class GiscedataPolissa(osv.osv):
 
         return posicio_id
 
+    def _related_attachments(self, cursor, uid, ids, field_name, arg, context=None):
+        if context is None:
+            context = {}
+        ctx = context.copy()
+        ctx['active_test'] = False
+        ir_model_obj = self.pool.get("ir.model.data")
+        attach_obj = self.pool.get("ir.attachment")
+        pol_obj = self.pool.get("giscedata.polissa")
+
+        dni_categ_id = ir_model_obj.get_object_reference(
+            cursor, uid, "som_polissa", "ir_attachment_vat_dni_category"
+        )[1]
+
+        res = super(GiscedataPolissa, self)._related_attachments(
+            cursor, uid, ids, field_name, arg, context=ctx
+        )
+
+        polisses = pol_obj.read(cursor, uid, ids, ["titular"], context=ctx)
+        for polissa in polisses:
+            if polissa["titular"]:
+                polissa_id = polissa["id"]
+                titular_id = polissa["titular"][0]
+
+                attachment_ids = attach_obj.search(cursor, uid, [
+                    ("res_model", "=", "res.partner"),
+                    ("res_id", "=", titular_id),
+                    ("category_id", "=", dni_categ_id)
+                ])
+                if attachment_ids:
+                    res[polissa_id].extend(attachment_ids)
+
     _columns = {
         "info_gestio_endarrerida": fields.text("Informació gestió endarrerida"),
         "info_gestio_endarrerida_curta": fields.function(

--- a/som_polissa/migrations/5.0.23.9.0/post-0002_create_dni_attachment_categ.py
+++ b/som_polissa/migrations/5.0.23.9.0/post-0002_create_dni_attachment_categ.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+
+    logger.info("Creating pooler")
+    pooler.get_pool(cursor.dbname)
+
+    logger.info("Creating XMLs records")
+    list_of_records = ["ir_attachment_vat_dni_category"]
+    load_data_records(
+        cursor, "som_polissa", "som_polissa_data.xml", list_of_records, mode="init"
+    )
+    logger.info("XMLs records succesfully created.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa/som_polissa_data.xml
+++ b/som_polissa/som_polissa_data.xml
@@ -62,4 +62,10 @@
             <field name="name">DESESTIMENT (Moure Flux Solar)</field>
         </record>
     </data>
+    <data>
+        <record id="ir_attachment_vat_dni_category" model="ir.attachment.category">
+            <field name="code">vat_dni_attachment_category</field>
+            <field name="name">Document d'Identitat</field>
+        </record>
+    </data>
 </openerp>

--- a/som_polissa/tests/giscedata_polissa_tests.py
+++ b/som_polissa/tests/giscedata_polissa_tests.py
@@ -235,3 +235,31 @@ class TestGisceDataCups(testing.OOTestCase):
         )
 
         self.assertEqual(result, False)
+
+    def test__related_attachment(self):
+        ir_model_o = self.model("ir.model.data")
+        ir_attachment_o = self.model("ir.attachment")
+        pol_o = self.model("giscedata.polissa")
+
+        dni_categ_id = ir_model_o.get_object_reference(
+            self.cursor, self.uid, "som_polissa", "ir_attachment_vat_dni_category"
+        )[1]
+
+        pol = pol_o.read(
+            self.cursor, self.uid, self.contract_20TD_id, ['related_attachments', 'titular']
+        )
+        self.assertEqual(len(pol['related_attachments']), 0)
+
+        create_vals = {
+            "res_model": "res.partner",
+            "res_id": pol['titular'][0],
+            "category_id": dni_categ_id,
+            "name": "DNI DEMO"
+        }
+
+        ir_attachment_o.create(self.cursor, self.uid, create_vals)
+
+        pol_att = pol_o.read(
+            self.cursor, self.uid, self.contract_20TD_id, ['related_attachments']
+        )['related_attachments']
+        self.assertEqual(len(pol_att), 1)


### PR DESCRIPTION
## Objectiu
Molaria tenir d'alguna manera identificats els attachments dels DNI.
Ara mateix l'ET no té una manera "estàndard" de guardar aquests attachments i moltes vegades ho posen com a adjunt de la polissa.
Això pot suposar un problema perquè hi ha partners amb és d'una polissa i clar... No totes les polisses tindran el DNI adjunt.
Aquesta PR crea una categoria pels document d'identitat i si aquest s'adjunta al titular, sortirà a la pestanya de documents relacionats de la polissa que ensenya el camp funció `related_attachments`

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/286/activity

## Comportament antic
Cadascú ho feia com volia

## Comportament nou
S'intenta estandaritzar una manera

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar ERP
- [x] Script de migració: S'ha d'executar l'script post-0002_create_dni_attachment_categ del módul som_polissa
