### PR TITLE
Nou sub component per mostrar l'informació dels autoconsums col·lectius al pdf de la factura

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -76,7 +76,7 @@ def te_autoconsum_amb_excedents(fact, pol):
 def te_autoconsum_collectiu(fact, pol):
     if te_autoconsum(fact, pol):
         for cups_autoconsum in pol.autoconsum_cups_ids:
-            if cups_autoconsum.autoconsum_id and cups_autoconsum.autoconsum_id.collectiu:
+            if cups_autoconsum.collectiu:
                 return True
     return False
 
@@ -87,9 +87,8 @@ def te_autoconsum_no_collectiu(fact, pol):
             return True
 
         for cups_autoconsum in pol.autoconsum_cups_ids:
-            if cups_autoconsum.autoconsum_id:
-                if cups_autoconsum.autoconsum_id.collectiu is False:
-                    return True
+            if cups_autoconsum.collectiu is False:
+                return True
     return False
 
 

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -83,6 +83,9 @@ def te_autoconsum_collectiu(fact, pol):
 
 def te_autoconsum_no_collectiu(fact, pol):
     if te_autoconsum(fact, pol):
+        if len(pol.autoconsum_cups_ids) == 0:  # old cases not migrated
+            return True
+
         for cups_autoconsum in pol.autoconsum_cups_ids:
             if cups_autoconsum.autoconsum_id:
                 if cups_autoconsum.autoconsum_id.collectiu is False:

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3513,22 +3513,16 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
             adjust_reason.append(data["adjust_reason"])
 
+        collectives = []
         if te_autoconsum_collectiu(fact, pol):
             data = self.get_sub_component_energy_consumption_detail_collective_td_data(fact, pol)
-
-        # collectives = []
-        # for coll in pol.autoconsum_cups_ids:
-        #     if coll.autoconsum_id.collectiu:
-        #         data = self.get_sub_component_energy_consumption_detail_collective_td_data(
-        #             fact, pol)
-        #         if data["is_visible"]:
-        #             collectives.append(data)
-        #         adjust_reason.append(data["adjust_reason"])
+            if data["is_visible"]:
+                collectives.append(data)
 
         highest_adjust_reason = self.adjust_readings_priority(adjust_reason)
         data = {
             "meters": meters,
-            "collectives": [data],
+            "collectives": collectives,
             "info": self.get_sub_component_energy_consumption_detail_td_info_data(
                 fact, pol, highest_adjust_reason
             ),
@@ -3774,10 +3768,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_energy_consumption_detail_collective_td_data(self, fact, pol):
-
-        def adjust_reason(subs):
-            return [sub["adjust_reason"] for sub in subs]
-
         def visibility(subs):
             return any([sub["is_visible"] for sub in subs])
 
@@ -3789,9 +3779,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "showing_periods": self.get_matrix_show_periods(pol),
             "generated": generated,
             "is_visible": visibility([generated]),
-            "adjust_reason": self.adjust_readings_priority(
-                adjust_reason([generated])
-            ),
+            "adjust_reason": False,
         }
         return data
 
@@ -3838,20 +3826,11 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         for p in data["showing_periods"]:
             data[p] = {}
 
-        # keys = {
-        #     'generacio_neta': 'generated_coef',
-        #     'autoconsum': 'auto_consumed',
-        #     'generacio': 'surplus',
-        # }
-
-        adjust_reason = []
         for linia in linies:
             data[linia.name][linia.tipus] = linia.quantity
             data["initial_date"] = linia.data_desde
             data["final_date"] = linia.data_fins
-            adjust_reason.append('98')
 
-        data["adjust_reason"] = self.adjust_readings_priority(adjust_reason)
         return data
 
     def get_sub_component_energy_consumption_detail_td_collective_data_data_old(self, fact, pol, collective):  # noqa: E501

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3635,7 +3635,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             data["is_visible"] = (
                 len(lectures[meter.name]) > 0
                 and te_autoconsum_amb_excedents(fact, pol)
-                and te_autoconsum_no_collectiu(fact, pol)
+                and not te_autoconsum_collectiu(fact, pol)
             )
             for reading in lectures[meter.name]:
                 data[reading[0]] = {

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3781,9 +3781,6 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "generated": generated,
             "is_visible": visibility([generated]),
             "adjust_reason": False,
-            "hide_total_surplus": (
-                te_autoconsum_collectiu(fact, pol) and te_autoconsum_no_collectiu(fact, pol)
-            ),
         }
         return data
 
@@ -3823,6 +3820,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "is_visible": False,
             "title": _(u"Autoconsum compartit (kWh)"),
             "is_active": False,
+            "hide_total_surplus": (
+                te_autoconsum_collectiu(fact, pol) and te_autoconsum_no_collectiu(fact, pol)
+            ),
         }
 
         data["is_visible"] = len(linies) > 0 and te_autoconsum_amb_excedents(fact, pol)

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3781,6 +3781,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "generated": generated,
             "is_visible": visibility([generated]),
             "adjust_reason": False,
+            "hide_total_surplus": (
+                te_autoconsum_collectiu(fact, pol) and te_autoconsum_no_collectiu(fact, pol)
+            ),
         }
         return data
 

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3832,8 +3832,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         for linia in linies:
             data[linia.name][linia.tipus] = linia.quantity
-            data["initial_date"] = linia.data_desde
-            data["final_date"] = linia.data_fins
+            data["initial_date"] = dateformat(linia.data_desde)
+            data["final_date"] = dateformat(linia.data_fins)
 
         return data
 

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3635,7 +3635,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             data["is_visible"] = (
                 len(lectures[meter.name]) > 0
                 and te_autoconsum_amb_excedents(fact, pol)
-                and not te_autoconsum_collectiu(fact, pol)
+                and te_autoconsum_no_collectiu(fact, pol)
             )
             for reading in lectures[meter.name]:
                 data[reading[0]] = {
@@ -3650,7 +3650,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 if "final_type" not in data or reading[7] != u"real":
                     data["final_type"] = reading[7]
                 adjust_reason.append(reading[9])
-
+        data["hide_total_surplus"] = (
+            te_autoconsum_collectiu(fact, pol) and te_autoconsum_no_collectiu(fact, pol)
+        )
         data["adjust_reason"] = self.adjust_readings_priority(adjust_reason)
         return data
 

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -2,927 +2,938 @@
 # This file contains the translation of the following modules:
 # * giscedata_facturacio_comer_som
 #
+# Translators:
+#   <>, 2017, 2018, 2019, 2020.
+# Agustí Fita <afita@gisce.net>, 2018.
+# GISCE-TI, S.L. <devel@gisce.net>, 2014, 2017.
+# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022, 2023, 2024, 2025.
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 5.0.14\n"
+"Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2025-05-05 13:22+0000\n"
-"PO-Revision-Date: 2025-05-05 13:22+0000\n"
-"Last-Translator: <>\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2025-05-05 16:35+0000\n"
+"PO-Revision-Date: 2025-05-05 14:35+0000\n"
+"Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
+"Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Generated-By: Babel 2.9.1\n"
+"Language: es_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3694
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3696
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
-msgstr ""
+msgstr "Energía Reactiva Capacitiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
 #: model:giscedata.polissa.category,name:giscedata_facturacio_comer_som.cat_gp_factura_sign
 #: model:res.partner.category,name:giscedata_facturacio_comer_som.cat_rp_factura_sign
 msgid "Signar Factures"
-msgstr ""
+msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:ir.ui.view:0
 msgid "Invalid XML for View Architecture!"
-msgstr ""
+msgstr "Invalid XML for View Architecture!"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2680
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
-msgstr ""
+msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3663
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3665
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
-msgstr ""
+msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
 #: model:ir.module.module,description:giscedata_facturacio_comer_som.module_meta_information
 #: model:ir.module.module,shortdesc:giscedata_facturacio_comer_som.module_meta_information
 msgid "Reports Facturació SOM (Comercialitzadora)"
-msgstr ""
+msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3724
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3726
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
-msgstr ""
+msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2724
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
-msgstr ""
+msgstr "sin lectura"
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:giscedata.facturacio.factura:0
 msgid "La llista de preu no és compatible amb la tarifa d'accés."
-msgstr ""
+msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2491
 msgid "(sense lectura)"
-msgstr ""
+msgstr "(sin lectura)"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:213
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:352
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
-msgstr ""
+msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:212
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2676
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
-msgstr ""
+msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3819
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3847
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3821
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3849
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
 msgid "Autoconsum compartit (kWh)"
-msgstr ""
+msgstr "Autoconsumo compartido (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3594
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3596
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
-msgstr ""
+msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:999
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
-msgstr ""
+msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2422
 msgid " (Som Energia, SCCL)"
-msgstr ""
+msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3626
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3628
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
-msgstr ""
+msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2489
 msgid "(estimada)"
-msgstr ""
+msgstr "(estimada)"
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:res.partner.category:0
 msgid "Error ! You can not create recursive categories."
-msgstr ""
+msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2674
 msgid "estimada"
-msgstr ""
+msgstr "estimada"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2423
 msgid "TRANSFERÈNCIA"
-msgstr ""
+msgstr "TRANSFERENCIA"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:214
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
-msgstr ""
+msgstr "calculada por Som Energía"
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:giscedata.polissa.category:0
 msgid "Error ! No pots crear categories recursives."
-msgstr ""
+msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
 #: field:giscedata.facturacio.factura,enviat_mail_id:0
 msgid "E-Mail factura adjunta"
-msgstr ""
+msgstr "E-Mail factura adjunta"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2493
 msgid "(real)"
-msgstr ""
+msgstr "(real)"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:52
 msgid "INFORMACIÓ DE L'ELECTRICITAT UTILITZADA"
-msgstr ""
+msgstr "INFORMACIÓN DE LA ELECTRICIDAD UTILIZADA"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:69
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:142
 msgid "DETALL DE LA FACTURA"
-msgstr ""
+msgstr "DETALLE DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:82
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:168
 msgid ""
 "Informació sobre protecció de dades: Les dades personals tractades per "
-"gestionar la relació contractual i, si s'escau, remetre informació "
-"comercial per mitjans electrònics, es conservaran fins a la fi de la "
-"relació, baixa comercial o els terminis de retenció legals. Pots exercir "
-"els teus drets a l'adreça postal de Som Energia com a responsable o a "
-"somenergia@delegado-datos.com ."
-msgstr ""
+"gestionar la relació contractual i, si s'escau, remetre informació comercial"
+" per mitjans electrònics, es conservaran fins a la fi de la relació, baixa "
+"comercial o els terminis de retenció legals. Pots exercir els teus drets a "
+"l'adreça postal de Som Energia com a responsable o a somenergia@delegado-"
+"datos.com ."
+msgstr "Información sobre protección de datos: Los datos personales tratados para gestionar la relación contractual y, en su caso, remitir información comercial por medios electrónicos, se conservarán hasta el fin de la relación, baja comercial o los plazos de retención legales. Puedes ejercer tus derechos en la dirección postal de Som Energia como responsable o en somenergia@delegado-datos.com ."
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:100
 msgid "INFORMACIÓ DEL CONSUM ELÈCTRIC"
-msgstr ""
+msgstr "INFORMACIÓN DEL CONSUMO ELÉCTRICO"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:159
 msgid "ENTITAT EMISORA"
-msgstr ""
+msgstr "ENTIDAD EMISORA"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:160
 msgid "Nº DE REFERENCIA"
-msgstr ""
+msgstr "N.º DE REFERENCIA"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:161
 msgid "IDENTIFICACIÓ"
-msgstr ""
+msgstr "IDENTIFICACIÓN"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:169
 msgid "DATA EMISSIÓ"
-msgstr ""
+msgstr "FECHA EMISIÓN"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:170
 msgid "Document vàlid fins a:"
-msgstr ""
+msgstr "Documento válido hasta:"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:171
 msgid "IMPORT TOTAL Euros"
-msgstr ""
+msgstr "IMPORTE TOTAL Euros"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:187
 msgid "Factura Nº:"
-msgstr ""
+msgstr "Factura N.º:"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:194
 msgid "Data Factura:"
-msgstr ""
+msgstr "Fecha Factura:"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:195
 msgid "Contracte:"
-msgstr ""
+msgstr "Contrato:"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:212
 msgid "EUROS"
-msgstr ""
+msgstr "EUROS"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:228
 msgid "NOM I DOMICILI DEL PAGADOR"
-msgstr ""
+msgstr "NOMBRE Y DOMICILIO DEL PAGADOR"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:290
 msgid ""
 "Per fer el pagament online, pots entrar a <a "
 "href='https://www2.caixabank.es/apl/pagos/index_ca.html?IMP_codigoBarras={recibo507}'>https://www2.caixabank.es/apl/pagos/index_ca.html</a>"
-msgstr ""
+msgstr "Para hacer el pago online, puedes entrar a <a href='https://www2.caixabank.es/apl/pagos/index_es.html?IMP_codigoBarras={recibo507}'>https://www.caixabank.es/apl/pagos/codigoBarras_es.html</a>"
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:297
 msgid "Resum factures agrupades"
-msgstr ""
+msgstr "Resumen facturas agrupadas"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:14
 msgid "Incentius a les energies renovables, cogeneració i residus"
-msgstr ""
+msgstr "Incentivos a las energías renovables, cogeneración y residuos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:15
 msgid "Cost de xarxes de distribució i transport"
-msgstr ""
+msgstr "Coste de las redes de distribución y transporte"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:16
 msgid "Altres costos regulats (inclosa anualitat del dèficit)"
-msgstr ""
+msgstr "Otros costes regulados (incluida anualidad del déficit)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:26
 msgid "Costos regulats"
-msgstr ""
+msgstr "Costes regulados"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
 msgid "Impostos aplicats"
-msgstr ""
+msgstr "Impuestos aplicados"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:28
 msgid "Costos de producció electricitat"
-msgstr ""
+msgstr "Costes de producción de electricidad"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:48
 msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
-msgstr ""
+msgstr "DESTINO DEL IMPORTE DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:52
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
-msgstr ""
+msgstr "El destino del importe de tu factura, %s euros, es el siguiente:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:40
 #, python-format
 msgid ""
-"Als imports indicats en el diagrama s'ha d'afegir, si s'escau, el lloguer"
-" dels equips de mesura i control: %s €."
-msgstr ""
+"Als imports indicats en el diagrama s'ha d'afegir, si s'escau, el lloguer "
+"dels equips de mesura i control: %s €."
+msgstr "A los importes indicados en el diagrama debe añadirse, en su caso, el alquiler de los equipos de medida y control: %s €."
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
 msgid "Anualitat del dèficit"
-msgstr ""
+msgstr "Anualidad del déficit"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
 msgid "RECORE: retribució a les renovables, cogeneració i residus"
-msgstr ""
+msgstr "RECORE: retribución a las renovables, cogeneración y residuos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
 msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
-msgstr ""
+msgstr "Sobrecoste de generación en territorios no peninsulares (TNP)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:24
 msgid "Altres costos regulats"
-msgstr ""
+msgstr "Otros costes regulados"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:112
 msgid "Lloguer de comptador"
-msgstr ""
+msgstr "Alquiler de contador"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
 msgid "Peatges de transport i distribució"
-msgstr ""
+msgstr "Peajes de transporte y distribución"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:39
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:4
 msgid "Càrrecs"
-msgstr ""
+msgstr "Cargos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
 msgid "Energia"
-msgstr ""
+msgstr "Energía"
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:50
 #, python-format
 msgid ""
-"El destí de l'import de la teva factura sense flux solar, %s euros, és el"
-" següent:"
-msgstr ""
+"El destí de l'import de la teva factura sense flux solar, %s euros, és el "
+"següent:"
+msgstr "El destino del importe de tu factura sin flux solar, %s euros, es el siguiente:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:10
 msgid "COMPARADOR DE PREUS DE LA CNMC"
-msgstr ""
+msgstr "COMPARADOR DE PRECIOS DE LA CNMC"
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:14
 msgid "Amb aquest codi QR o bé amb l’enllaç "
-msgstr ""
+msgstr "Con este código QR o en el enlace "
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:14
 msgid ""
 "pots consultar i comparar les diferents ofertes vigents de les "
 "comercialitzadores d’electricitat del mercat lliure."
-msgstr ""
+msgstr "puedes consultar y comparar las distintas ofertas vigentes de las comercializadoras de electricidad del mercado libre."
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:16
 msgid "Recorda que tens "
-msgstr ""
+msgstr "Recuerda que tienes "
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:16
 msgid "tarifa Generation kWh"
-msgstr ""
+msgstr "tarifa Generation kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:16
 msgid ""
-", que té un preu diferent de la tarifa general, i que el comparador no la"
-" té en compte."
-msgstr ""
+", que té un preu diferent de la tarifa general, i que el comparador no la té"
+" en compte."
+msgstr ", que tiene un precio diferente al de la tarifa general, y que el comparador no la tiene en cuenta."
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:22
-msgid "(no disposem de les dades suficients per omplir els camps del formulari)"
-msgstr ""
+msgid ""
+"(no disposem de les dades suficients per omplir els camps del formulari)"
+msgstr "(no disponemos de los datos suficientes para poder rellenar los campos del formulario)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:3
 msgid "CIF:"
-msgstr ""
+msgstr "CIF:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:4
 msgid "Domicili:"
-msgstr ""
+msgstr "Domicilio:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:5
 msgid "Adreça electrònica:"
-msgstr ""
+msgstr "E-mail:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:6
 msgid "Comercialitzadora del Mercat Lliure"
-msgstr ""
+msgstr "Comercializadora del Mercado Libre"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:8
 msgid "Sense Autoconsum"
-msgstr ""
+msgstr "Sin Autoconsumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:13
 msgid "Sense Excedents Individual - Consum"
-msgstr ""
+msgstr "Sin Excedentes Individual – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:14
 msgid "Sense Excedents Col·lectiu - Consum"
-msgstr ""
+msgstr "Sin Excedentes Colectivo – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:15
 msgid "Sense Excedents Col·lectiu amb acord de compensació – Consum"
-msgstr ""
+msgstr "Sin Excedentes Colectivo con acuerdo de compensación – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:16
 msgid "Amb excedents i compensació Individual-Consum"
-msgstr ""
+msgstr "Con excedentes y compensación Individual - Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:17
 msgid "Amb excedents i compensació Col·lectiu-Consum"
-msgstr ""
+msgstr "Con excedentes y compensación Colectivo– Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:18
 msgid "Amb excedents i compensació Col·lectiu a través de xarxa - Consum"
-msgstr ""
+msgstr "Con excedentes y compensación Colectivo a través de red - Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:19
 msgid ""
-"Amb excedents sense compensació Individual sense cte. de Serv. Aux. en "
-"Xarxa Interior - Consum"
-msgstr ""
+"Amb excedents sense compensació Individual sense cte. de Serv. Aux. en Xarxa"
+" Interior - Consum"
+msgstr "Con excedentes sin compensación Individual sin cto de SSAA en Red Interior– Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:20
 msgid ""
-"Amb excedents sense compensació Col·lectiu sense cte. de Serv. Aux. en "
-"Xarxa Interior - Consum"
-msgstr ""
+"Amb excedents sense compensació Col·lectiu sense cte. de Serv. Aux. en Xarxa"
+" Interior - Consum"
+msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA en Red Interior– Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:21
 msgid ""
-"Amb excedents sense compensació Individual amb cte. de Serv. Aux. en "
-"Xarxa Interior - Consum"
-msgstr ""
+"Amb excedents sense compensació Individual amb cte. de Serv. Aux. en Xarxa "
+"Interior - Consum"
+msgstr "Con excedentes sin compensación Individual con cto SSAA en Red Interior– Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:22
 msgid ""
-"Amb excedents sense compensació individual amb cte. de Serv. Aux. en "
-"Xarxa Interior - Serv. Aux."
-msgstr ""
+"Amb excedents sense compensació individual amb cte. de Serv. Aux. en Xarxa "
+"Interior - Serv. Aux."
+msgstr "Con excedentes sin compensación individual con cto SSAA en Red Interior– SSAA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:23
-msgid "Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"
-msgstr ""
+msgid ""
+"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"
+msgstr "Con excedentes sin compensación Colectivo/en Red Interior– Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:24
 msgid ""
-"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. "
-"Aux."
-msgstr ""
+"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. Aux."
+msgstr "Con excedentes sin compensación Colectivo/en Red Interior - SSAA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:21
 msgid ""
 "Amb excedents sense compensació Col·lectiu sense cte de Serv. Aux. "
 "(menyspreable) en Xarxa Interior – Consum')"
-msgstr ""
+msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA (despreciable) en red interior – Consumo')"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:22
 msgid ""
-"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a "
-"través de xarxa - Consum')"
-msgstr ""
+"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a través "
+"de xarxa - Consum')"
+msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA a través de red - Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:23
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:25
 msgid ""
-"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a "
-"través de xarxa - Consum"
-msgstr ""
+"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través "
+"de xarxa - Consum"
+msgstr "Con excedentes sin compensación Individual con cto SSAA a través de red – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:26
 msgid ""
-"Amb excedents sense compensació individual amb cte. de Serv. Aux. a "
-"través de xarxa - Serv. Aux."
-msgstr ""
+"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través "
+"de xarxa - Serv. Aux."
+msgstr "Con excedentes sin compensación individual con cto SSAA a través de red – SSAA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:25
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:27
 msgid "Amb excedents sense compensació Col·lectiu a través de xarxa - Consum"
-msgstr ""
+msgstr "Con excedentes sin compensación Colectivo a través de red – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:28
-msgid "Amb excedents sense compensació Col·lectiu a través de xarxa - Serv. Aux."
-msgstr ""
+msgid ""
+"Amb excedents sense compensació Col·lectiu a través de xarxa - Serv. Aux."
+msgstr "Con excedentes sin compensación Colectivo a través de red - SSAA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:29
 msgid ""
-"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a "
-"través de xarxa i xarxa interior - Consum"
-msgstr ""
+"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través "
+"de xarxa i xarxa interior - Consum"
+msgstr "Con excedentes sin compensación Individual con cto SSAA a través de red y red interior – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:30
 msgid ""
-"Amb excedents sense compensació individual amb cte. de Serv. Aux. a "
-"través de xarxa i xarxa interior - Serv. Aux."
-msgstr ""
+"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través "
+"de xarxa i xarxa interior - Serv. Aux."
+msgstr "Con excedentes sin compensación individual con cto SSAA a través de red y red interior – SSAA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:31
 msgid ""
-"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a "
-"través de xarxa i xarxa interior - Consum"
-msgstr ""
+"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través "
+"de xarxa i xarxa interior - Consum"
+msgstr "Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:32
 msgid ""
-"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a "
-"través de xarxa i xarxa interior - SSAA"
-msgstr ""
+"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través "
+"de xarxa i xarxa interior - SSAA"
+msgstr "Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:33
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:35
 msgid "Sense excedents No acollit a compensació"
-msgstr ""
+msgstr "Sin excedentes No acogido a compensación"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:36
 msgid "Sense excedents acollit a compensació"
-msgstr ""
+msgstr "Sin excedentes acogido a compensación"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:35
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:37
 msgid "Amb excedents no acollits a compensació"
-msgstr ""
+msgstr "Con excedentes no acogidos a compensación"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:38
 msgid "Amb excedents acollits a compensació"
-msgstr ""
+msgstr "Con excedentes acogidos a compensación"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:39
 msgid "Sense autoconsum"
-msgstr ""
+msgstr "Sin autoconsumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:38
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:40
 msgid "Baixa com a membre d'autoconsum col·lectiu"
-msgstr ""
+msgstr "Baja como miembro de autoconsumo colectivo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:45
 msgid "DADES DEL CONTRACTE"
-msgstr ""
+msgstr "DATOS DEL CONTRATO"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:46
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:48
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:19
 msgid "Adreça de subministrament:"
-msgstr ""
+msgstr "Dirección de suministro:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:54
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:56
 msgid "Potència contractada (kW):"
-msgstr ""
+msgstr "Potencia contratada (kW):"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 msgid "facturació per maxímetre"
-msgstr ""
+msgstr "facturación por maxímetro"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 msgid "facturació per ICP"
-msgstr ""
+msgstr "facturación por ICP"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:48
 msgid "Tarifa contractada:"
-msgstr ""
+msgstr "Tarifa contratada:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:49
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:70
 msgid "CUPS:"
-msgstr ""
+msgstr "CUPS:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "Comptador telegestionat:"
-msgstr ""
+msgstr "Contador telegestionado:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "Sí"
-msgstr ""
+msgstr "Sí"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:51
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:76
 msgid "CNAE:"
-msgstr ""
+msgstr "CNAE:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:52
 #, python-format
 msgid ""
 "Data d'alta del contracte: <span style=\"font-weight: bold;\">%s</span>, "
 "sense condicions de permanència"
-msgstr ""
+msgstr "Fecha de alta del contrato: <span style=\"font-weight: bold;\">%s</span>, sin condiciones de permanencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:53
 msgid "Forma de pagament: rebut domiciliat"
-msgstr ""
+msgstr "Forma de pago: recibo domiciliado"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:54
 #, python-format
 msgid "Data de renovació automàtica: <span style=\"font-weight: bold;\">%s</span>"
-msgstr ""
+msgstr "Fecha de renovación automática: <span style=\"font-weight: bold;\">%s</span>"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:59
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:81
 msgid "Autoproducció tipus:"
-msgstr ""
+msgstr "Autoproducción tipo:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:60
 msgid "Codi d'autoconsum unificat (CAU):"
-msgstr ""
+msgstr "Código de autoconsumo unificado (CAU):"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:62
 msgid "Percentatge de repartiment de l'autoproducció compartida:"
-msgstr ""
+msgstr "Porcentaje de reparto de la autoproducción compartida:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:9
 msgid "Autoconsum Tipus 1"
-msgstr ""
+msgstr "Autoconsumo Tipo 1"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:10
 msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. a) RD 900/2015)"
-msgstr ""
+msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. a) RD 900/2015)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:11
 msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. b) RD 900/2015)"
-msgstr ""
+msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. b) RD 900/2015)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:12
 msgid "Serveis auxiliars de generació lligada a un autoconsum tipus 2"
-msgstr ""
+msgstr "Servicios auxiliares de generación ligada a un autoconsumo tipo 2"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:54
 #, python-format
 msgid "Punta: <b><i>%s</i></b> - Vall: <b><i>%s</i></b>"
-msgstr ""
+msgstr "Punta: <b><i>%s</i></b> - Valle: <b><i>%s</i></b>"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:59
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:61
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
 msgid "Facturació potència:"
-msgstr ""
+msgstr "Facturación potencia:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:59
 msgid "Facturació per maxímetre"
-msgstr ""
+msgstr "Facturación por maxímetro"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:61
 msgid "Facturació per potència quarthorari"
-msgstr ""
+msgstr "Facturación por potencia cuartohorario"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
 msgid "Facturació per ICP"
-msgstr ""
+msgstr "Facturación por ICP"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:65
 msgid "Peatge de transport i distribució:"
-msgstr ""
+msgstr "Peaje de transporte y distribución:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:66
 msgid "Segment tarifari:"
-msgstr ""
+msgstr "Segmento tarifario:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:68
 msgid "Tarifa:"
-msgstr ""
+msgstr "Tarifa:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:77
 #, python-format
 msgid "Data d'alta del contracte: <span style=\"font-weight: bold;\">%s</span>"
-msgstr ""
+msgstr "Fecha de alta del contrato: <span style=\"font-weight: bold;\">%s</span>"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:78
 msgid ""
 "Forma de pagament: <span style=\"font-weight: bold;\">Rebut "
 "domiciliat</span>"
-msgstr ""
+msgstr "Forma de pago: <span style=\"font-weight: bold;\">Recibo domiciliado</span>"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 #, python-format
 msgid "Data final del contracte: <span style=\"font-weight: bold;\">%s</span> %s"
-msgstr ""
+msgstr "Fecha final del contrato: <span style=\"font-weight: bold;\">%s</span> %s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 msgid "sense condicions de permanència"
-msgstr ""
+msgstr "sin condiciones de permanencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 msgid "pròrroga automàtica per períodes d'un any"
-msgstr ""
+msgstr "prórroga automática por periodos de un año"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:83
 msgid "CAU (Codi d'autoconsum unificat):"
-msgstr ""
+msgstr "CAU (Código de autoconsumo unificado):"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:7
 msgid "INFORMACIÓ DE L'ELECTRICITAT"
-msgstr ""
+msgstr "INFORMACIÓN DE LA ELECTRICIDAD"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:9
 #, python-format
 msgid ""
-"L'electricitat que entra a les nostres llars ens arriba a través de la "
-"xarxa de distribució, l'electricitat que hi circula prové de diferents "
-"fonts, però utilitzant el sistema de certificats de garantia d'origen que"
-" emet la CNMC, a Som Energia podem garantir que el volum d'electricitat "
-"que comercialitzem prové 100% de fonts renovables."
-msgstr ""
+"L'electricitat que entra a les nostres llars ens arriba a través de la xarxa"
+" de distribució, l'electricitat que hi circula prové de diferents fonts, "
+"però utilitzant el sistema de certificats de garantia d'origen que emet la "
+"CNMC, a Som Energia podem garantir que el volum d'electricitat que "
+"comercialitzem prové 100% de fonts renovables."
+msgstr "La electricidad que entra en nuestros hogares nos llega a través de la red de distribución, la electricidad que circula proviene de diferentes fuentes, pero utilizando el sistema de certificados de garantía de origen que emite la CNMC, en Som Energía podemos garantizar que el volumen de electricidad que comercializamos proviene 100% de fuentes renovables."
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:14
 msgid ""
-"En el gràfic següent mostrem el desglossament de la barreja de "
-"tecnologies de producció nacional per poder comparar el percentatge de "
-"l'energia produïda a escala nacional amb el percentatge d'energia venuda "
-"a través de la nostra cooperativa."
-msgstr ""
+"En el gràfic següent mostrem el desglossament de la barreja de tecnologies "
+"de producció nacional per poder comparar el percentatge de l'energia "
+"produïda a escala nacional amb el percentatge d'energia venuda a través de "
+"la nostra cooperativa."
+msgstr "En el gráfico siguiente se muestra el desglose de la mezcla de tecnologías de producción nacional para poder comparar el porcentaje de la energía producida a escala nacional con el porcentaje de energía vendida a través de nuestra cooperativa."
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:19
 msgid "ORIGEN DE L'ELECTRICITAT"
-msgstr ""
+msgstr "ORIGEN DE LA ELECTRICIDAD"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:23
 msgid "Mix Som Energia, SCCL"
-msgstr ""
+msgstr "Mix Som Energia, SCCL"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:45
 msgid "Mix producció en el sistema elèctric espanyol {year}"
-msgstr ""
+msgstr "Mix producción en el sistema eléctrico español {year}"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:35
 #, python-format
-msgid "El sistema elèctric espanyol ha importat un {}% de producció neta total"
-msgstr ""
+msgid ""
+"El sistema elèctric espanyol ha importat un {}% de producció neta total"
+msgstr "El sistema eléctrico español ha importado un {}% de producción neta total"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:37
 #, python-format
-msgid "El sistema elèctric espanyol ha exportat un {}% de producció neta total"
-msgstr ""
+msgid ""
+"El sistema elèctric espanyol ha exportat un {}% de producció neta total"
+msgstr "El sistema eléctrico español ha exportado un {}% de producción neta total"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:15
 msgid "Origen"
-msgstr ""
+msgstr "Origen"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:20
 msgid "Renovable"
-msgstr ""
+msgstr "Renovable"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:53
 msgid "Cogeneració alta eficiència"
-msgstr ""
+msgstr "Cogeneración alta eficiencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:56
 msgid "Cogeneració"
-msgstr ""
+msgstr "Cogeneración"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:59
 msgid "CC Gas natural"
-msgstr ""
+msgstr "CC Gas natural"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:35
 msgid "Carbó"
-msgstr ""
+msgstr "Carbón"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:65
 msgid "Fuel/Gas"
-msgstr ""
+msgstr "Fuel/Gas"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:68
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:45
 msgid "Nuclear"
-msgstr ""
+msgstr "Nuclear"
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:71
 msgid "Altres"
-msgstr ""
+msgstr "Otras"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:7
 msgid "AVARIES I URGÈNCIES"
-msgstr ""
+msgstr "AVERÍAS Y URGENCIAS"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:8
 msgid "Empresa distribuïdora:"
-msgstr ""
+msgstr "Empresa distribuidora:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:10
 msgid "Núm. contracte distribuïdora:"
-msgstr ""
+msgstr "Núm. contrato distribuidora:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:20
 #, python-format
 msgid "AVARIES I URGÈNCIES DEL SUBMINISTRAMENT (distribuïdora): %s (24 hores)"
-msgstr ""
+msgstr "AVERÍAS Y URGENCIAS DEL SUMINISTRO (distribuidora): %s (24 horas)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:28
 msgid "RECLAMACIONS"
-msgstr ""
+msgstr "RECLAMACIONES"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:31
 msgid ""
-"RECLAMACIONES COMERCIALIZACIÓN (ENERGÉTICA/SOM ENERGIA): Lunes a viernes,"
-" de 10 a 14h. (tardes, previa cita) 983 660 112"
-msgstr ""
+"RECLAMACIONES COMERCIALIZACIÓN (ENERGÉTICA/SOM ENERGIA): Lunes a viernes, de"
+" 10 a 14h. (tardes, previa cita) 983 660 112"
+msgstr "RECLAMACIONES COMERCIALIZACIÓN (ENERGÉTICA/SOM ENERGIA): Lunes a viernes, de 10 a 14h. (tardes, previa cita) 983 660 112"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:23
 msgid "Correo electrónico: info@energetica.coop"
-msgstr ""
+msgstr "Correo electrónico: info@energetica.coop"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:33
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:24
-msgid "Dirección postal: Avda. Ramón Pradera 12, bajo trasera; 47009-Valladolid"
-msgstr ""
+msgid ""
+"Dirección postal: Avda. Ramón Pradera 12, bajo trasera; 47009-Valladolid"
+msgstr "Dirección postal: Avda. Ramón Pradera 12, bajo trasera; 47009-Valladolid"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:35
 #, python-format
 msgid ""
-"RECLAMACIONS COMERCIALITZACIÓ (SOM ENERGIA): Horari d'atenció de 9 a 14 "
-"h. 900 103 605 (cost de la trucada per a la cooperativa).<br />Si tens "
-"tarifa plana, pots contactar igualment al %s, sense cap cost.<br />Adreça"
-" electrònica: reclama@somenergia.coop<br />Adreça postal: C/ Pic de "
-"Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
-msgstr ""
+"RECLAMACIONS COMERCIALITZACIÓ (SOM ENERGIA): Horari d'atenció de 9 a 14 h. "
+"900 103 605 (cost de la trucada per a la cooperativa).<br />Si tens tarifa "
+"plana, pots contactar igualment al %s, sense cap cost.<br />Adreça "
+"electrònica: reclama@somenergia.coop<br />Adreça postal: C/ Pic de Peguera, "
+"11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
+msgstr "RECLAMACIONES COMERCIALIZACIÓN (SOM ENERGIA): Horario de atención de 9 a 14h. 900 103 605 (coste de la llamada para la cooperativa) <br />Si tienes tarifa plana, puedes contactar igualmente al %s, sin ningún coste. <br />E-mail: reclama@somenergia.coop<br />Dirección postal: C/ Pic de Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:31
 msgid ""
-"Som Energia és la teva comercialitzadora elèctrica a mercè de l'acord "
-"firmat amb"
-msgstr ""
+"Som Energia és la teva comercialitzadora elèctrica a mercè de l'acord firmat"
+" amb"
+msgstr "Som Energia es tu comercializadora eléctrica merced al acuerdo firmado con"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:40
 msgid ""
-"Som Energia està adherida al Sistema Arbitral de Consum. Pots fer arribar"
-" la teva reclamació a la Junta Arbitral de Consum més propera: "
-msgstr ""
+"Som Energia està adherida al Sistema Arbitral de Consum. Pots fer arribar la"
+" teva reclamació a la Junta Arbitral de Consum més propera: "
+msgstr "Som Energia está adherida al Sistema Arbitral de Consumo. Puedes hacer llegar tu reclamación a la Junta Arbitral de Consumo más cercana: "
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:11
 msgid "AVARIES I URGÈNCIES DEL SUBMINISTRAMENT (distribuïdora): "
-msgstr ""
+msgstr "AVERÍAS Y URGENCIAS DEL SUMINISTRO (distribuidora): "
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:11
 #, python-format
 msgid "%s (24 hores)"
-msgstr ""
+msgstr "%s (24 horas)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:16
 msgid "RECLAMACIONES COMERCIALIZACIÓN ENERGÉTICA/SOM ENERGIA"
-msgstr ""
+msgstr "RECLAMACIONES COMERCIALIZACIÓN ENERGÉTICA/SOM ENERGIA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:18
 msgid "RECLAMACIONS COMERCIALITZACIÓ SOM ENERGIA"
-msgstr ""
+msgstr "RECLAMACIONES COMERCIALIZACIÓN SOM ENERGIA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:22
 msgid "Lunes a viernes, de 10 a 14h. (tardes, previa cita) 983 660 112"
-msgstr ""
+msgstr "Lunes a viernes, de 10 a 14h. (tardes, previa cita) 983 660 112"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:26
 #, python-format
 msgid ""
 "Horari de 9 a 14 h. 900 103 605 (Gratuït. cost de la trucada per a la "
-"cooperativa).<br />Si tens tarifa plana de telefonia, també pots trucar-"
-"nos al %s.<br />Adreça electrònica: reclama@somenergia.coop<br />Adreça "
-"postal: C/ Pic de Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - "
-"Girona<br />"
-msgstr ""
+"cooperativa).<br />Si tens tarifa plana de telefonia, també pots trucar-nos "
+"al %s.<br />Adreça electrònica: reclama@somenergia.coop<br />Adreça postal: "
+"C/ Pic de Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
+msgstr "Horario de 9 a 14 h. 900103605 (Gratuito. Coste de la llamada para la cooperativa).<br />Si tienes tarifa plana de telefonía, también puedes llamarnos al %s.<br />Correo electrónico: reclama@somenergia.coop<br />Dirección C / Pic de Peguera, 11, A 2 8. Edificio Giroemprèn. 17003 - Girona<br />"
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:34
 msgid "Pots obtenir més informació sobre reclamacions en aquest "
-msgstr ""
+msgstr "Puedes obtener más información acerca de reclamaciones en este "
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:38
 msgid "article."
-msgstr ""
+msgstr "artículo."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:7
 #, python-format
 msgid "Número de comptador: %s"
-msgstr ""
+msgstr "Número de contador: %s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:37
 msgid "Tipus"
-msgstr ""
+msgstr "Tipo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:11
 msgid "Detall de lectures"
-msgstr ""
+msgstr "Detalle de lecturas"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:11
 msgid "Punta"
-msgstr ""
+msgstr "Punta"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:41
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:12
 msgid "Pla"
-msgstr ""
+msgstr "Llano"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:13
 msgid "Vall"
-msgstr ""
+msgstr "Valle"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:45
@@ -1011,108 +1022,109 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:103
 #, python-format
 msgid "%s"
-msgstr ""
+msgstr "%s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:7
 #, python-format
 msgid "Lectura inicial (%s) (%s)"
-msgstr ""
+msgstr "Lectura inicial (%s) (%s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:21
 #, python-format
 msgid "Lectura final (%s) (%s)"
-msgstr ""
+msgstr "Lectura final (%s) (%s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:38
 msgid "Total periode "
-msgstr ""
+msgstr "Total periodo "
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:9
 msgid "Autoconsum (kWh)"
-msgstr ""
+msgstr "Autoconsumo (kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:13
 #, python-format
 msgid "Generació segons coeficient de repartiment (periode del %s fins al %s)"
-msgstr ""
+msgstr "Generación según coeficiente de reparto (periodo del %s hasta el %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:27
 #, python-format
 msgid "Energia autoconsumida (periode del %s fins al %s)"
-msgstr ""
+msgstr "Energía autoconsumida (periodo del %s hasta el %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:45
 msgid "Excedent"
-msgstr ""
+msgstr "Excedente"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:10
 #, python-format
-msgid "(1) La despesa diària és de %s €, que correspon a %s kWh/dia (%s dies)."
-msgstr ""
+msgid ""
+"(1) La despesa diària és de %s €, que correspon a %s kWh/dia (%s dies)."
+msgstr "(1) El gasto diario es de %s €, que corresponde a %s kWh/día (%s días)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:13
 msgid ""
 "(2) Aquesta energia utilitzada inclou ajustos aplicats per la companyia "
 "distribuïdora."
-msgstr ""
+msgstr "(2) Esta energía utilizada incluye ajustes aplicados por la compañía distribuidora."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:15
 msgid ""
-"(2) Aquesta energia utilitzada inclou els ajustos corresponents al balanç"
-" horari "
-msgstr ""
+"(2) Aquesta energia utilitzada inclou els ajustos corresponents al balanç "
+"horari "
+msgstr "(2) Esta energía utilizada incluye los ajustes correspondientes al balance horario "
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:12
 msgid "(més informació)."
-msgstr ""
+msgstr "(más información)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:23
 msgid ""
-"(2) Aquesta energia utilitzada inclou ajustos perquè les lectures "
-"informades per la companyia distribuïdora no concorden amb els consums "
-"informats per a cada període."
-msgstr ""
+"(2) Aquesta energia utilitzada inclou ajustos perquè les lectures informades"
+" per la companyia distribuïdora no concorden amb els consums informats per a"
+" cada període."
+msgstr "(2) Esta energía utilizada incluye ajustes porque las lecturas informadas por la compañía distribuidora no concuerdan con los consumos informados para cada período."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:9
 msgid ""
-"Si vols conèixer el detall de les teves dades horàries d’ús "
-"d’electricitat i de potència i disposes d’un comptador amb la telegestió "
-"activada, t’animem a registrar-te i accedir gratuïtament al portal web de"
-" la teva empresa distribuïdora: "
-msgstr ""
+"Si vols conèixer el detall de les teves dades horàries d’ús d’electricitat i"
+" de potència i disposes d’un comptador amb la telegestió activada, t’animem "
+"a registrar-te i accedir gratuïtament al portal web de la teva empresa "
+"distribuïdora: "
+msgstr "Si quieres conocer el detalle tus datos horarios de uso de electricidad y de potencia y dispones de un contador con la telegestión activada, te animamos a registrarte y acceder gratuitamente al portal web de tu empresa distribuidora:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:13
 #, python-format
 msgid "(Ho sentim, %s encara no ens ha facilitat l’enllaç al portal)"
-msgstr ""
+msgstr "(Lo sentimos, %s todavía no nos ha facilitado el enlace al portal)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:59
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:8
 msgid "Potència contractada"
-msgstr ""
+msgstr "Potencia contratada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:70
 msgid "Potència maxímetre"
-msgstr ""
+msgstr "Potencia maxímetro"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:82
 msgid "Potència excedida"
-msgstr ""
+msgstr "Potencia excedida"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:57
 msgid "Maximetre (kW)"
-msgstr ""
+msgstr "Maxímetro (kW)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:15
@@ -1120,228 +1132,228 @@ msgstr ""
 msgid ""
 "La despesa mitjana diària en els últims %.0f mesos (%s dies) ha estat de "
 "<b>%s</b> €, que corresponen a <b>%s</b> kWh/dia."
-msgstr ""
+msgstr "El gasto medio diario en los últimos %.0f meses (%s días)  ha sido de <b>%s</b> €, que corresponden a <b>%s</b> kWh/día."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:17
 #, python-format
 msgid "L'electricitat utilitzada durant el darrer any: <b>%s</b> kWh."
-msgstr ""
+msgstr "La electricidad utilizada durante el último año: <b>%s</b> kWh."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:17
 #, python-format
-msgid "L'electricitat utilitzada durant el darrer any ha estat de <b>%s</b> kWh."
-msgstr ""
+msgid ""
+"L'electricitat utilitzada durant el darrer any ha estat de <b>%s</b> kWh."
+msgstr "La electricidad utilizada durante el último año ha sido de <b>%s</b> kWh."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:31
 #, python-format
 msgid ""
-"La potència màxima que has fet servir en el període que va del %s fins al"
-" %s és de: Punta: <b><i>%s</i></b> kW - Vall: <b><i>%s</i></b> kW "
-"(últimes dades rebudes per l’empresa distribuïdora)"
-msgstr ""
+"La potència màxima que has fet servir en el període que va del %s fins al %s"
+" és de: Punta: <b><i>%s</i></b> kW - Vall: <b><i>%s</i></b> kW (últimes "
+"dades rebudes per l’empresa distribuïdora)"
+msgstr "La potencia máxima que has utilizado en el período que va del %s hasta el %s és de: Punta: <b><i>%s</i></b> kW - Valle: <b><i>%s</i></b> kW (últimos datos recibidos por la empresa distribuidora)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:34
 #, python-format
 msgid ""
 "Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat "
 "aquestes dades)."
-msgstr ""
+msgstr "Potencia máxima demandada: (lo sentimos, %s aún no nos ha facilitado este dato)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:39
 #, python-format
 msgid ""
 "El consum mitjà de la teva zona (CP %s) durant l'últim mes ha estat de "
 "<b>%s</b> kWh."
-msgstr ""
+msgstr "El consumo medio de tu zona (CP %s) durante el último mes ha sido de <b>%s</b> kWh."
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:41
 #, python-format
 msgid ""
-"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s)"
-" de l’últim mes."
-msgstr ""
+"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s) de"
+" l’últim mes."
+msgstr "Lo sentimos, %s no nos ha facilitado el consumo medio de tu zona (CP %s) del último mes."
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:7
 msgid "IMPACTE AMBIENTAL"
-msgstr ""
+msgstr "IMPACTO MEDIOAMBIENTAL"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:9
 msgid ""
-"L'impacte ambiental de l'electricitat que utilitzem depèn de les fonts de"
-" generació que s'utilitzen per a la seva producció."
-msgstr ""
+"L'impacte ambiental de l'electricitat que utilitzem depèn de les fonts de "
+"generació que s'utilitzen per a la seva producció."
+msgstr "El impacto ambiental de la electricidad que utilizamos depende de las fuentes de generación que se utilizan para su producción."
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:11
 msgid ""
 "En una escala de A a G (on A indica el mínim impacte ambiental i G el "
-"màxim), i tenint en compte que el valor mitjà nacional correspon al "
-"nivell D, l'energia comercialitzada per Som Energia, SCCL, té els valors "
-"següents:"
-msgstr ""
+"màxim), i tenint en compte que el valor mitjà nacional correspon al nivell "
+"D, l'energia comercialitzada per Som Energia, SCCL, té els valors següents:"
+msgstr "En una escala de A a G (donde A indica el mínimo impacto ambiental y G el máximo), y teniendo en cuenta que el valor medio nacional corresponde al nivel D, la energía comercializada por <b>Som Energia, SCCL</b>, tiene los siguientes valores:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:16
 msgid "Emissions de diòxid de carboni "
-msgstr ""
+msgstr "Emisiones de dióxido de carbono "
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:17
 msgid "Menys diòxid de carboni"
-msgstr ""
+msgstr "Menos dióxido de carbono"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:34
 msgid "Mitjana nacional"
-msgstr ""
+msgstr "Media nacional"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:24
 msgid "Contingut de carboni<br />Quilograms de diòxid de carboni per kWh"
-msgstr ""
+msgstr "Contenido de carbono<br />Kilogramos de dióxido de carbono por kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:25
 msgid "Més diòxid de carboni"
-msgstr ""
+msgstr "Más dióxido de carbono"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:28
 msgid "Residus radioactius d'alta activitat "
-msgstr ""
+msgstr "Residuos radiactivos de alta actividad "
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:29
 msgid "Menys residus radioactius"
-msgstr ""
+msgstr "Menos residuos radiactivos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:36
 msgid "Residus radioactius<br />Mil·ligrams per kWh"
-msgstr ""
+msgstr "Residuos radioactivos<br />Miligramos por kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:37
 msgid "Més residus radioactius"
-msgstr ""
+msgstr "Más residuos radiactivos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:6
 msgid "DETALL DELS CERTIFICATS DE GARANTIA D'ORIGEN PER A SOM ENERGIA"
-msgstr ""
+msgstr "DETALLE DE LOS CERTIFICADOS DE GARANTÍA DE ORIGEN PARA SOM ENERGIA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:12
 msgid "Font renovable"
-msgstr ""
+msgstr "Fuente renovable"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:12
 msgid "Energia MWh"
-msgstr ""
+msgstr "Energía MWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:17
 msgid "Eòlica"
-msgstr ""
+msgstr "Eólica"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:20
 msgid "Solar fotovoltaica"
-msgstr ""
+msgstr "Solar fotovoltaica"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:23
 msgid "Minihidràulica"
-msgstr ""
+msgstr "Minihidráulica"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:27
 msgid "Biogàs"
-msgstr ""
+msgstr "Biogás"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:32
 msgid "Biomassa"
-msgstr ""
+msgstr "Biomasa"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:38
 msgid "TOTAL"
-msgstr ""
+msgstr "TOTAL"
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:43
 msgid ""
 "Pots veure l'origen dels certificats de garantia d'origen en l'enllaç "
 "següent:"
-msgstr ""
+msgstr "Puedes ver el origen de los certificados de garantía de origen en el siguiente enlace:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:16
 msgid "Evolució horaria"
-msgstr ""
+msgstr "Evolución horaria"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:21
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:19
 msgid "Consum"
-msgstr ""
+msgstr "Consumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:26
 msgid "Preu Horari Final (cts. de €)"
-msgstr ""
+msgstr "Precio Horario Final (cts. de €)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:31
 msgid "Consum Horari (kWh)"
-msgstr ""
+msgstr "Consumo Horario (kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:36
 msgid "Preu OMIE €/kWh"
-msgstr ""
+msgstr "Precio OMIE €/kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:41
 msgid "Pagament per capacitat mig (€/kWh"
-msgstr ""
+msgstr "Pago por capacidad media (€/kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:46
 msgid "Pèrdues (%)"
-msgstr ""
+msgstr "Perdidas (%)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:83
 msgid "Consums totals per dies (kWh)"
-msgstr ""
+msgstr "Consumos totales por días (kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:83
 msgid "Corba horària de potència (kW)"
-msgstr ""
+msgstr "Curva horaria de potencia (kW)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:148
 msgid "Ús elèctric i corba horària"
-msgstr ""
+msgstr "Uso eléctrico y curva horaria"
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:160
 msgid ""
 "Corbes horàries perfilades segons l'ús mensual informat per la "
 "distribuïdora."
-msgstr ""
+msgstr "Curvas horarias perfiladas según el uso mensual informado por la distribuidora."
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:162
 msgid "Corbes horàries informades per la distribuïdora."
-msgstr ""
+msgstr "Curvas horarias informadas por la distribuidora."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:16
 msgid ""
 "Els preus dels termes de peatge d'accés són els publicats a ORDRE "
 "IET/107/2014."
-msgstr ""
+msgstr "Los precios de los términos del peaje de acceso están publicados a ORDEN IET/107/2014."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:17
 msgid ""
 "Els preus del lloguer dels comptadors són els establerts a ORDRE "
 "ITC/3860/2007."
-msgstr ""
+msgstr "Los precios del alquiler de los contadores son los establecidos en ORDEN ITC/3860/2007."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:12
 msgid "Facturació per electricitat utilitzada"
-msgstr ""
+msgstr "Facturación por electricidad utilizada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:8
 msgid "Detall del càlcul del cost segons l'energia utilitzada:"
-msgstr ""
+msgstr "Detalle del cálculo del coste según la energía utilizada:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:15
 #, python-format
 msgid "(%s)"
-msgstr ""
+msgstr "(%s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:69
 #, python-format
 msgid "%s kWh x %s €/kWh"
-msgstr ""
+msgstr "%s kWh x %s €/kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:33
@@ -1410,121 +1422,119 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:51
 #, python-format
 msgid "%s €"
-msgstr ""
+msgstr "%s €"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:27
 msgid "D'aquest import, el cost per peatge d'accés ha estat de:"
-msgstr ""
+msgstr "De este importe, el coste por peaje de acceso ha sido de:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:32
 #, python-format
 msgid "(%s) %s kWh x %s €/kWh"
-msgstr ""
+msgstr "(%s) %s kWh x %s €/kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:38
 msgid ""
-"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari"
-" al terme d'energia per a desenvolupar la nostra activitat de "
-"comercialització."
-msgstr ""
+"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari al"
+" terme d'energia per a desenvolupar la nostra activitat de comercialització."
+msgstr "Tal y como se decidió en la Asamblea de 2020, añadimos el margen necesario el término de energía para desarrollar nuestra actividad de comercialización."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:42
 msgid ""
 "En el terme d'energia, afegim el marge necessari per a desenvolupar la "
-"nostra activitat de comercialització. Donem un major pes al terme "
-"variable de la factura, que depèn del nostre ús de l'energia. Busquem "
-"incentivar l'estalvi i l'eficiència energètica dels nostres socis/es i "
-"clients"
-msgstr ""
+"nostra activitat de comercialització. Donem un major pes al terme variable "
+"de la factura, que depèn del nostre ús de l'energia. Busquem incentivar "
+"l'estalvi i l'eficiència energètica dels nostres socis/es i clients"
+msgstr "En el término de energía, añadimos el margen necesario para desarrollar nuestra actividad de comercialización. Damos un mayor peso al término variable de la factura, que depende de nuestro uso de la energía. Buscamos incentivar el ahorro y la eficiencia energética de las personas socias y clientas."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:8
 msgid "Compensació per electricitat autoproduïda"
-msgstr ""
+msgstr "Compensación por electricidad autoproducida"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:9
 msgid "Detall del càlcul de l'energia compensada:"
-msgstr ""
+msgstr "Detalle del cálculo de la energía compensada:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:27
 msgid ""
-"Segons estableix el Reial Decret 244/2019 aquest import no serà mai "
-"superior a l'import per energia utilitzada. En cas que la compensació "
-"sigui superior a l'energia utilitzada, el terme d'energia serà igual a 0€"
-msgstr ""
+"Segons estableix el Reial Decret 244/2019 aquest import no serà mai superior"
+" a l'import per energia utilitzada. En cas que la compensació sigui superior"
+" a l'energia utilitzada, el terme d'energia serà igual a 0€"
+msgstr "Según establece el Real Decreto 244/2019 este importe no será nunca superior al importe por energía utilizada. En caso de que la compensación sea superior a la energía utilizada, el término de energía será igual a 0€"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:8
 msgid "Gener"
-msgstr ""
+msgstr "Enero"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:9
 msgid "Febrer"
-msgstr ""
+msgstr "Febrero"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:10
 msgid "Març"
-msgstr ""
+msgstr "Marzo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:11
 msgid "Abril"
-msgstr ""
+msgstr "Abril"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:12
 msgid "Maig"
-msgstr ""
+msgstr "Mayo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:13
 msgid "Juny"
-msgstr ""
+msgstr "Junio"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:14
 msgid "Juliol"
-msgstr ""
+msgstr "Julio"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:15
 msgid "Agost"
-msgstr ""
+msgstr "Agosto"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:16
 msgid "Setembre"
-msgstr ""
+msgstr "Septiembre"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:17
 msgid "Octubre"
-msgstr ""
+msgstr "Octubre"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:18
 msgid "Novembre"
-msgstr ""
+msgstr "Noviembre"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:19
 msgid "Desembre"
-msgstr ""
+msgstr "Diciembre"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:27
 msgid ""
 "Els preus dels termes de peatges de transport i distribució són els "
-"publicats en el BOE núm. 70, de 23 de març de 2021. Els preus dels "
-"càrrecs són els publicats a l'Ordre TED/371/2021. Els preus del lloguer "
-"dels comptadors són els publicats a l'Ordre ITC/3860/2007."
-msgstr ""
+"publicats en el BOE núm. 70, de 23 de març de 2021. Els preus dels càrrecs "
+"són els publicats a l'Ordre TED/371/2021. Els preus del lloguer dels "
+"comptadors són els publicats a l'Ordre ITC/3860/2007."
+msgstr "Los precios de los términos de peajes de transporte y distribución son los publicados en el BOE núm. 70, del 23 de marzo de 2021. Los precios de los cargos son los publicados en la Orden TED/371/2021. Los precios del alquiler de los contadores son los publicados en la Orden ITC/3860/2007."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:30
 msgid ""
 "Les comercialitzadores del mercat lliure poden triar voluntàriament "
-"repercutir l'import de l'energia associada a la compensació del mecanisme"
-" ibèric regulat pel Reial Decret-llei 10/2022, del 13 de maig, dins dels "
-"costos d'aprovisionament, o bé traslladar-lo de manera diferenciada als "
-"seus consumidors. En aquest cas, la seva comercialitzadora ha optat per "
-"aquesta última opció."
-msgstr ""
+"repercutir l'import de l'energia associada a la compensació del mecanisme "
+"ibèric regulat pel Reial Decret-llei 10/2022, del 13 de maig, dins dels "
+"costos d'aprovisionament, o bé traslladar-lo de manera diferenciada als seus"
+" consumidors. En aquest cas, la seva comercialitzadora ha optat per aquesta "
+"última opció."
+msgstr "Las comercializadoras en mercado libre pueden elegir voluntariamente repercutir el importe de la energía asociada a la compensación del mecanismo ibérico regulado por el Real Decreto-ley 10/2022, de 13 de mayo, dentro de sus costes de aprovisionamiento, o bien trasladarlo de forma diferenciada a sus consumidores. En este caso su comercializadora ha optado por esta última opción."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:32
 #, python-format
 msgid ""
-"Preu mitjà del Mecanisme d'Ajust el darrer mes natural complet (%s) ha "
-"estat de %s €/MWh, segons estableix el RD-L 10/2022."
-msgstr ""
+"Preu mitjà del Mecanisme d'Ajust el darrer mes natural complet (%s) ha estat"
+" de %s €/MWh, segons estableix el RD-L 10/2022."
+msgstr "Precio medio del Mecanismo de Ajuste en el último mes natural completo (%s) ha sido de %s €/MWh, según establece el RD-L 10/2022."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:34
 #, python-format
@@ -1533,26 +1543,26 @@ msgid ""
 "preu del mercat majorista de l'energia en el període comprès en aquesta "
 "factura ha estat de %s €/MWh, considerant que el preu mitjà del mercat "
 "majorista sense ajustament hagués estat de %s €/MWh (preu mitjà OMIE + "
-"mitjana de la quantia unitària) mentre que el preu mitjà amb ajustament "
-"ha estat de %s €/MWh (preu mitjà OMIE + mitjana del cost del MAG)"
-msgstr ""
+"mitjana de la quantia unitària) mentre que el preu mitjà amb ajustament ha "
+"estat de %s €/MWh (preu mitjà OMIE + mitjana del cost del MAG)"
+msgstr "El efecto reductor del Mecanismo de Ajuste regulado en el RD-L 10/2022 sobre el precio del mercado mayorista de la energía en el período comprendido en esta factura ha sido de %s €/MWh, considerando que el precio medio del mercado mayorista sin ajuste hubiera sido de %s €/MWh (precio medio OMIE + promedio de la cuantía unitaria) mientras que el precio medio con ajuste ha sido de %s €/MWh (precio medio OMIE + promedio del coste del MAJ)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:38
 msgid ""
 "(1) Segons estableix el Reial Decret 244/2019 aquest import no serà mai "
-"superior al l'import per energia utilitzada. En cas que la compensació "
-"sigui superior a l'energia utilitzada, el terme d'energia serà igual a 0€"
-msgstr ""
+"superior al l'import per energia utilitzada. En cas que la compensació sigui"
+" superior a l'energia utilitzada, el terme d'energia serà igual a 0€"
+msgstr "(1) Según establece el Real Decreto 244/2019 este importe no será nunca superior al importe por energía utilizada. En caso de que la compensación sea superior a la energía utilizada, el término de energía será igual a 0 €"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:7
 msgid ""
 "A aquests imports hauràs de sumar els altres costos que detallem a "
 "continuació:"
-msgstr ""
+msgstr "A estos importes deberás sumar otros costes que detallamos a continuación:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:10
 msgid "Bo social (RD 7/2016 23 desembre)"
-msgstr ""
+msgstr "Bono social (RD 7/2016 23 diciembre)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:41
@@ -1560,236 +1570,236 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:113
 #, python-format
 msgid "%s dies x %s €/dia"
-msgstr ""
+msgstr "%s días x %s €/día"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:25
 msgid "Impost d'electricitat"
-msgstr ""
+msgstr "Impuesto de electricidad"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:33
 #, python-format
 msgid "%s x 5,11269%%"
-msgstr ""
+msgstr "%s x 5,11269%%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:22
 #, python-format
 msgid " (amb l'exempció del {} sobre el {}% de Base Imposable IE)"
-msgstr ""
+msgstr " (con la exención del {} sobre el {}% de Base imponible IE)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:75
 msgid " (amb l'exempció del "
-msgstr ""
+msgstr " (con la eximisión del "
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:48
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:84
 msgid "Impost de l'electricitat"
-msgstr ""
+msgstr "Impuesto de electricidad"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:55
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:123
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:139
 msgid "(BASE IMPOSABLE)"
-msgstr ""
+msgstr "(BASE IMPONIBLE)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:68
 msgid "Donatiu voluntari (exempt d'IVA)"
-msgstr ""
+msgstr "Donativo voluntario (exento de IVA)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:42
 msgid "TOTAL IMPORT FACTURA"
-msgstr ""
+msgstr "TOTAL IMPORTE FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:79
 #, python-format
 msgid "%s &euro;"
-msgstr ""
+msgstr "%s &euro;"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:7
 msgid "Facturació per potència contractada"
-msgstr ""
+msgstr "Facturación por potencia contratada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:8
 msgid "Detall del càlcul del cost segons potència contractada:"
-msgstr ""
+msgstr "Detalle del cálculo del coste según potencia contratada:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:31
 #, python-format
 msgid "(%s) %s kW x %s €/kW i any x (%.f/%d) dies"
-msgstr ""
+msgstr "(%s) %s kW x %s €/kW y año x (%.f/%d) días"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:19
 msgid "Import Excés de Potència"
-msgstr ""
+msgstr "Importe Exceso de Potencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:36
 msgid ""
-"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari"
-" al terme de potència per a desenvolupar la nostra activitat de "
+"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari al"
+" terme de potència per a desenvolupar la nostra activitat de "
 "comercialització."
-msgstr ""
+msgstr "Tal y como se decidió en la Asamblea de 2020, añadimos el margen necesario el término de potencia para desarrollar nuestra actividad de comercialización."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:8
 msgid "Facturació per penalització de reactiva"
-msgstr ""
+msgstr "Facturación por penalización de reactiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:9
 msgid "Detall del càlcul del cost segons la penalització per reactiva:"
-msgstr ""
+msgstr "Detalle del cálculo del coste según la penalización por reactiva:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:20
 #, python-format
 msgid "(%s) %s kVArh x %s €/kVArh"
-msgstr ""
+msgstr "(%s) %s kVArh x %s €/kVArh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:16
 msgid ""
-"Detall del cost per peatge de penalització de reactiva inclós en l'import"
-" resultant:"
-msgstr ""
+"Detall del cost per peatge de penalització de reactiva inclós en l'import "
+"resultant:"
+msgstr "Detalle del coste por peaje de penalización de reactiva incluido en el importe resultante:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:8
 msgid "Concepte"
-msgstr ""
+msgstr "Concepto"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:9
 msgid "Detall"
-msgstr ""
+msgstr "Detalle"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:19
 msgid "Total conceptes"
-msgstr ""
+msgstr "Total conceptos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:22
 msgid "IGIC"
-msgstr ""
+msgstr "IGIC"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:24
 msgid "IVA"
-msgstr ""
+msgstr "IVA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:46
 msgid "TOTAL FACTURA"
-msgstr ""
+msgstr "TOTAL FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
 msgid "Bo social"
-msgstr ""
+msgstr "Bono social"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:9
 msgid "Penalització energia reactiva capacitiva"
-msgstr ""
+msgstr "Penalización energía reactiva capacitiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:12
 msgid "Energia reactiva capacitiva penalitzable [kVArh]"
-msgstr ""
+msgstr "Energía reactiva capacitiva penalizable [kVArh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:26
 msgid "Preu energia reactiva capacitiva [€/kVArh]"
-msgstr ""
+msgstr "Precio energía reactiva capacitiva [€/kVArh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:40
 msgid "kVArh x €/kVArh"
-msgstr ""
+msgstr "kVArh x €/kVArh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:19
 #, python-format
 msgid "Electricitat utilitzada [kWh] (%s)"
-msgstr ""
+msgstr "Electricidad utilizada [kWh] (%s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:7
 msgid "subjectes a descompte"
-msgstr ""
+msgstr "sujetos a descuento"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:26
 msgid "Electricitat utilitzada [kWh]"
-msgstr ""
+msgstr "Electricidad utilizada [kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:43
 msgid "Preu mitjà de l'energia [€/kWh]"
-msgstr ""
+msgstr "Precio medio de la energía [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:28
 msgid "Preu energia [€/kWh]"
-msgstr ""
+msgstr "Precio energía [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:60
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:47
 #, python-format
 msgid "kWh x €/kWh (del %s al %s)"
-msgstr ""
+msgstr "kWh x €/kWh (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:77
 #, python-format
 msgid ""
-"Import de l'energia associada al mecanisme ibèric regulat pel Reial "
-"Decret-llei 10/2022, del 13 de maig. (%s kWh x %s €/kWh)"
-msgstr ""
+"Import de l'energia associada al mecanisme ibèric regulat pel Reial Decret-"
+"llei 10/2022, del 13 de maig. (%s kWh x %s €/kWh)"
+msgstr "Importe de la energía asociada al mecanismo ibérico regulado por el Real Decreto-ley 10/2022, de 13 de mayo. (%s kWh x %s €/kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:5
 msgid "Preu càrrecs per electricitat utilitzades [€/kWh]"
-msgstr ""
+msgstr "Precio cargos por electricidad utilizada [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:19
 msgid "kWh x €/kWh"
-msgstr ""
+msgstr "kWh x €/kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kWh]"
-msgstr ""
+msgstr "Descuento sobre los cargos (RDL 17/2021) [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:9
 msgid "Electricitat GenerationkWh utilitzada [kWh]"
-msgstr ""
+msgstr "Electricidad GenerationkWh utilizada [kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:25
 msgid "Preu GenerationkWh [€/kWh]"
-msgstr ""
+msgstr "Precio GenerationkWh [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:4
 msgid "Peatges"
-msgstr ""
+msgstr "Peajes"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:5
 msgid "Preu peatges per electricitat utilitzada [€/kWh]"
-msgstr ""
+msgstr "Precio peajes por electricidad utilizada [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:113
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:11
 msgid "Facturacio per excés de potència"
-msgstr ""
+msgstr "Facturacion por exceso de potencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:116
 msgid "Potència maxímetre [kW]"
-msgstr ""
+msgstr "Potencia maxímetro [kW]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:132
 msgid "2 x (Potència maxímetre - Potència contractada) [kW]"
-msgstr ""
+msgstr "2 x (Potencia maxímetro - Potencia contratada) [kW]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:38
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:134
@@ -1799,88 +1809,88 @@ msgstr "Potencia maxímetro - Potencia contratada [kW]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:60
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:151
 msgid "Preu excés potència [€/kW i dia]"
-msgstr ""
+msgstr "Precio exceso potencia [€/kW y día]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:153
 msgid "Preu excés potència [€/kW i mes]"
-msgstr ""
+msgstr "Precio exceso potencia [€/kW y mes]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:88
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:174
 #, python-format
 msgid "kW x €/kW x %s dies (del %s al %s)"
-msgstr ""
+msgstr "kW x €/kW x %s días (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:90
 msgid "kW x €/kW"
-msgstr ""
+msgstr "kW x €/kW"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:176
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:71
 #, python-format
 msgid "kW x €/kW x (%.f/%d) dies (del %s al %s)"
-msgstr ""
+msgstr "kW x €/kW x (%.f/%d) días (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:14
 msgid "Potència excés [kW]"
-msgstr ""
+msgstr "Potencia exceso [kW]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:31
 msgid "Preu potència excés [€/kW i mes]"
-msgstr ""
+msgstr "Precio potencia exceso [€/kW y mes]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:33
 msgid "Preu potència excés [€/kW]"
-msgstr ""
+msgstr "Precio potencia exceso [€/kW]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:49
 msgid "Coeficient kp"
-msgstr ""
+msgstr "Coeficiente kp"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:69
 #, python-format
 msgid "kW excés x €/kW excés x kp x (%.f/30) dies (del %s al %s)"
-msgstr ""
+msgstr "kW exceso x €/kW exceso x kp x (%.f/30) días (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:71
 #, python-format
 msgid "kW excés x €/kW excés x kp (del %s al %s)"
-msgstr ""
+msgstr "kW exceso x €/kW exceso x kp (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:25
 msgid "Flux Solar"
-msgstr ""
+msgstr "Flux Solar"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
 msgid "Descompte per Flux Solar"
-msgstr ""
+msgstr "Descuento por Flux Solar"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:10
 msgid "Compensació per electricitat excedentària"
-msgstr ""
+msgstr "Compensación por electricidad excedentaria"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:13
 msgid "Electricitat excedentària [kWh]"
-msgstr ""
+msgstr "Electricidad excedentaria [kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:64
 msgid "Ajust límit de compensació per autoconsum"
-msgstr ""
+msgstr "Ajuste límite de compensación por autoconsumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:9
 msgid "Penalització energia reactiva inductiva"
-msgstr ""
+msgstr "Penalización energía reactiva inductiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:12
 msgid "Energia reactiva inductiva penalitzable [kVArh]"
-msgstr ""
+msgstr "Energía reactiva inductiva penalizable [kVArh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:26
 msgid "Preu energia reactiva inductiva [€/kVArh]"
-msgstr ""
+msgstr "Precio energía reactiva inductiva [€/kVArh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:22
@@ -1888,24 +1898,24 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
 msgid "Altres conceptes"
-msgstr ""
+msgstr "Otros conceptos"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:12
 #, python-format
 msgid "Bo social (RD 7/2016 23 desembre) %s dies x %s €/dia"
-msgstr ""
+msgstr "Bono social (RD 7/2016 23 de diciembre) %s días x %s €/día"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:38
 #, python-format
 msgid "Donatiu voluntari (exempt d'IVA) %s kWh x %s €/kWh"
-msgstr ""
+msgstr "Donativo voluntario (exento de IVA) %s kWh x %s €/kWh"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:51
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:64
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:87
 #, python-format
 msgid "%s € x 0,5%%"
-msgstr ""
+msgstr "%s € x 0,5%%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:52
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:88
@@ -1913,13 +1923,13 @@ msgid ""
 "En virtut del Reial Decret-llei 17/2021, del 14 de setembre, l'impost "
 "especial sobre l'electricitat aplicable a la factura es troba reduït del "
 "5,11269632% al 0,5%."
-msgstr ""
+msgstr "En virtud del Real Decreto-ley 17/2021, de 14 de septiembre, el impuesto especial sobre la electricidad aplicable a su factura se encuentra reducido del 5,11269632% al 0,5%."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:54
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:90
 #, python-format
 msgid "%s € x 2,5%%"
-msgstr ""
+msgstr "%s € x 2,5%%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:55
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:91
@@ -1927,13 +1937,13 @@ msgid ""
 "En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l'impost "
 "especial sobre l'electricitat aplicable a la factura es troba reduït del "
 "5,11269632% al 2,5%."
-msgstr ""
+msgstr "En virtud del Real Decreto-ley 8/2023, del 27 de diciembre, el impuesto especial sobre la electricidad aplicable a su factura se encuentra reducido del 5,11269632% al 2,5%."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:57
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:93
 #, python-format
 msgid "%s € x 3,8%%"
-msgstr ""
+msgstr "%s € x 3,8%%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:58
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:94
@@ -1941,193 +1951,193 @@ msgid ""
 "En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l'impost "
 "especial sobre l'electricitat aplicable a la factura es troba reduït del "
 "5,11269632% al 3,8%."
-msgstr ""
+msgstr "En virtud del Real Decreto-ley 8/2023, del 27 de diciembre, el impuesto especial sobre la electricidad aplicable a su factura se encuentra reducido del 5,11269632% al 3,8%."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:60
 #, python-format
 msgid ""
-"%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense "
-"bonificació del 85%%)"
-msgstr ""
+"%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense bonificació"
+" del 85%%)"
+msgstr "%s kWh x 0,001 €/kWh (aplicando Art 99.2 de la Ley 28/2014 sin bonificación del 85%%)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:62
 #, python-format
 msgid ""
 "%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense "
 "bonificació del 85%%)"
-msgstr ""
+msgstr "%s kWh x 0,0005 €/kWh (aplicando Art 99.2 de la Ley 28/2014 sin bonificación del 85%%)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:66
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:100
 #, python-format
 msgid "%s € x 5,11269%%"
-msgstr ""
+msgstr "%s € x 5,11269%%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:70
 #, python-format
 msgid " (amb l'exempció del {}% sobre el {}% de Base Imposable IE)"
-msgstr ""
+msgstr " (con la exención del {}% sobre el {}% de Base Imponible IE)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:96
 #, python-format
 msgid "%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014)"
-msgstr ""
+msgstr "%s kWh x 0,001 €/kWh (aplicando Art 99.2 de la Ley 28/2014)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:98
 #, python-format
 msgid "%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014)"
-msgstr ""
+msgstr "%s kWh x 0,0005 €/kWh (aplicando Art 99.2 de la Ley 28/2014)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:123
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:139
 #, python-format
 msgid "%s € "
-msgstr ""
+msgstr "%s € "
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:125
 msgid ""
-"En virtut del Reial Decret-llei 12/2021, del 24 de juny, l'IVA aplicable "
-"a la factura es troba reduït del 21% al 5%."
-msgstr ""
+"En virtut del Reial Decret-llei 12/2021, del 24 de juny, l'IVA aplicable a "
+"la factura es troba reduït del 21% al 5%."
+msgstr "En virtud del Real Decreto-ley 12/2021, de 24 de junio, el IVA aplicable a su factura se encuentra reducido del 21% al 5%."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:127
 msgid ""
-"En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l’IVA aplicat"
-" a la factura es troba reduït del 21% al 10%"
-msgstr ""
+"En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l’IVA aplicat a "
+"la factura es troba reduït del 21% al 10%"
+msgstr "En virtud del Real Decreto-Ley 8/2023, de 27 de diciembre, el IVA aplicado a la factura se encuentra reducido del 21% al 10%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:10
 msgid "Facturació per potencia contractada"
-msgstr ""
+msgstr "Facturación por potencia contratada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:13
 msgid "Potència contractada [kW]"
-msgstr ""
+msgstr "Potencia contratada [kW]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:42
 msgid "Preu potència contractada [€/kW i any]"
-msgstr ""
+msgstr "Precio potencia contratada [€/kW y año]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:5
 msgid "Preu càrrecs per potència contractada [€/kW i any]"
-msgstr ""
+msgstr "Precio cargos por potencia contratada [€/kW y año]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:34
 #, python-format
 msgid "kW x €/kW x (%s/%s) dies"
-msgstr ""
+msgstr "kW x €/kW x (%s/%s) días"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kW i any]"
-msgstr ""
+msgstr "Descuento sobre los cargos (RDL 17/2021) [€/kW y año]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:5
 msgid "Preu peatges per potència contractada [€/kW i any]"
-msgstr ""
+msgstr "Precio peajes por potencia contratada [€/kW y año]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_tec271/invoice_details_tec271.mako:8
 msgid "TAULA DETALLADA DELS SUPLEMENTS AUTONÒMICS 2013 (*)"
-msgstr ""
+msgstr "TABLA DETALLADA DE LOS SUPLEMENTOS AUTONÓMICOS 2013 (*)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:5
 msgid "DADES DE LA FACTURA"
-msgstr ""
+msgstr "DATOS DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:6
 #, python-format
 msgid "IMPORT DE LA FACTURA:  %s &euro;"
-msgstr ""
+msgstr "IMPORTE DE LA FACTURA: %s &euro;"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:8
 msgid "ABONAMENT"
-msgstr ""
+msgstr "ABONO"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:11
 msgid "Núm. de factura:"
-msgstr ""
+msgstr "N.º de factura:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:13
 msgid "Aquesta factura anul·la la factura"
-msgstr ""
+msgstr "Esta factura anula la factura"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:15
 msgid "Data de la factura:"
-msgstr ""
+msgstr "Fecha de la factura:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:16
 msgid "Període facturat:"
-msgstr ""
+msgstr "Período facturado:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:16
 #, python-format
 msgid "del %s al %s"
-msgstr ""
+msgstr "del %s al %s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:17
 msgid "Data venciment de la factura:"
-msgstr ""
+msgstr "Fecha vencimiento de la factura:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:18
 msgid "Núm. de contracte:"
-msgstr ""
+msgstr "N.º de contrato:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:6
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:6
 msgid "RESUM DE LA FACTURA"
-msgstr ""
+msgstr "RESUMEN DE LA FACTURA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:8
 msgid "Per energia utilitzada"
-msgstr ""
+msgstr "Por energía utilizada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:10
 msgid "Per energia excedentaria"
-msgstr ""
+msgstr "Por energía excedentaria"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:12
 msgid "Per potència contractada"
-msgstr ""
+msgstr "Por potencia contratada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:10
 msgid "Excés de potència"
-msgstr ""
+msgstr "Excesos de potencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:17
 msgid "Penalització per energia reactiva"
-msgstr ""
+msgstr "Penalización por energía reactiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:26
 msgid "Lloguer del comptador"
-msgstr ""
+msgstr "Alquiler del contador"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:40
 msgid "Donatiu voluntari (0,01 &euro;/kWh) (exempt d'IVA)"
-msgstr ""
+msgstr "Donativo voluntario (0,01 &euro;/kWh) (exento de IVA)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:12
 msgid "Electricitat utilitzada"
-msgstr ""
+msgstr "Electricidad utilizada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:14
 msgid "Electricitat excedentaria"
-msgstr ""
+msgstr "Electricidad excedentaria"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:17
 msgid "Penalització per energia reactiva inductiva"
-msgstr ""
+msgstr "Penalización por energía reactiva inductiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:20
 msgid "Penalització per energia reactiva capacitiva"
-msgstr ""
+msgstr "Penalización por energía reactiva capacitiva"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:28
 msgid "Descompte sobre els càrrecs (RDL 17/2021)"
-msgstr ""
+msgstr "Descuento sobre los cargos (RDL 17/2021)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/lateral_text/lateral_text.mako:6
 #: rml:giscedata_facturacio_comer_som/report/components/lateral_text/lateral_text.mako:7
@@ -2136,12 +2146,12 @@ msgstr ""
 msgid ""
 "%s Amb seu social a %s . %s - %s - Inscrita al Registre General de "
 "Cooperatives, full 13936, Inscripció 1a CIF: %s"
-msgstr ""
+msgstr "%s Con sede social en %s. %s - %s - Inscrita en el Registro General de Cooperativas, hoja 13936, Inscripción 1a CIF: %s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/maximeter_readings_table/maximeter_readings_table.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/maximeter_readings_table_td/maximeter_readings_table_td.mako:8
 msgid "MAXÍMETRE"
-msgstr ""
+msgstr "MAXÍMETRO"
 
 #: rml:giscedata_facturacio_comer_som/report/components/meters/meters.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table/reactive_readings_table.mako:60
@@ -2150,117 +2160,117 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:22
 msgid "Núm. de comptador"
-msgstr ""
+msgstr "N.º de contador"
 
 #: rml:giscedata_facturacio_comer_som/report/components/meters/meters.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table/reactive_readings_table.mako:66
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:69
 msgid "Darrera lectura real "
-msgstr ""
+msgstr "Última lectura real "
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:7
 msgid "DADES DE LA TITULARITAT"
-msgstr ""
+msgstr "DATOS DE LA TITULARIDAD"
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:8
 msgid "Nom del / de la titular del contracte: "
-msgstr ""
+msgstr "Nombre del / de la titular del contrato: "
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:9
 msgid "NIF/CIF:"
-msgstr ""
+msgstr "NIF/CIF:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:13
 msgid "DADES D'ABONAMENT"
-msgstr ""
+msgstr "DATOS DE ABONO"
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:16
 msgid "DADES DE PAGAMENT"
-msgstr ""
+msgstr "DATOS DE PAGO"
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:19
 msgid "Entitat bancària:"
-msgstr ""
+msgstr "Entidad bancaria:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:20
 msgid "Núm. compte bancari:"
-msgstr ""
+msgstr "N.º cuenta bancaria:"
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:25
 msgid ""
-"L'import d'aquesta factura es carregarà al teu compte. El seu pagament "
-"queda justificat amb l'apunt bancari corresponent."
-msgstr ""
+"L'import d'aquesta factura es carregarà al teu compte. El seu pagament queda"
+" justificat amb l'apunt bancari corresponent."
+msgstr "El importe de esta factura se cargará en tu cuenta. Su pago queda justificado con el correspondiente apunte bancario."
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:27
 msgid ""
-"L'import d'aquesta factura es pagarà mitjançant transferència bancària al"
-" compte indicat."
-msgstr ""
+"L'import d'aquesta factura es pagarà mitjançant transferència bancària al "
+"compte indicat."
+msgstr "El importe de esta factura se pagará mediante transferencia bancaria a la cuenta indicada."
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table/reactive_readings_table.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:7
 msgid "ENERGIA REACTIVA"
-msgstr ""
+msgstr "ENERGÍA REACTIVA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:25
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:28
 msgid "Lectura anterior"
-msgstr ""
+msgstr "Lectura anterior"
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:45
 msgid "Lectura final"
-msgstr ""
+msgstr "Lectura final"
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:44
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:53
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:56
 msgid "Total període"
-msgstr ""
+msgstr "Total período"
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:17
 msgid "Lectura actual"
-msgstr ""
+msgstr "Lectura actual"
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:19
 msgid "en el període"
-msgstr ""
+msgstr "en el período"
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:74
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:66
 #, python-format
 msgid "La despesa diària és de %s € que correspon a %s kWh/dia (%s dies)."
-msgstr ""
+msgstr "El gasto diario es de %s € que corresponde a %s kWh/día (%s días)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:9
 msgid "Energia excedentària"
-msgstr ""
+msgstr "Energía excedentaria"
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:9
 msgid "Energia utilitzada"
-msgstr ""
+msgstr "Energía utilizada"
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:8
 msgid "* Aquest consum té l'ajust corresponent al balanç horari "
-msgstr ""
+msgstr "* Este consumo tiene el ajuste correspondiente al balance horario "
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:10
 msgid "(más información)."
-msgstr ""
+msgstr "(más información)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:16
 msgid ""
-"* Aquesta factura recull un ajust de consum de períodes anteriors per "
-"part de la distribuïdora."
-msgstr ""
+"* Aquesta factura recull un ajust de consum de períodes anteriors per part "
+"de la distribuïdora."
+msgstr "* Esta factura recoge un ajuste de consumo de períodos anteriores por parte de la distribuidora."
 
 #: rml:giscedata_facturacio_comer_som/report/components/rectificative_banner/rectificative_banner.mako:7
 msgid "FACTURA RECTIFICATIVA PER IVA"
-msgstr ""
+msgstr "FACTURA RECTIFICATIVA POR IVA"
 
 #: rml:giscedata_facturacio_comer_som/report/components/rectificative_banner/rectificative_banner.mako:9
 #, python-format
@@ -2268,26 +2278,26 @@ msgid ""
 "Factura rectificativa de %s de data %s per causa de modificacio de base "
 "imposable i anulació de la quota repercutida conforme art. 80 Llei 24 RD "
 "162/1992 IVA. Quota anulada: %s €"
-msgstr ""
+msgstr "Factura rectificativa de %s de fecha %s por causa de modificación de base imponible y anulación de la cuota repercutida conforme art. 80 Ley 24 RD 162/1992 IVA. Cuota anulada: %s €"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:7
 #, python-format
 msgid "Origen de l'electricitat de la comercialitzadora. %s"
-msgstr ""
+msgstr "Origen de la electricidad de la comercializadora. %s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:8
 msgid "Som Energia SCCL"
-msgstr ""
+msgstr "Som Energia SCCL"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:64
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:68
 msgid "Som Energia"
-msgstr ""
+msgstr "Som Energia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:17
 msgid "Mix generació<br>nacional"
-msgstr ""
+msgstr "Mix generación<br>nacional"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:21
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:22
@@ -2305,121 +2315,121 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:52
 #, python-format
 msgid "%s %%"
-msgstr ""
+msgstr "%s %%"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:25
 msgid "Cogen Alta Eficiència"
-msgstr ""
+msgstr "Cogen Alta Eficiencia"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:30
 msgid "CC Gas Natural"
-msgstr ""
+msgstr "CC Gas Natural"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:40
 msgid "Fuel Gas"
-msgstr ""
+msgstr "Fuel Gas"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:50
 msgid "Altres no renovables"
-msgstr ""
+msgstr "Otras no renovables"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:58
 #, python-format
 msgid "Impacte ambiental de Som Energia. %s"
-msgstr ""
+msgstr "Impacto ambiental de Som Energia. %s"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:59
 msgid ""
 "La lletra 'A' correspon al mínim impacte ambiental, la lletra 'D' a la "
 "mitjana de generació nacional i la 'G' al màxim impacte ambiental."
-msgstr ""
+msgstr "La letra 'A' corresponde al mínimo impacto ambiental, la letra 'D' a la media de generación nacional y la 'G' al máximo impacto ambiental."
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:63
 msgid "Emissions de CO<sub>2</sub> equivalents"
-msgstr ""
+msgstr "Emisiones de CO<sub>2</sub> equivalentes"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:67
 msgid "Residus Radioactius Alta Activitat"
-msgstr ""
+msgstr "Residuos Radioactivos Alta Actividad"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:84
 msgid "Emissions CO<sub>2</sub> eq. (g/kWh)"
-msgstr ""
+msgstr "Emisiones CO<sub>2</sub> eq. (g/kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:88
 msgid "Mitjana Nacional (g/kWh)"
-msgstr ""
+msgstr "Media Nacional (g/kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:98
 msgid "Residus radioactius (&micro;g/kWh)"
-msgstr ""
+msgstr "Residuos radioactivos (&micro;g/kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:102
 msgid "Mitjana Nacional (&micro;g/kWh)"
-msgstr ""
+msgstr "Media Nacional (&micro;g/kWh)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:110
 msgid "Més informació sobre l'origen de la seva electricitat a"
-msgstr ""
+msgstr "Más información sobre el origen de su electricidad en"
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:7
 msgid "INFORMACIÓ DEL FLUX SOLAR"
-msgstr ""
+msgstr "INFORMACIÓN DEL FLUX SOLAR"
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:12
 #, python-format
 msgid ""
-"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció,"
-" que tenen un valor de    <b>%s</b> €. A través de la compensació "
+"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció, "
+"que tenen un valor de    <b>%s</b> €. A través de la compensació "
 "simplificada se t’han compensat <b>%s</b> €, i els  <b>%s</b> € restants "
-"se’t convertiran en   <b>%s</b> Sols (cada euro no compensat equival a "
-"0,8 Sols)."
-msgstr ""
+"se’t convertiran en   <b>%s</b> Sols (cada euro no compensat equival a 0,8 "
+"Sols)."
+msgstr "En esta factura has generado <b>%s</b> kWh de excedentes de autoproducción, que tienen un valor de    <b>%s</b> €. A través de la compensación simplificada se te han compensado <b>%s</b> € y los  <b>%s</b> € restantes se convertirán en   <b>%s</b> Sols (cada euro no compensado equivale a 0,8 Sols)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:14
 msgid "A partir de demà s’actualitzaran els Sols que tens disponibles a l’"
-msgstr ""
+msgstr "A partir de mañana se actualizarán los Sols que tienes disponibles en la "
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:22
 msgid "Oficina Virtual"
-msgstr ""
+msgstr "Oficina Virtual"
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:14
 msgid "i a les properes factures se’t transformaran en descomptes."
-msgstr ""
+msgstr "y en las próximas facturas se transformarán en descuentos."
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:16
 #, python-format
 msgid ""
-"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció,"
-" que tenen un valor de    <b>%s</b> €. A través de la compensació "
-"simplificada se t’han compensat <b>%s</b> €  (la totalitat dels excedents"
-" generats)."
-msgstr ""
+"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció, "
+"que tenen un valor de    <b>%s</b> €. A través de la compensació "
+"simplificada se t’han compensat <b>%s</b> €  (la totalitat dels excedents "
+"generats)."
+msgstr "En esta factura has generado <b>%s</b> kWh de excedentes de autoproducción, que tienen un valor de    <b>%s</b> €. A través de la compensación simplificada se te han compensado  <b>%s</b> € (la totalidad de los excedentes generados)."
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:22
 msgid ""
 "Per tant, en aquesta factura no es generen Sols. Pots consultar els teus "
 "Sols disponibles a la teva"
-msgstr ""
+msgstr "Por tanto, en esta factura no se generan Sols. Puedes consultar tus Sols disponibles en tu"
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:20
 msgid "En aquesta factura no han quedat"
-msgstr ""
+msgstr "En esta factura no han quedado"
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:20
 msgid "excedents sense compensar"
-msgstr ""
+msgstr "excedentes sin compensar"
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:20
 msgid "Si has autoconsumit i compensat tota la generació, ben aprofitada!."
-msgstr ""
+msgstr "Si has autoconsumido y compensado toda la generación, ¡bien aprovechada!."
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:25
 msgid ""
-"Al nostre Centre d’Ajuda tens més detalls del càlcul de Sols i del "
-"sistema de"
-msgstr ""
+"Al nostre Centre d’Ajuda tens més detalls del càlcul de Sols i del sistema "
+"de"
+msgstr "En nuestro Centro de Ayuda tienes más detalles del cálculo de Sols y del sistema de "

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -2,932 +2,936 @@
 # This file contains the translation of the following modules:
 # * giscedata_facturacio_comer_som
 #
-# Translators:
-#   <>, 2017, 2018, 2019, 2020.
-# Agustí Fita <afita@gisce.net>, 2018.
-# GISCE-TI, S.L. <devel@gisce.net>, 2014, 2017.
-# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022, 2023, 2024, 2025.
 msgid ""
 msgstr ""
-"Project-Id-Version: Som Energia\n"
+"Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2025-04-17 16:22+0000\n"
-"PO-Revision-Date: 2025-04-17 14:23+0000\n"
-"Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
-"Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
+"POT-Creation-Date: 2025-05-05 13:22+0000\n"
+"PO-Revision-Date: 2025-05-05 13:22+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: \n"
 "Generated-By: Babel 2.9.1\n"
-"Language: es_ES\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3673
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3694
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
-msgstr "Energía Reactiva Capacitiva (kVArh)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: model:giscedata.polissa.category,name:giscedata_facturacio_comer_som.cat_gp_factura_sign
 #: model:res.partner.category,name:giscedata_facturacio_comer_som.cat_rp_factura_sign
 msgid "Signar Factures"
-msgstr "Signar Facuras"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2669
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2673
+#: constraint:ir.ui.view:0
+msgid "Invalid XML for View Architecture!"
+msgstr ""
+
+#. module: giscedata_facturacio_comer_som
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2680
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
-msgstr "calculada"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2663
-msgid "estimada"
-msgstr "estimada"
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3663
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
+msgid "Energia Reactiva Inductiva (kVArh)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: model:ir.module.module,description:giscedata_facturacio_comer_som.module_meta_information
 #: model:ir.module.module,shortdesc:giscedata_facturacio_comer_som.module_meta_information
 msgid "Reports Facturació SOM (Comercialitzadora)"
-msgstr "Reports Facturación SOM (Comercializadora)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3703
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3724
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
-msgstr "Maxímetro (kW)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2713
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2724
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
-msgstr "sin lectura"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:giscedata.facturacio.factura:0
 msgid "La llista de preu no és compatible amb la tarifa d'accés."
-msgstr "La lista de precio no es compatible con la tarifa de acceso."
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2480
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2491
 msgid "(sense lectura)"
-msgstr "(sin lectura)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:202
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:341
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:213
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:352
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
-msgstr "estimada distribuidora"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:201
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2665
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:212
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2676
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
-msgstr "real"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
-msgstr "Invalid XML for View Architecture!"
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3819
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3847
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
+msgid "Autoconsum compartit (kWh)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3577
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3594
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
-msgstr "Energía Activa (kWh)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:988
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:999
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
-msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2411
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2422
 msgid " (Som Energia, SCCL)"
-msgstr "(Som Energia, SCCL)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3609
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3626
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
-msgstr "Energía Excedentaria (kWh)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2478
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2489
 msgid "(estimada)"
-msgstr "(estimada)"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:res.partner.category:0
 msgid "Error ! You can not create recursive categories."
-msgstr "Error ! You can not create recursive categories."
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3642
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
-msgid "Energia Reactiva Inductiva (kVArh)"
-msgstr "Energía Reactiva Inductiva (kVArh)"
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2674
+msgid "estimada"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2412
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2423
 msgid "TRANSFERÈNCIA"
-msgstr "TRANSFERENCIA"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:203
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:214
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
-msgstr "calculada por Som Energía"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: constraint:giscedata.polissa.category:0
 msgid "Error ! No pots crear categories recursives."
-msgstr "Error ! You can not create recursive categories."
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: field:giscedata.facturacio.factura,enviat_mail_id:0
 msgid "E-Mail factura adjunta"
-msgstr "E-Mail factura adjunta"
+msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2482
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2493
 msgid "(real)"
-msgstr "(real)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:52
 msgid "INFORMACIÓ DE L'ELECTRICITAT UTILITZADA"
-msgstr "INFORMACIÓN DE LA ELECTRICIDAD UTILIZADA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:69
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:142
 msgid "DETALL DE LA FACTURA"
-msgstr "DETALLE DE LA FACTURA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:82
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:168
 msgid ""
 "Informació sobre protecció de dades: Les dades personals tractades per "
-"gestionar la relació contractual i, si s'escau, remetre informació comercial"
-" per mitjans electrònics, es conservaran fins a la fi de la relació, baixa "
-"comercial o els terminis de retenció legals. Pots exercir els teus drets a "
-"l'adreça postal de Som Energia com a responsable o a somenergia@delegado-"
-"datos.com ."
-msgstr "Información sobre protección de datos: Los datos personales tratados para gestionar la relación contractual y, en su caso, remitir información comercial por medios electrónicos, se conservarán hasta el fin de la relación, baja comercial o los plazos de retención legales. Puedes ejercer tus derechos en la dirección postal de Som Energia como responsable o en somenergia@delegado-datos.com ."
+"gestionar la relació contractual i, si s'escau, remetre informació "
+"comercial per mitjans electrònics, es conservaran fins a la fi de la "
+"relació, baixa comercial o els terminis de retenció legals. Pots exercir "
+"els teus drets a l'adreça postal de Som Energia com a responsable o a "
+"somenergia@delegado-datos.com ."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_factura_comer.mako:100
 msgid "INFORMACIÓ DEL CONSUM ELÈCTRIC"
-msgstr "INFORMACIÓN DEL CONSUMO ELÉCTRICO"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:159
 msgid "ENTITAT EMISORA"
-msgstr "ENTIDAD EMISORA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:160
 msgid "Nº DE REFERENCIA"
-msgstr "N.º DE REFERENCIA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:161
 msgid "IDENTIFICACIÓ"
-msgstr "IDENTIFICACIÓN"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:169
 msgid "DATA EMISSIÓ"
-msgstr "FECHA EMISIÓN"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:170
 msgid "Document vàlid fins a:"
-msgstr "Documento válido hasta:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:171
 msgid "IMPORT TOTAL Euros"
-msgstr "IMPORTE TOTAL Euros"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:187
 msgid "Factura Nº:"
-msgstr "Factura N.º:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:194
 msgid "Data Factura:"
-msgstr "Fecha Factura:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:195
 msgid "Contracte:"
-msgstr "Contrato:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:212
 msgid "EUROS"
-msgstr "EUROS"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:228
 msgid "NOM I DOMICILI DEL PAGADOR"
-msgstr "NOMBRE Y DOMICILIO DEL PAGADOR"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:290
 msgid ""
 "Per fer el pagament online, pots entrar a <a "
 "href='https://www2.caixabank.es/apl/pagos/index_ca.html?IMP_codigoBarras={recibo507}'>https://www2.caixabank.es/apl/pagos/index_ca.html</a>"
-msgstr "Para hacer el pago online, puedes entrar a <a href='https://www2.caixabank.es/apl/pagos/index_es.html?IMP_codigoBarras={recibo507}'>https://www.caixabank.es/apl/pagos/codigoBarras_es.html</a>"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/report_giscedata_facturacio_rebut_comer.mako:297
 msgid "Resum factures agrupades"
-msgstr "Resumen facturas agrupadas"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:14
 msgid "Incentius a les energies renovables, cogeneració i residus"
-msgstr "Incentivos a las energías renovables, cogeneración y residuos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:15
 msgid "Cost de xarxes de distribució i transport"
-msgstr "Coste de las redes de distribución y transporte"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:16
 msgid "Altres costos regulats (inclosa anualitat del dèficit)"
-msgstr "Otros costes regulados (incluida anualidad del déficit)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:26
 msgid "Costos regulats"
-msgstr "Costes regulados"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:37
 msgid "Impostos aplicats"
-msgstr "Impuestos aplicados"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:28
 msgid "Costos de producció electricitat"
-msgstr "Costes de producción de electricidad"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:48
 msgid "DESTÍ DE L'IMPORT DE LA FACTURA"
-msgstr "DESTINO DEL IMPORTE DE LA FACTURA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:52
 #, python-format
 msgid "El destí de l'import de la teva factura, %s euros, és el següent:"
-msgstr "El destino del importe de tu factura, %s euros, es el siguiente:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination/amount_destination.mako:40
 #, python-format
 msgid ""
-"Als imports indicats en el diagrama s'ha d'afegir, si s'escau, el lloguer "
-"dels equips de mesura i control: %s €."
-msgstr "A los importes indicados en el diagrama debe añadirse, en su caso, el alquiler de los equipos de medida y control: %s €."
+"Als imports indicats en el diagrama s'ha d'afegir, si s'escau, el lloguer"
+" dels equips de mesura i control: %s €."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:21
 msgid "Anualitat del dèficit"
-msgstr "Anualidad del déficit"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:22
 msgid "RECORE: retribució a les renovables, cogeneració i residus"
-msgstr "RECORE: retribución a las renovables, cogeneración y residuos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:23
 msgid "Sobrecost de generació a territoris no peninsulars (TNP)"
-msgstr "Sobrecoste de generación en territorios no peninsulares (TNP)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:24
 msgid "Altres costos regulats"
-msgstr "Otros costes regulados"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:112
 msgid "Lloguer de comptador"
-msgstr "Alquiler de contador"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:38
 msgid "Peatges de transport i distribució"
-msgstr "Peajes de transporte y distribución"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:39
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:4
 msgid "Càrrecs"
-msgstr "Cargos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:40
 msgid "Energia"
-msgstr "Energía"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:50
 #, python-format
 msgid ""
-"El destí de l'import de la teva factura sense flux solar, %s euros, és el "
-"següent:"
-msgstr "El destino del importe de tu factura sin flux solar, %s euros, es el siguiente:"
+"El destí de l'import de la teva factura sense flux solar, %s euros, és el"
+" següent:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:10
 msgid "COMPARADOR DE PREUS DE LA CNMC"
-msgstr "COMPARADOR DE PRECIOS DE LA CNMC"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:14
 msgid "Amb aquest codi QR o bé amb l’enllaç "
-msgstr "Con este código QR o en el enlace "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:14
 msgid ""
 "pots consultar i comparar les diferents ofertes vigents de les "
 "comercialitzadores d’electricitat del mercat lliure."
-msgstr "puedes consultar y comparar las distintas ofertas vigentes de las comercializadoras de electricidad del mercado libre."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:16
 msgid "Recorda que tens "
-msgstr "Recuerda que tienes "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:16
 msgid "tarifa Generation kWh"
-msgstr "tarifa Generation kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:16
 msgid ""
-", que té un preu diferent de la tarifa general, i que el comparador no la té"
-" en compte."
-msgstr ", que tiene un precio diferente al de la tarifa general, y que el comparador no la tiene en cuenta."
+", que té un preu diferent de la tarifa general, i que el comparador no la"
+" té en compte."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako:22
-msgid ""
-"(no disposem de les dades suficients per omplir els camps del formulari)"
-msgstr "(no disponemos de los datos suficientes para poder rellenar los campos del formulario)"
+msgid "(no disposem de les dades suficients per omplir els camps del formulari)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:3
 msgid "CIF:"
-msgstr "CIF:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:4
 msgid "Domicili:"
-msgstr "Domicilio:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:5
 msgid "Adreça electrònica:"
-msgstr "E-mail:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/company/company.mako:6
 msgid "Comercialitzadora del Mercat Lliure"
-msgstr "Comercializadora del Mercado Libre"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:8
 msgid "Sense Autoconsum"
-msgstr "Sin Autoconsumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:13
 msgid "Sense Excedents Individual - Consum"
-msgstr "Sin Excedentes Individual – Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:14
 msgid "Sense Excedents Col·lectiu - Consum"
-msgstr "Sin Excedentes Colectivo – Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:15
 msgid "Sense Excedents Col·lectiu amb acord de compensació – Consum"
-msgstr "Sin Excedentes Colectivo con acuerdo de compensación – Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:16
 msgid "Amb excedents i compensació Individual-Consum"
-msgstr "Con excedentes y compensación Individual - Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:17
 msgid "Amb excedents i compensació Col·lectiu-Consum"
-msgstr "Con excedentes y compensación Colectivo– Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:18
 msgid "Amb excedents i compensació Col·lectiu a través de xarxa - Consum"
-msgstr "Con excedentes y compensación Colectivo a través de red - Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:19
 msgid ""
-"Amb excedents sense compensació Individual sense cte. de Serv. Aux. en Xarxa"
-" Interior - Consum"
-msgstr "Con excedentes sin compensación Individual sin cto de SSAA en Red Interior– Consumo"
+"Amb excedents sense compensació Individual sense cte. de Serv. Aux. en "
+"Xarxa Interior - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:20
 msgid ""
-"Amb excedents sense compensació Col·lectiu sense cte. de Serv. Aux. en Xarxa"
-" Interior - Consum"
-msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA en Red Interior– Consumo"
+"Amb excedents sense compensació Col·lectiu sense cte. de Serv. Aux. en "
+"Xarxa Interior - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:21
 msgid ""
-"Amb excedents sense compensació Individual amb cte. de Serv. Aux. en Xarxa "
-"Interior - Consum"
-msgstr "Con excedentes sin compensación Individual con cto SSAA en Red Interior– Consumo"
+"Amb excedents sense compensació Individual amb cte. de Serv. Aux. en "
+"Xarxa Interior - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:22
 msgid ""
-"Amb excedents sense compensació individual amb cte. de Serv. Aux. en Xarxa "
-"Interior - Serv. Aux."
-msgstr "Con excedentes sin compensación individual con cto SSAA en Red Interior– SSAA"
+"Amb excedents sense compensació individual amb cte. de Serv. Aux. en "
+"Xarxa Interior - Serv. Aux."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:23
-msgid ""
-"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"
-msgstr "Con excedentes sin compensación Colectivo/en Red Interior– Consumo"
+msgid "Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:24
 msgid ""
-"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. Aux."
-msgstr "Con excedentes sin compensación Colectivo/en Red Interior - SSAA"
+"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. "
+"Aux."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:21
 msgid ""
 "Amb excedents sense compensació Col·lectiu sense cte de Serv. Aux. "
 "(menyspreable) en Xarxa Interior – Consum')"
-msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA (despreciable) en red interior – Consumo')"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:22
 msgid ""
-"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a través "
-"de xarxa - Consum')"
-msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA a través de red - Consumo"
+"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a "
+"través de xarxa - Consum')"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:23
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:25
 msgid ""
-"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través "
-"de xarxa - Consum"
-msgstr "Con excedentes sin compensación Individual con cto SSAA a través de red – Consumo"
+"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a "
+"través de xarxa - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:26
 msgid ""
-"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través "
-"de xarxa - Serv. Aux."
-msgstr "Con excedentes sin compensación individual con cto SSAA a través de red – SSAA"
+"Amb excedents sense compensació individual amb cte. de Serv. Aux. a "
+"través de xarxa - Serv. Aux."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:25
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:27
 msgid "Amb excedents sense compensació Col·lectiu a través de xarxa - Consum"
-msgstr "Con excedentes sin compensación Colectivo a través de red – Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:28
-msgid ""
-"Amb excedents sense compensació Col·lectiu a través de xarxa - Serv. Aux."
-msgstr "Con excedentes sin compensación Colectivo a través de red - SSAA"
+msgid "Amb excedents sense compensació Col·lectiu a través de xarxa - Serv. Aux."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:29
 msgid ""
-"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través "
-"de xarxa i xarxa interior - Consum"
-msgstr "Con excedentes sin compensación Individual con cto SSAA a través de red y red interior – Consumo"
+"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a "
+"través de xarxa i xarxa interior - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:30
 msgid ""
-"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través "
-"de xarxa i xarxa interior - Serv. Aux."
-msgstr "Con excedentes sin compensación individual con cto SSAA a través de red y red interior – SSAA"
+"Amb excedents sense compensació individual amb cte. de Serv. Aux. a "
+"través de xarxa i xarxa interior - Serv. Aux."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:31
 msgid ""
-"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través "
-"de xarxa i xarxa interior - Consum"
-msgstr "Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo"
+"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a "
+"través de xarxa i xarxa interior - Consum"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:32
 msgid ""
-"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través "
-"de xarxa i xarxa interior - SSAA"
-msgstr "Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA"
+"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a "
+"través de xarxa i xarxa interior - SSAA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:33
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:35
 msgid "Sense excedents No acollit a compensació"
-msgstr "Sin excedentes No acogido a compensación"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:36
 msgid "Sense excedents acollit a compensació"
-msgstr "Sin excedentes acogido a compensación"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:35
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:37
 msgid "Amb excedents no acollits a compensació"
-msgstr "Con excedentes no acogidos a compensación"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:38
 msgid "Amb excedents acollits a compensació"
-msgstr "Con excedentes acogidos a compensación"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:37
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:39
 msgid "Sense autoconsum"
-msgstr "Sin autoconsumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:38
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:40
 msgid "Baixa com a membre d'autoconsum col·lectiu"
-msgstr "Baja como miembro de autoconsumo colectivo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:45
 msgid "DADES DEL CONTRACTE"
-msgstr "DATOS DEL CONTRATO"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:46
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:48
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:19
 msgid "Adreça de subministrament:"
-msgstr "Dirección de suministro:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:54
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:56
 msgid "Potència contractada (kW):"
-msgstr "Potencia contratada (kW):"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 msgid "facturació per maxímetre"
-msgstr "facturación por maxímetro"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 msgid "facturació per ICP"
-msgstr "facturación por ICP"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:48
 msgid "Tarifa contractada:"
-msgstr "Tarifa contratada:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:49
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:70
 msgid "CUPS:"
-msgstr "CUPS:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "Comptador telegestionat:"
-msgstr "Contador telegestionado:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "Sí"
-msgstr "Sí"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "No"
-msgstr "No"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:51
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:76
 msgid "CNAE:"
-msgstr "CNAE:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:52
 #, python-format
 msgid ""
 "Data d'alta del contracte: <span style=\"font-weight: bold;\">%s</span>, "
 "sense condicions de permanència"
-msgstr "Fecha de alta del contrato: <span style=\"font-weight: bold;\">%s</span>, sin condiciones de permanencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:53
 msgid "Forma de pagament: rebut domiciliat"
-msgstr "Forma de pago: recibo domiciliado"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:54
 #, python-format
 msgid "Data de renovació automàtica: <span style=\"font-weight: bold;\">%s</span>"
-msgstr "Fecha de renovación automática: <span style=\"font-weight: bold;\">%s</span>"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:59
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:81
 msgid "Autoproducció tipus:"
-msgstr "Autoproducción tipo:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:60
 msgid "Codi d'autoconsum unificat (CAU):"
-msgstr "Código de autoconsumo unificado (CAU):"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:62
 msgid "Percentatge de repartiment de l'autoproducció compartida:"
-msgstr "Porcentaje de reparto de la autoproducción compartida:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:9
 msgid "Autoconsum Tipus 1"
-msgstr "Autoconsumo Tipo 1"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:10
 msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. a) RD 900/2015)"
-msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. a) RD 900/2015)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:11
 msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. b) RD 900/2015)"
-msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. b) RD 900/2015)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:12
 msgid "Serveis auxiliars de generació lligada a un autoconsum tipus 2"
-msgstr "Servicios auxiliares de generación ligada a un autoconsumo tipo 2"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:54
 #, python-format
 msgid "Punta: <b><i>%s</i></b> - Vall: <b><i>%s</i></b>"
-msgstr "Punta: <b><i>%s</i></b> - Valle: <b><i>%s</i></b>"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:59
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:61
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
 msgid "Facturació potència:"
-msgstr "Facturación potencia:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:59
 msgid "Facturació per maxímetre"
-msgstr "Facturación por maxímetro"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:61
 msgid "Facturació per potència quarthorari"
-msgstr "Facturación por potencia cuartohorario"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
 msgid "Facturació per ICP"
-msgstr "Facturación por ICP"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:65
 msgid "Peatge de transport i distribució:"
-msgstr "Peaje de transporte y distribución:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:66
 msgid "Segment tarifari:"
-msgstr "Segmento tarifario:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:68
 msgid "Tarifa:"
-msgstr "Tarifa:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:77
 #, python-format
 msgid "Data d'alta del contracte: <span style=\"font-weight: bold;\">%s</span>"
-msgstr "Fecha de alta del contrato: <span style=\"font-weight: bold;\">%s</span>"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:78
 msgid ""
 "Forma de pagament: <span style=\"font-weight: bold;\">Rebut "
 "domiciliat</span>"
-msgstr "Forma de pago: <span style=\"font-weight: bold;\">Recibo domiciliado</span>"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 #, python-format
 msgid "Data final del contracte: <span style=\"font-weight: bold;\">%s</span> %s"
-msgstr "Fecha final del contrato: <span style=\"font-weight: bold;\">%s</span> %s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 msgid "sense condicions de permanència"
-msgstr "sin condiciones de permanencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 msgid "pròrroga automàtica per períodes d'un any"
-msgstr "prórroga automática por periodos de un año"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:83
 msgid "CAU (Codi d'autoconsum unificat):"
-msgstr "CAU (Código de autoconsumo unificado):"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:7
 msgid "INFORMACIÓ DE L'ELECTRICITAT"
-msgstr "INFORMACIÓN DE LA ELECTRICIDAD"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:9
 #, python-format
 msgid ""
-"L'electricitat que entra a les nostres llars ens arriba a través de la xarxa"
-" de distribució, l'electricitat que hi circula prové de diferents fonts, "
-"però utilitzant el sistema de certificats de garantia d'origen que emet la "
-"CNMC, a Som Energia podem garantir que el volum d'electricitat que "
-"comercialitzem prové 100% de fonts renovables."
-msgstr "La electricidad que entra en nuestros hogares nos llega a través de la red de distribución, la electricidad que circula proviene de diferentes fuentes, pero utilizando el sistema de certificados de garantía de origen que emite la CNMC, en Som Energía podemos garantizar que el volumen de electricidad que comercializamos proviene 100% de fuentes renovables."
+"L'electricitat que entra a les nostres llars ens arriba a través de la "
+"xarxa de distribució, l'electricitat que hi circula prové de diferents "
+"fonts, però utilitzant el sistema de certificats de garantia d'origen que"
+" emet la CNMC, a Som Energia podem garantir que el volum d'electricitat "
+"que comercialitzem prové 100% de fonts renovables."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:14
 msgid ""
-"En el gràfic següent mostrem el desglossament de la barreja de tecnologies "
-"de producció nacional per poder comparar el percentatge de l'energia "
-"produïda a escala nacional amb el percentatge d'energia venuda a través de "
-"la nostra cooperativa."
-msgstr "En el gráfico siguiente se muestra el desglose de la mezcla de tecnologías de producción nacional para poder comparar el porcentaje de la energía producida a escala nacional con el porcentaje de energía vendida a través de nuestra cooperativa."
+"En el gràfic següent mostrem el desglossament de la barreja de "
+"tecnologies de producció nacional per poder comparar el percentatge de "
+"l'energia produïda a escala nacional amb el percentatge d'energia venuda "
+"a través de la nostra cooperativa."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:19
 msgid "ORIGEN DE L'ELECTRICITAT"
-msgstr "ORIGEN DE LA ELECTRICIDAD"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:23
 msgid "Mix Som Energia, SCCL"
-msgstr "Mix Som Energia, SCCL"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:45
 msgid "Mix producció en el sistema elèctric espanyol {year}"
-msgstr "Mix producción en el sistema eléctrico español {year}"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:35
 #, python-format
-msgid ""
-"El sistema elèctric espanyol ha importat un {}% de producció neta total"
-msgstr "El sistema eléctrico español ha importado un {}% de producción neta total"
+msgid "El sistema elèctric espanyol ha importat un {}% de producció neta total"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:37
 #, python-format
-msgid ""
-"El sistema elèctric espanyol ha exportat un {}% de producció neta total"
-msgstr "El sistema eléctrico español ha exportado un {}% de producción neta total"
+msgid "El sistema elèctric espanyol ha exportat un {}% de producció neta total"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:15
 msgid "Origen"
-msgstr "Origen"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:50
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:20
 msgid "Renovable"
-msgstr "Renovable"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:53
 msgid "Cogeneració alta eficiència"
-msgstr "Cogeneración alta eficiencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:56
 msgid "Cogeneració"
-msgstr "Cogeneración"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:59
 msgid "CC Gas natural"
-msgstr "CC Gas natural"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:35
 msgid "Carbó"
-msgstr "Carbón"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:65
 msgid "Fuel/Gas"
-msgstr "Fuel/Gas"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:68
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:45
 msgid "Nuclear"
-msgstr "Nuclear"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/electricity_information/electricity_information.mako:71
 msgid "Altres"
-msgstr "Otras"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:7
 msgid "AVARIES I URGÈNCIES"
-msgstr "AVERÍAS Y URGENCIAS"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:8
 msgid "Empresa distribuïdora:"
-msgstr "Empresa distribuidora:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:10
 msgid "Núm. contracte distribuïdora:"
-msgstr "Núm. contrato distribuidora:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:20
 #, python-format
 msgid "AVARIES I URGÈNCIES DEL SUBMINISTRAMENT (distribuïdora): %s (24 hores)"
-msgstr "AVERÍAS Y URGENCIAS DEL SUMINISTRO (distribuidora): %s (24 horas)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:28
 msgid "RECLAMACIONS"
-msgstr "RECLAMACIONES"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:31
 msgid ""
-"RECLAMACIONES COMERCIALIZACIÓN (ENERGÉTICA/SOM ENERGIA): Lunes a viernes, de"
-" 10 a 14h. (tardes, previa cita) 983 660 112"
-msgstr "RECLAMACIONES COMERCIALIZACIÓN (ENERGÉTICA/SOM ENERGIA): Lunes a viernes, de 10 a 14h. (tardes, previa cita) 983 660 112"
+"RECLAMACIONES COMERCIALIZACIÓN (ENERGÉTICA/SOM ENERGIA): Lunes a viernes,"
+" de 10 a 14h. (tardes, previa cita) 983 660 112"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:23
 msgid "Correo electrónico: info@energetica.coop"
-msgstr "Correo electrónico: info@energetica.coop"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:33
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:24
-msgid ""
-"Dirección postal: Avda. Ramón Pradera 12, bajo trasera; 47009-Valladolid"
-msgstr "Dirección postal: Avda. Ramón Pradera 12, bajo trasera; 47009-Valladolid"
+msgid "Dirección postal: Avda. Ramón Pradera 12, bajo trasera; 47009-Valladolid"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:35
 #, python-format
 msgid ""
-"RECLAMACIONS COMERCIALITZACIÓ (SOM ENERGIA): Horari d'atenció de 9 a 14 h. "
-"900 103 605 (cost de la trucada per a la cooperativa).<br />Si tens tarifa "
-"plana, pots contactar igualment al %s, sense cap cost.<br />Adreça "
-"electrònica: reclama@somenergia.coop<br />Adreça postal: C/ Pic de Peguera, "
-"11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
-msgstr "RECLAMACIONES COMERCIALIZACIÓN (SOM ENERGIA): Horario de atención de 9 a 14h. 900 103 605 (coste de la llamada para la cooperativa) <br />Si tienes tarifa plana, puedes contactar igualmente al %s, sin ningún coste. <br />E-mail: reclama@somenergia.coop<br />Dirección postal: C/ Pic de Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
+"RECLAMACIONS COMERCIALITZACIÓ (SOM ENERGIA): Horari d'atenció de 9 a 14 "
+"h. 900 103 605 (cost de la trucada per a la cooperativa).<br />Si tens "
+"tarifa plana, pots contactar igualment al %s, sense cap cost.<br />Adreça"
+" electrònica: reclama@somenergia.coop<br />Adreça postal: C/ Pic de "
+"Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:31
 msgid ""
-"Som Energia és la teva comercialitzadora elèctrica a mercè de l'acord firmat"
-" amb"
-msgstr "Som Energia es tu comercializadora eléctrica merced al acuerdo firmado con"
+"Som Energia és la teva comercialitzadora elèctrica a mercè de l'acord "
+"firmat amb"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints/emergency_complaints.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:40
 msgid ""
-"Som Energia està adherida al Sistema Arbitral de Consum. Pots fer arribar la"
-" teva reclamació a la Junta Arbitral de Consum més propera: "
-msgstr "Som Energia está adherida al Sistema Arbitral de Consumo. Puedes hacer llegar tu reclamación a la Junta Arbitral de Consumo más cercana: "
+"Som Energia està adherida al Sistema Arbitral de Consum. Pots fer arribar"
+" la teva reclamació a la Junta Arbitral de Consum més propera: "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:11
 msgid "AVARIES I URGÈNCIES DEL SUBMINISTRAMENT (distribuïdora): "
-msgstr "AVERÍAS Y URGENCIAS DEL SUMINISTRO (distribuidora): "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:11
 #, python-format
 msgid "%s (24 hores)"
-msgstr "%s (24 horas)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:16
 msgid "RECLAMACIONES COMERCIALIZACIÓN ENERGÉTICA/SOM ENERGIA"
-msgstr "RECLAMACIONES COMERCIALIZACIÓN ENERGÉTICA/SOM ENERGIA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:18
 msgid "RECLAMACIONS COMERCIALITZACIÓ SOM ENERGIA"
-msgstr "RECLAMACIONES COMERCIALIZACIÓN SOM ENERGIA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:22
 msgid "Lunes a viernes, de 10 a 14h. (tardes, previa cita) 983 660 112"
-msgstr "Lunes a viernes, de 10 a 14h. (tardes, previa cita) 983 660 112"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:26
 #, python-format
 msgid ""
 "Horari de 9 a 14 h. 900 103 605 (Gratuït. cost de la trucada per a la "
-"cooperativa).<br />Si tens tarifa plana de telefonia, també pots trucar-nos "
-"al %s.<br />Adreça electrònica: reclama@somenergia.coop<br />Adreça postal: "
-"C/ Pic de Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - Girona<br />"
-msgstr "Horario de 9 a 14 h. 900103605 (Gratuito. Coste de la llamada para la cooperativa).<br />Si tienes tarifa plana de telefonía, también puedes llamarnos al %s.<br />Correo electrónico: reclama@somenergia.coop<br />Dirección C / Pic de Peguera, 11, A 2 8. Edificio Giroemprèn. 17003 - Girona<br />"
+"cooperativa).<br />Si tens tarifa plana de telefonia, també pots trucar-"
+"nos al %s.<br />Adreça electrònica: reclama@somenergia.coop<br />Adreça "
+"postal: C/ Pic de Peguera, 11, A 2 8. Edifici Giroemprèn. 17003 - "
+"Girona<br />"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:34
 msgid "Pots obtenir més informació sobre reclamacions en aquest "
-msgstr "Puedes obtener más información acerca de reclamaciones en este "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/emergency_complaints_td/emergency_complaints_td.mako:38
 msgid "article."
-msgstr "artículo."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:7
 #, python-format
 msgid "Número de comptador: %s"
-msgstr "Número de contador: %s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:10
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:37
 msgid "Tipus"
-msgstr "Tipo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:11
 msgid "Detall de lectures"
-msgstr "Detalle de lecturas"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:13
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:11
 msgid "Punta"
-msgstr "Punta"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:14
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:41
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:12
 msgid "Pla"
-msgstr "Llano"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:15
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:13
 msgid "Vall"
-msgstr "Valle"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:18
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:31
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:19
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:33
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:55
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:28
@@ -937,6 +941,9 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:73
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:85
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:10
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:25
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:15
@@ -1004,87 +1011,108 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:103
 #, python-format
 msgid "%s"
-msgstr "%s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:7
 #, python-format
 msgid "Lectura inicial (%s) (%s)"
-msgstr "Lectura inicial (%s) (%s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:19
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:21
 #, python-format
 msgid "Lectura final (%s) (%s)"
-msgstr "Lectura final (%s) (%s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:43
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:38
 msgid "Total periode "
-msgstr "Total periodo "
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:9
+msgid "Autoconsum (kWh)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:13
+#, python-format
+msgid "Generació segons coeficient de repartiment (periode del %s fins al %s)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:27
+#, python-format
+msgid "Energia autoconsumida (periode del %s fins al %s)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:45
+msgid "Excedent"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:10
 #, python-format
-msgid ""
-"(1) La despesa diària és de %s €, que correspon a %s kWh/dia (%s dies)."
-msgstr "(1) El gasto diario es de %s €, que corresponde a %s kWh/día (%s días)."
+msgid "(1) La despesa diària és de %s €, que correspon a %s kWh/dia (%s dies)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:13
 msgid ""
 "(2) Aquesta energia utilitzada inclou ajustos aplicats per la companyia "
 "distribuïdora."
-msgstr "(2) Esta energía utilizada incluye ajustes aplicados por la compañía distribuidora."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:15
 msgid ""
-"(2) Aquesta energia utilitzada inclou els ajustos corresponents al balanç "
-"horari "
-msgstr "(2) Esta energía utilizada incluye los ajustes correspondientes al balance horario "
+"(2) Aquesta energia utilitzada inclou els ajustos corresponents al balanç"
+" horari "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:12
 msgid "(més informació)."
-msgstr "(más información)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:23
 msgid ""
-"(2) Aquesta energia utilitzada inclou ajustos perquè les lectures informades"
-" per la companyia distribuïdora no concorden amb els consums informats per a"
-" cada període."
-msgstr "(2) Esta energía utilizada incluye ajustes porque las lecturas informadas por la compañía distribuidora no concuerdan con los consumos informados para cada período."
+"(2) Aquesta energia utilitzada inclou ajustos perquè les lectures "
+"informades per la companyia distribuïdora no concorden amb els consums "
+"informats per a cada període."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:9
 msgid ""
-"Si vols conèixer el detall de les teves dades horàries d’ús d’electricitat i"
-" de potència i disposes d’un comptador amb la telegestió activada, t’animem "
-"a registrar-te i accedir gratuïtament al portal web de la teva empresa "
-"distribuïdora: "
-msgstr "Si quieres conocer el detalle tus datos horarios de uso de electricidad y de potencia y dispones de un contador con la telegestión activada, te animamos a registrarte y acceder gratuitamente al portal web de tu empresa distribuidora:"
+"Si vols conèixer el detall de les teves dades horàries d’ús "
+"d’electricitat i de potència i disposes d’un comptador amb la telegestió "
+"activada, t’animem a registrar-te i accedir gratuïtament al portal web de"
+" la teva empresa distribuïdora: "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:13
 #, python-format
 msgid "(Ho sentim, %s encara no ens ha facilitat l’enllaç al portal)"
-msgstr "(Lo sentimos, %s todavía no nos ha facilitado el enlace al portal)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:59
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:8
 msgid "Potència contractada"
-msgstr "Potencia contratada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:70
 msgid "Potència maxímetre"
-msgstr "Potencia maxímetro"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:82
 msgid "Potència excedida"
-msgstr "Potencia excedida"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:57
 msgid "Maximetre (kW)"
-msgstr "Maxímetro (kW)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:15
@@ -1092,228 +1120,228 @@ msgstr "Maxímetro (kW)"
 msgid ""
 "La despesa mitjana diària en els últims %.0f mesos (%s dies) ha estat de "
 "<b>%s</b> €, que corresponen a <b>%s</b> kWh/dia."
-msgstr "El gasto medio diario en los últimos %.0f meses (%s días)  ha sido de <b>%s</b> €, que corresponden a <b>%s</b> kWh/día."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:17
 #, python-format
 msgid "L'electricitat utilitzada durant el darrer any: <b>%s</b> kWh."
-msgstr "La electricidad utilizada durante el último año: <b>%s</b> kWh."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:17
 #, python-format
-msgid ""
-"L'electricitat utilitzada durant el darrer any ha estat de <b>%s</b> kWh."
-msgstr "La electricidad utilizada durante el último año ha sido de <b>%s</b> kWh."
+msgid "L'electricitat utilitzada durant el darrer any ha estat de <b>%s</b> kWh."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:31
 #, python-format
 msgid ""
-"La potència màxima que has fet servir en el període que va del %s fins al %s"
-" és de: Punta: <b><i>%s</i></b> kW - Vall: <b><i>%s</i></b> kW (últimes "
-"dades rebudes per l’empresa distribuïdora)"
-msgstr "La potencia máxima que has utilizado en el período que va del %s hasta el %s és de: Punta: <b><i>%s</i></b> kW - Valle: <b><i>%s</i></b> kW (últimos datos recibidos por la empresa distribuidora)"
+"La potència màxima que has fet servir en el període que va del %s fins al"
+" %s és de: Punta: <b><i>%s</i></b> kW - Vall: <b><i>%s</i></b> kW "
+"(últimes dades rebudes per l’empresa distribuïdora)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:34
 #, python-format
 msgid ""
 "Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat "
 "aquestes dades)."
-msgstr "Potencia máxima demandada: (lo sentimos, %s aún no nos ha facilitado este dato)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:39
 #, python-format
 msgid ""
 "El consum mitjà de la teva zona (CP %s) durant l'últim mes ha estat de "
 "<b>%s</b> kWh."
-msgstr "El consumo medio de tu zona (CP %s) durante el último mes ha sido de <b>%s</b> kWh."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:41
 #, python-format
 msgid ""
-"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s) de"
-" l’últim mes."
-msgstr "Lo sentimos, %s no nos ha facilitado el consumo medio de tu zona (CP %s) del último mes."
+"Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s)"
+" de l’últim mes."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:7
 msgid "IMPACTE AMBIENTAL"
-msgstr "IMPACTO MEDIOAMBIENTAL"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:9
 msgid ""
-"L'impacte ambiental de l'electricitat que utilitzem depèn de les fonts de "
-"generació que s'utilitzen per a la seva producció."
-msgstr "El impacto ambiental de la electricidad que utilizamos depende de las fuentes de generación que se utilizan para su producción."
+"L'impacte ambiental de l'electricitat que utilitzem depèn de les fonts de"
+" generació que s'utilitzen per a la seva producció."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:11
 msgid ""
 "En una escala de A a G (on A indica el mínim impacte ambiental i G el "
-"màxim), i tenint en compte que el valor mitjà nacional correspon al nivell "
-"D, l'energia comercialitzada per Som Energia, SCCL, té els valors següents:"
-msgstr "En una escala de A a G (donde A indica el mínimo impacto ambiental y G el máximo), y teniendo en cuenta que el valor medio nacional corresponde al nivel D, la energía comercializada por <b>Som Energia, SCCL</b>, tiene los siguientes valores:"
+"màxim), i tenint en compte que el valor mitjà nacional correspon al "
+"nivell D, l'energia comercialitzada per Som Energia, SCCL, té els valors "
+"següents:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:16
 msgid "Emissions de diòxid de carboni "
-msgstr "Emisiones de dióxido de carbono "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:17
 msgid "Menys diòxid de carboni"
-msgstr "Menos dióxido de carbono"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:34
 msgid "Mitjana nacional"
-msgstr "Media nacional"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:24
 msgid "Contingut de carboni<br />Quilograms de diòxid de carboni per kWh"
-msgstr "Contenido de carbono<br />Kilogramos de dióxido de carbono por kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:25
 msgid "Més diòxid de carboni"
-msgstr "Más dióxido de carbono"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:28
 msgid "Residus radioactius d'alta activitat "
-msgstr "Residuos radiactivos de alta actividad "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:29
 msgid "Menys residus radioactius"
-msgstr "Menos residuos radiactivos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:36
 msgid "Residus radioactius<br />Mil·ligrams per kWh"
-msgstr "Residuos radioactivos<br />Miligramos por kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/environmental_impact/environmental_impact.mako:37
 msgid "Més residus radioactius"
-msgstr "Más residuos radiactivos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:6
 msgid "DETALL DELS CERTIFICATS DE GARANTIA D'ORIGEN PER A SOM ENERGIA"
-msgstr "DETALLE DE LOS CERTIFICADOS DE GARANTÍA DE ORIGEN PARA SOM ENERGIA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:12
 msgid "Font renovable"
-msgstr "Fuente renovable"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:12
 msgid "Energia MWh"
-msgstr "Energía MWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:17
 msgid "Eòlica"
-msgstr "Eólica"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:20
 msgid "Solar fotovoltaica"
-msgstr "Solar fotovoltaica"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:23
 msgid "Minihidràulica"
-msgstr "Minihidráulica"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:27
 msgid "Biogàs"
-msgstr "Biogás"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:32
 msgid "Biomassa"
-msgstr "Biomasa"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:38
 msgid "TOTAL"
-msgstr "TOTAL"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/gdo/gdo.mako:43
 msgid ""
 "Pots veure l'origen dels certificats de garantia d'origen en l'enllaç "
 "següent:"
-msgstr "Puedes ver el origen de los certificados de garantía de origen en el siguiente enlace:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:16
 msgid "Evolució horaria"
-msgstr "Evolución horaria"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:21
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:19
 msgid "Consum"
-msgstr "Consumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:26
 msgid "Preu Horari Final (cts. de €)"
-msgstr "Precio Horario Final (cts. de €)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:31
 msgid "Consum Horari (kWh)"
-msgstr "Consumo Horario (kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:36
 msgid "Preu OMIE €/kWh"
-msgstr "Precio OMIE €/kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:41
 msgid "Pagament per capacitat mig (€/kWh"
-msgstr "Pago por capacidad media (€/kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:46
 msgid "Pèrdues (%)"
-msgstr "Perdidas (%)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:83
 msgid "Consums totals per dies (kWh)"
-msgstr "Consumos totales por días (kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:83
 msgid "Corba horària de potència (kW)"
-msgstr "Curva horaria de potencia (kW)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:148
 msgid "Ús elèctric i corba horària"
-msgstr "Uso eléctrico y curva horaria"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:160
 msgid ""
 "Corbes horàries perfilades segons l'ús mensual informat per la "
 "distribuïdora."
-msgstr "Curvas horarias perfiladas según el uso mensual informado por la distribuidora."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/hourly_curve/hourly_curve.mako:162
 msgid "Corbes horàries informades per la distribuïdora."
-msgstr "Curvas horarias informadas por la distribuidora."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:16
 msgid ""
 "Els preus dels termes de peatge d'accés són els publicats a ORDRE "
 "IET/107/2014."
-msgstr "Los precios de los términos del peaje de acceso están publicados a ORDEN IET/107/2014."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_comments/invoice_details_comments.mako:17
 msgid ""
 "Els preus del lloguer dels comptadors són els establerts a ORDRE "
 "ITC/3860/2007."
-msgstr "Los precios del alquiler de los contadores son los establecidos en ORDEN ITC/3860/2007."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:12
 msgid "Facturació per electricitat utilitzada"
-msgstr "Facturación por electricidad utilizada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:8
 msgid "Detall del càlcul del cost segons l'energia utilitzada:"
-msgstr "Detalle del cálculo del coste según la energía utilizada:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:15
 #, python-format
 msgid "(%s)"
-msgstr "(%s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:69
 #, python-format
 msgid "%s kWh x %s €/kWh"
-msgstr "%s kWh x %s €/kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:33
@@ -1382,119 +1410,121 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:51
 #, python-format
 msgid "%s €"
-msgstr "%s €"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:27
 msgid "D'aquest import, el cost per peatge d'accés ha estat de:"
-msgstr "De este importe, el coste por peaje de acceso ha sido de:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:32
 #, python-format
 msgid "(%s) %s kWh x %s €/kWh"
-msgstr "(%s) %s kWh x %s €/kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:38
 msgid ""
-"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari al"
-" terme d'energia per a desenvolupar la nostra activitat de comercialització."
-msgstr "Tal y como se decidió en la Asamblea de 2020, añadimos el margen necesario el término de energía para desarrollar nuestra actividad de comercialización."
+"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari"
+" al terme d'energia per a desenvolupar la nostra activitat de "
+"comercialització."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_energy/invoice_details_energy.mako:42
 msgid ""
 "En el terme d'energia, afegim el marge necessari per a desenvolupar la "
-"nostra activitat de comercialització. Donem un major pes al terme variable "
-"de la factura, que depèn del nostre ús de l'energia. Busquem incentivar "
-"l'estalvi i l'eficiència energètica dels nostres socis/es i clients"
-msgstr "En el término de energía, añadimos el margen necesario para desarrollar nuestra actividad de comercialización. Damos un mayor peso al término variable de la factura, que depende de nuestro uso de la energía. Buscamos incentivar el ahorro y la eficiencia energética de las personas socias y clientas."
+"nostra activitat de comercialització. Donem un major pes al terme "
+"variable de la factura, que depèn del nostre ús de l'energia. Busquem "
+"incentivar l'estalvi i l'eficiència energètica dels nostres socis/es i "
+"clients"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:8
 msgid "Compensació per electricitat autoproduïda"
-msgstr "Compensación por electricidad autoproducida"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:9
 msgid "Detall del càlcul de l'energia compensada:"
-msgstr "Detalle del cálculo de la energía compensada:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_generation/invoice_details_generation.mako:27
 msgid ""
-"Segons estableix el Reial Decret 244/2019 aquest import no serà mai superior"
-" a l'import per energia utilitzada. En cas que la compensació sigui superior"
-" a l'energia utilitzada, el terme d'energia serà igual a 0€"
-msgstr "Según establece el Real Decreto 244/2019 este importe no será nunca superior al importe por energía utilizada. En caso de que la compensación sea superior a la energía utilizada, el término de energía será igual a 0€"
+"Segons estableix el Reial Decret 244/2019 aquest import no serà mai "
+"superior a l'import per energia utilitzada. En cas que la compensació "
+"sigui superior a l'energia utilitzada, el terme d'energia serà igual a 0€"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:8
 msgid "Gener"
-msgstr "Enero"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:9
 msgid "Febrer"
-msgstr "Febrero"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:10
 msgid "Març"
-msgstr "Marzo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:11
 msgid "Abril"
-msgstr "Abril"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:12
 msgid "Maig"
-msgstr "Mayo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:13
 msgid "Juny"
-msgstr "Junio"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:14
 msgid "Juliol"
-msgstr "Julio"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:15
 msgid "Agost"
-msgstr "Agosto"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:16
 msgid "Setembre"
-msgstr "Septiembre"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:17
 msgid "Octubre"
-msgstr "Octubre"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:18
 msgid "Novembre"
-msgstr "Noviembre"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:19
 msgid "Desembre"
-msgstr "Diciembre"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:27
 msgid ""
 "Els preus dels termes de peatges de transport i distribució són els "
-"publicats en el BOE núm. 70, de 23 de març de 2021. Els preus dels càrrecs "
-"són els publicats a l'Ordre TED/371/2021. Els preus del lloguer dels "
-"comptadors són els publicats a l'Ordre ITC/3860/2007."
-msgstr "Los precios de los términos de peajes de transporte y distribución son los publicados en el BOE núm. 70, del 23 de marzo de 2021. Los precios de los cargos son los publicados en la Orden TED/371/2021. Los precios del alquiler de los contadores son los publicados en la Orden ITC/3860/2007."
+"publicats en el BOE núm. 70, de 23 de març de 2021. Els preus dels "
+"càrrecs són els publicats a l'Ordre TED/371/2021. Els preus del lloguer "
+"dels comptadors són els publicats a l'Ordre ITC/3860/2007."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:30
 msgid ""
 "Les comercialitzadores del mercat lliure poden triar voluntàriament "
-"repercutir l'import de l'energia associada a la compensació del mecanisme "
-"ibèric regulat pel Reial Decret-llei 10/2022, del 13 de maig, dins dels "
-"costos d'aprovisionament, o bé traslladar-lo de manera diferenciada als seus"
-" consumidors. En aquest cas, la seva comercialitzadora ha optat per aquesta "
-"última opció."
-msgstr "Las comercializadoras en mercado libre pueden elegir voluntariamente repercutir el importe de la energía asociada a la compensación del mecanismo ibérico regulado por el Real Decreto-ley 10/2022, de 13 de mayo, dentro de sus costes de aprovisionamiento, o bien trasladarlo de forma diferenciada a sus consumidores. En este caso su comercializadora ha optado por esta última opción."
+"repercutir l'import de l'energia associada a la compensació del mecanisme"
+" ibèric regulat pel Reial Decret-llei 10/2022, del 13 de maig, dins dels "
+"costos d'aprovisionament, o bé traslladar-lo de manera diferenciada als "
+"seus consumidors. En aquest cas, la seva comercialitzadora ha optat per "
+"aquesta última opció."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:32
 #, python-format
 msgid ""
-"Preu mitjà del Mecanisme d'Ajust el darrer mes natural complet (%s) ha estat"
-" de %s €/MWh, segons estableix el RD-L 10/2022."
-msgstr "Precio medio del Mecanismo de Ajuste en el último mes natural completo (%s) ha sido de %s €/MWh, según establece el RD-L 10/2022."
+"Preu mitjà del Mecanisme d'Ajust el darrer mes natural complet (%s) ha "
+"estat de %s €/MWh, segons estableix el RD-L 10/2022."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:34
 #, python-format
@@ -1503,26 +1533,26 @@ msgid ""
 "preu del mercat majorista de l'energia en el període comprès en aquesta "
 "factura ha estat de %s €/MWh, considerant que el preu mitjà del mercat "
 "majorista sense ajustament hagués estat de %s €/MWh (preu mitjà OMIE + "
-"mitjana de la quantia unitària) mentre que el preu mitjà amb ajustament ha "
-"estat de %s €/MWh (preu mitjà OMIE + mitjana del cost del MAG)"
-msgstr "El efecto reductor del Mecanismo de Ajuste regulado en el RD-L 10/2022 sobre el precio del mercado mayorista de la energía en el período comprendido en esta factura ha sido de %s €/MWh, considerando que el precio medio del mercado mayorista sin ajuste hubiera sido de %s €/MWh (precio medio OMIE + promedio de la cuantía unitaria) mientras que el precio medio con ajuste ha sido de %s €/MWh (precio medio OMIE + promedio del coste del MAJ)"
+"mitjana de la quantia unitària) mentre que el preu mitjà amb ajustament "
+"ha estat de %s €/MWh (preu mitjà OMIE + mitjana del cost del MAG)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_info_td/invoice_details_info_td.mako:38
 msgid ""
 "(1) Segons estableix el Reial Decret 244/2019 aquest import no serà mai "
-"superior al l'import per energia utilitzada. En cas que la compensació sigui"
-" superior a l'energia utilitzada, el terme d'energia serà igual a 0€"
-msgstr "(1) Según establece el Real Decreto 244/2019 este importe no será nunca superior al importe por energía utilizada. En caso de que la compensación sea superior a la energía utilizada, el término de energía será igual a 0 €"
+"superior al l'import per energia utilitzada. En cas que la compensació "
+"sigui superior a l'energia utilitzada, el terme d'energia serà igual a 0€"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:7
 msgid ""
 "A aquests imports hauràs de sumar els altres costos que detallem a "
 "continuació:"
-msgstr "A estos importes deberás sumar otros costes que detallamos a continuación:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:10
 msgid "Bo social (RD 7/2016 23 desembre)"
-msgstr "Bono social (RD 7/2016 23 diciembre)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:41
@@ -1530,236 +1560,236 @@ msgstr "Bono social (RD 7/2016 23 diciembre)"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:113
 #, python-format
 msgid "%s dies x %s €/dia"
-msgstr "%s días x %s €/día"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:25
 msgid "Impost d'electricitat"
-msgstr "Impuesto de electricidad"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:33
 #, python-format
 msgid "%s x 5,11269%%"
-msgstr "%s x 5,11269%%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:22
 #, python-format
 msgid " (amb l'exempció del {} sobre el {}% de Base Imposable IE)"
-msgstr " (con la exención del {} sobre el {}% de Base imponible IE)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:75
 msgid " (amb l'exempció del "
-msgstr " (con la eximisión del "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:48
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:84
 msgid "Impost de l'electricitat"
-msgstr "Impuesto de electricidad"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:55
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:123
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:139
 msgid "(BASE IMPOSABLE)"
-msgstr "(BASE IMPONIBLE)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:68
 msgid "Donatiu voluntari (exempt d'IVA)"
-msgstr "Donativo voluntario (exento de IVA)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:77
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:42
 msgid "TOTAL IMPORT FACTURA"
-msgstr "TOTAL IMPORTE FACTURA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:79
 #, python-format
 msgid "%s &euro;"
-msgstr "%s &euro;"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:7
 msgid "Facturació per potència contractada"
-msgstr "Facturación por potencia contratada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:8
 msgid "Detall del càlcul del cost segons potència contractada:"
-msgstr "Detalle del cálculo del coste según potencia contratada:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:31
 #, python-format
 msgid "(%s) %s kW x %s €/kW i any x (%.f/%d) dies"
-msgstr "(%s) %s kW x %s €/kW y año x (%.f/%d) días"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:19
 msgid "Import Excés de Potència"
-msgstr "Importe Exceso de Potencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:36
 msgid ""
-"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari al"
-" terme de potència per a desenvolupar la nostra activitat de "
+"Tal i com es va decidir a l’Assamblea del 2020, afegim el marge necessari"
+" al terme de potència per a desenvolupar la nostra activitat de "
 "comercialització."
-msgstr "Tal y como se decidió en la Asamblea de 2020, añadimos el margen necesario el término de potencia para desarrollar nuestra actividad de comercialización."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:8
 msgid "Facturació per penalització de reactiva"
-msgstr "Facturación por penalización de reactiva"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:9
 msgid "Detall del càlcul del cost segons la penalització per reactiva:"
-msgstr "Detalle del cálculo del coste según la penalización por reactiva:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:20
 #, python-format
 msgid "(%s) %s kVArh x %s €/kVArh"
-msgstr "(%s) %s kVArh x %s €/kVArh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:16
 msgid ""
-"Detall del cost per peatge de penalització de reactiva inclós en l'import "
-"resultant:"
-msgstr "Detalle del coste por peaje de penalización de reactiva incluido en el importe resultante:"
+"Detall del cost per peatge de penalització de reactiva inclós en l'import"
+" resultant:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:8
 msgid "Concepte"
-msgstr "Concepto"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:9
 msgid "Detall"
-msgstr "Detalle"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:19
 msgid "Total conceptes"
-msgstr "Total conceptos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:22
 msgid "IGIC"
-msgstr "IGIC"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:24
 msgid "IVA"
-msgstr "IVA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:46
 msgid "TOTAL FACTURA"
-msgstr "TOTAL FACTURA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
 msgid "Bo social"
-msgstr "Bono social"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:9
 msgid "Penalització energia reactiva capacitiva"
-msgstr "Penalización energía reactiva capacitiva"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:12
 msgid "Energia reactiva capacitiva penalitzable [kVArh]"
-msgstr "Energía reactiva capacitiva penalizable [kVArh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:26
 msgid "Preu energia reactiva capacitiva [€/kVArh]"
-msgstr "Precio energía reactiva capacitiva [€/kVArh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:40
 msgid "kVArh x €/kVArh"
-msgstr "kVArh x €/kVArh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:19
 #, python-format
 msgid "Electricitat utilitzada [kWh] (%s)"
-msgstr "Electricidad utilizada [kWh] (%s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:7
 msgid "subjectes a descompte"
-msgstr "sujetos a descuento"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:26
 msgid "Electricitat utilitzada [kWh]"
-msgstr "Electricidad utilizada [kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:43
 msgid "Preu mitjà de l'energia [€/kWh]"
-msgstr "Precio medio de la energía [€/kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:28
 msgid "Preu energia [€/kWh]"
-msgstr "Precio energía [€/kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:60
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:47
 #, python-format
 msgid "kWh x €/kWh (del %s al %s)"
-msgstr "kWh x €/kWh (del %s al %s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:77
 #, python-format
 msgid ""
-"Import de l'energia associada al mecanisme ibèric regulat pel Reial Decret-"
-"llei 10/2022, del 13 de maig. (%s kWh x %s €/kWh)"
-msgstr "Importe de la energía asociada al mecanismo ibérico regulado por el Real Decreto-ley 10/2022, de 13 de mayo. (%s kWh x %s €/kWh)"
+"Import de l'energia associada al mecanisme ibèric regulat pel Reial "
+"Decret-llei 10/2022, del 13 de maig. (%s kWh x %s €/kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:5
 msgid "Preu càrrecs per electricitat utilitzades [€/kWh]"
-msgstr "Precio cargos por electricidad utilizada [€/kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:19
 msgid "kWh x €/kWh"
-msgstr "kWh x €/kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kWh]"
-msgstr "Descuento sobre los cargos (RDL 17/2021) [€/kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:9
 msgid "Electricitat GenerationkWh utilitzada [kWh]"
-msgstr "Electricidad GenerationkWh utilizada [kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:25
 msgid "Preu GenerationkWh [€/kWh]"
-msgstr "Precio GenerationkWh [€/kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:4
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:4
 msgid "Peatges"
-msgstr "Peajes"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:5
 msgid "Preu peatges per electricitat utilitzada [€/kWh]"
-msgstr "Precio peajes por electricidad utilizada [€/kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:113
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:11
 msgid "Facturacio per excés de potència"
-msgstr "Facturacion por exceso de potencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:116
 msgid "Potència maxímetre [kW]"
-msgstr "Potencia maxímetro [kW]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:36
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:132
 msgid "2 x (Potència maxímetre - Potència contractada) [kW]"
-msgstr "2 x (Potencia maxímetro - Potencia contratada) [kW]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:38
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:134
@@ -1769,88 +1799,88 @@ msgstr "Potencia maxímetro - Potencia contratada [kW]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:60
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:151
 msgid "Preu excés potència [€/kW i dia]"
-msgstr "Precio exceso potencia [€/kW y día]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:153
 msgid "Preu excés potència [€/kW i mes]"
-msgstr "Precio exceso potencia [€/kW y mes]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:88
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:174
 #, python-format
 msgid "kW x €/kW x %s dies (del %s al %s)"
-msgstr "kW x €/kW x %s días (del %s al %s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:90
 msgid "kW x €/kW"
-msgstr "kW x €/kW"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:176
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:71
 #, python-format
 msgid "kW x €/kW x (%.f/%d) dies (del %s al %s)"
-msgstr "kW x €/kW x (%.f/%d) días (del %s al %s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:14
 msgid "Potència excés [kW]"
-msgstr "Potencia exceso [kW]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:31
 msgid "Preu potència excés [€/kW i mes]"
-msgstr "Precio potencia exceso [€/kW y mes]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:33
 msgid "Preu potència excés [€/kW]"
-msgstr "Precio potencia exceso [€/kW]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:49
 msgid "Coeficient kp"
-msgstr "Coeficiente kp"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:69
 #, python-format
 msgid "kW excés x €/kW excés x kp x (%.f/30) dies (del %s al %s)"
-msgstr "kW exceso x €/kW exceso x kp x (%.f/30) días (del %s al %s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako:71
 #, python-format
 msgid "kW excés x €/kW excés x kp (del %s al %s)"
-msgstr "kW exceso x €/kW exceso x kp (del %s al %s)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:25
 msgid "Flux Solar"
-msgstr "Flux Solar"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
 msgid "Descompte per Flux Solar"
-msgstr "Descuento por Flux Solar"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:10
 msgid "Compensació per electricitat excedentària"
-msgstr "Compensación por electricidad excedentaria"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:13
 msgid "Electricitat excedentària [kWh]"
-msgstr "Electricidad excedentaria [kWh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako:64
 msgid "Ajust límit de compensació per autoconsum"
-msgstr "Ajuste límite de compensación por autoconsumo"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:9
 msgid "Penalització energia reactiva inductiva"
-msgstr "Penalización energía reactiva inductiva"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:12
 msgid "Energia reactiva inductiva penalitzable [kVArh]"
-msgstr "Energía reactiva inductiva penalizable [kVArh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_inductive/invoice_details_td_inductive.mako:26
 msgid "Preu energia reactiva inductiva [€/kVArh]"
-msgstr "Precio energía reactiva inductiva [€/kVArh]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:22
@@ -1858,24 +1888,24 @@ msgstr "Precio energía reactiva inductiva [€/kVArh]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
 msgid "Altres conceptes"
-msgstr "Otros conceptos"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:12
 #, python-format
 msgid "Bo social (RD 7/2016 23 desembre) %s dies x %s €/dia"
-msgstr "Bono social (RD 7/2016 23 de diciembre) %s días x %s €/día"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:38
 #, python-format
 msgid "Donatiu voluntari (exempt d'IVA) %s kWh x %s €/kWh"
-msgstr "Donativo voluntario (exento de IVA) %s kWh x %s €/kWh"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:51
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:64
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:87
 #, python-format
 msgid "%s € x 0,5%%"
-msgstr "%s € x 0,5%%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:52
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:88
@@ -1883,13 +1913,13 @@ msgid ""
 "En virtut del Reial Decret-llei 17/2021, del 14 de setembre, l'impost "
 "especial sobre l'electricitat aplicable a la factura es troba reduït del "
 "5,11269632% al 0,5%."
-msgstr "En virtud del Real Decreto-ley 17/2021, de 14 de septiembre, el impuesto especial sobre la electricidad aplicable a su factura se encuentra reducido del 5,11269632% al 0,5%."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:54
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:90
 #, python-format
 msgid "%s € x 2,5%%"
-msgstr "%s € x 2,5%%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:55
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:91
@@ -1897,13 +1927,13 @@ msgid ""
 "En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l'impost "
 "especial sobre l'electricitat aplicable a la factura es troba reduït del "
 "5,11269632% al 2,5%."
-msgstr "En virtud del Real Decreto-ley 8/2023, del 27 de diciembre, el impuesto especial sobre la electricidad aplicable a su factura se encuentra reducido del 5,11269632% al 2,5%."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:57
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:93
 #, python-format
 msgid "%s € x 3,8%%"
-msgstr "%s € x 3,8%%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:58
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:94
@@ -1911,193 +1941,193 @@ msgid ""
 "En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l'impost "
 "especial sobre l'electricitat aplicable a la factura es troba reduït del "
 "5,11269632% al 3,8%."
-msgstr "En virtud del Real Decreto-ley 8/2023, del 27 de diciembre, el impuesto especial sobre la electricidad aplicable a su factura se encuentra reducido del 5,11269632% al 3,8%."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:60
 #, python-format
 msgid ""
-"%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense bonificació"
-" del 85%%)"
-msgstr "%s kWh x 0,001 €/kWh (aplicando Art 99.2 de la Ley 28/2014 sin bonificación del 85%%)"
+"%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense "
+"bonificació del 85%%)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:62
 #, python-format
 msgid ""
 "%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014 sense "
 "bonificació del 85%%)"
-msgstr "%s kWh x 0,0005 €/kWh (aplicando Art 99.2 de la Ley 28/2014 sin bonificación del 85%%)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:66
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:100
 #, python-format
 msgid "%s € x 5,11269%%"
-msgstr "%s € x 5,11269%%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:70
 #, python-format
 msgid " (amb l'exempció del {}% sobre el {}% de Base Imposable IE)"
-msgstr " (con la exención del {}% sobre el {}% de Base Imponible IE)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:96
 #, python-format
 msgid "%s kWh x 0,001 €/kWh (aplicant Art 99.2 de la Llei 28/2014)"
-msgstr "%s kWh x 0,001 €/kWh (aplicando Art 99.2 de la Ley 28/2014)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:98
 #, python-format
 msgid "%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014)"
-msgstr "%s kWh x 0,0005 €/kWh (aplicando Art 99.2 de la Ley 28/2014)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:123
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:139
 #, python-format
 msgid "%s € "
-msgstr "%s € "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:125
 msgid ""
-"En virtut del Reial Decret-llei 12/2021, del 24 de juny, l'IVA aplicable a "
-"la factura es troba reduït del 21% al 5%."
-msgstr "En virtud del Real Decreto-ley 12/2021, de 24 de junio, el IVA aplicable a su factura se encuentra reducido del 21% al 5%."
+"En virtut del Reial Decret-llei 12/2021, del 24 de juny, l'IVA aplicable "
+"a la factura es troba reduït del 21% al 5%."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:127
 msgid ""
-"En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l’IVA aplicat a "
-"la factura es troba reduït del 21% al 10%"
-msgstr "En virtud del Real Decreto-Ley 8/2023, de 27 de diciembre, el IVA aplicado a la factura se encuentra reducido del 21% al 10%"
+"En virtut del Reial Decret-llei 8/2023, del 27 de desembre, l’IVA aplicat"
+" a la factura es troba reduït del 21% al 10%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:10
 msgid "Facturació per potencia contractada"
-msgstr "Facturación por potencia contratada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:13
 msgid "Potència contractada [kW]"
-msgstr "Potencia contratada [kW]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:42
 msgid "Preu potència contractada [€/kW i any]"
-msgstr "Precio potencia contratada [€/kW y año]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:5
 msgid "Preu càrrecs per potència contractada [€/kW i any]"
-msgstr "Precio cargos por potencia contratada [€/kW y año]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:34
 #, python-format
 msgid "kW x €/kW x (%s/%s) dies"
-msgstr "kW x €/kW x (%s/%s) días"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kW i any]"
-msgstr "Descuento sobre los cargos (RDL 17/2021) [€/kW y año]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:5
 msgid "Preu peatges per potència contractada [€/kW i any]"
-msgstr "Precio peajes por potencia contratada [€/kW y año]"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_tec271/invoice_details_tec271.mako:8
 msgid "TAULA DETALLADA DELS SUPLEMENTS AUTONÒMICS 2013 (*)"
-msgstr "TABLA DETALLADA DE LOS SUPLEMENTOS AUTONÓMICOS 2013 (*)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:5
 msgid "DADES DE LA FACTURA"
-msgstr "DATOS DE LA FACTURA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:6
 #, python-format
 msgid "IMPORT DE LA FACTURA:  %s &euro;"
-msgstr "IMPORTE DE LA FACTURA: %s &euro;"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:8
 msgid "ABONAMENT"
-msgstr "ABONO"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:11
 msgid "Núm. de factura:"
-msgstr "N.º de factura:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:13
 msgid "Aquesta factura anul·la la factura"
-msgstr "Esta factura anula la factura"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:15
 msgid "Data de la factura:"
-msgstr "Fecha de la factura:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:16
 msgid "Període facturat:"
-msgstr "Período facturado:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:16
 #, python-format
 msgid "del %s al %s"
-msgstr "del %s al %s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:17
 msgid "Data venciment de la factura:"
-msgstr "Fecha vencimiento de la factura:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:18
 msgid "Núm. de contracte:"
-msgstr "N.º de contrato:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:6
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:6
 msgid "RESUM DE LA FACTURA"
-msgstr "RESUMEN DE LA FACTURA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:8
 msgid "Per energia utilitzada"
-msgstr "Por energía utilizada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:10
 msgid "Per energia excedentaria"
-msgstr "Por energía excedentaria"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:12
 msgid "Per potència contractada"
-msgstr "Por potencia contratada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:10
 msgid "Excés de potència"
-msgstr "Excesos de potencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:17
 msgid "Penalització per energia reactiva"
-msgstr "Penalización por energía reactiva"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:26
 msgid "Lloguer del comptador"
-msgstr "Alquiler del contador"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:40
 msgid "Donatiu voluntari (0,01 &euro;/kWh) (exempt d'IVA)"
-msgstr "Donativo voluntario (0,01 &euro;/kWh) (exento de IVA)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:12
 msgid "Electricitat utilitzada"
-msgstr "Electricidad utilizada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:14
 msgid "Electricitat excedentaria"
-msgstr "Electricidad excedentaria"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:17
 msgid "Penalització per energia reactiva inductiva"
-msgstr "Penalización por energía reactiva inductiva"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:20
 msgid "Penalització per energia reactiva capacitiva"
-msgstr "Penalización por energía reactiva capacitiva"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:28
 msgid "Descompte sobre els càrrecs (RDL 17/2021)"
-msgstr "Descuento sobre los cargos (RDL 17/2021)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/lateral_text/lateral_text.mako:6
 #: rml:giscedata_facturacio_comer_som/report/components/lateral_text/lateral_text.mako:7
@@ -2106,12 +2136,12 @@ msgstr "Descuento sobre los cargos (RDL 17/2021)"
 msgid ""
 "%s Amb seu social a %s . %s - %s - Inscrita al Registre General de "
 "Cooperatives, full 13936, Inscripció 1a CIF: %s"
-msgstr "%s Con sede social en %s. %s - %s - Inscrita en el Registro General de Cooperativas, hoja 13936, Inscripción 1a CIF: %s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/maximeter_readings_table/maximeter_readings_table.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/maximeter_readings_table_td/maximeter_readings_table_td.mako:8
 msgid "MAXÍMETRE"
-msgstr "MAXÍMETRO"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/meters/meters.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table/reactive_readings_table.mako:60
@@ -2120,117 +2150,117 @@ msgstr "MAXÍMETRO"
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:22
 msgid "Núm. de comptador"
-msgstr "N.º de contador"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/meters/meters.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table/reactive_readings_table.mako:66
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:69
 msgid "Darrera lectura real "
-msgstr "Última lectura real "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:7
 msgid "DADES DE LA TITULARITAT"
-msgstr "DATOS DE LA TITULARIDAD"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:8
 msgid "Nom del / de la titular del contracte: "
-msgstr "Nombre del / de la titular del contrato: "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:9
 msgid "NIF/CIF:"
-msgstr "NIF/CIF:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:13
 msgid "DADES D'ABONAMENT"
-msgstr "DATOS DE ABONO"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:16
 msgid "DADES DE PAGAMENT"
-msgstr "DATOS DE PAGO"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:19
 msgid "Entitat bancària:"
-msgstr "Entidad bancaria:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:20
 msgid "Núm. compte bancari:"
-msgstr "N.º cuenta bancaria:"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:25
 msgid ""
-"L'import d'aquesta factura es carregarà al teu compte. El seu pagament queda"
-" justificat amb l'apunt bancari corresponent."
-msgstr "El importe de esta factura se cargará en tu cuenta. Su pago queda justificado con el correspondiente apunte bancario."
+"L'import d'aquesta factura es carregarà al teu compte. El seu pagament "
+"queda justificat amb l'apunt bancari corresponent."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/partner_info/partner_info.mako:27
 msgid ""
-"L'import d'aquesta factura es pagarà mitjançant transferència bancària al "
-"compte indicat."
-msgstr "El importe de esta factura se pagará mediante transferencia bancaria a la cuenta indicada."
+"L'import d'aquesta factura es pagarà mitjançant transferència bancària al"
+" compte indicat."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table/reactive_readings_table.mako:7
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:7
 msgid "ENERGIA REACTIVA"
-msgstr "ENERGÍA REACTIVA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:25
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:28
 msgid "Lectura anterior"
-msgstr "Lectura anterior"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:34
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:45
 msgid "Lectura final"
-msgstr "Lectura final"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/reactive_readings_table_td/reactive_readings_table_td.mako:44
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:53
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:56
 msgid "Total període"
-msgstr "Total período"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:17
 msgid "Lectura actual"
-msgstr "Lectura actual"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:19
 msgid "en el període"
-msgstr "en el período"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_6x/readings_6x.mako:74
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:66
 #, python-format
 msgid "La despesa diària és de %s € que correspon a %s kWh/dia (%s dies)."
-msgstr "El gasto diario es de %s € que corresponde a %s kWh/día (%s días)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_g_table/readings_g_table.mako:9
 msgid "Energia excedentària"
-msgstr "Energía excedentaria"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_table/readings_table.mako:9
 msgid "Energia utilitzada"
-msgstr "Energía utilizada"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:8
 msgid "* Aquest consum té l'ajust corresponent al balanç horari "
-msgstr "* Este consumo tiene el ajuste correspondiente al balance horario "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:10
 msgid "(más información)."
-msgstr "(más información)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/readings_text/readings_text.mako:16
 msgid ""
-"* Aquesta factura recull un ajust de consum de períodes anteriors per part "
-"de la distribuïdora."
-msgstr "* Esta factura recoge un ajuste de consumo de períodos anteriores por parte de la distribuidora."
+"* Aquesta factura recull un ajust de consum de períodes anteriors per "
+"part de la distribuïdora."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/rectificative_banner/rectificative_banner.mako:7
 msgid "FACTURA RECTIFICATIVA PER IVA"
-msgstr "FACTURA RECTIFICATIVA POR IVA"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/rectificative_banner/rectificative_banner.mako:9
 #, python-format
@@ -2238,26 +2268,26 @@ msgid ""
 "Factura rectificativa de %s de data %s per causa de modificacio de base "
 "imposable i anulació de la quota repercutida conforme art. 80 Llei 24 RD "
 "162/1992 IVA. Quota anulada: %s €"
-msgstr "Factura rectificativa de %s de fecha %s por causa de modificación de base imponible y anulación de la cuota repercutida conforme art. 80 Ley 24 RD 162/1992 IVA. Cuota anulada: %s €"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:7
 #, python-format
 msgid "Origen de l'electricitat de la comercialitzadora. %s"
-msgstr "Origen de la electricidad de la comercializadora. %s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:8
 msgid "Som Energia SCCL"
-msgstr "Som Energia SCCL"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:64
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:68
 msgid "Som Energia"
-msgstr "Som Energia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:17
 msgid "Mix generació<br>nacional"
-msgstr "Mix generación<br>nacional"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:21
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:22
@@ -2275,121 +2305,121 @@ msgstr "Mix generación<br>nacional"
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:52
 #, python-format
 msgid "%s %%"
-msgstr "%s %%"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:25
 msgid "Cogen Alta Eficiència"
-msgstr "Cogen Alta Eficiencia"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:30
 msgid "CC Gas Natural"
-msgstr "CC Gas Natural"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:40
 msgid "Fuel Gas"
-msgstr "Fuel Gas"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:50
 msgid "Altres no renovables"
-msgstr "Otras no renovables"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:58
 #, python-format
 msgid "Impacte ambiental de Som Energia. %s"
-msgstr "Impacto ambiental de Som Energia. %s"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:59
 msgid ""
 "La lletra 'A' correspon al mínim impacte ambiental, la lletra 'D' a la "
 "mitjana de generació nacional i la 'G' al màxim impacte ambiental."
-msgstr "La letra 'A' corresponde al mínimo impacto ambiental, la letra 'D' a la media de generación nacional y la 'G' al máximo impacto ambiental."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:63
 msgid "Emissions de CO<sub>2</sub> equivalents"
-msgstr "Emisiones de CO<sub>2</sub> equivalentes"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:67
 msgid "Residus Radioactius Alta Activitat"
-msgstr "Residuos Radioactivos Alta Actividad"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:84
 msgid "Emissions CO<sub>2</sub> eq. (g/kWh)"
-msgstr "Emisiones CO<sub>2</sub> eq. (g/kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:88
 msgid "Mitjana Nacional (g/kWh)"
-msgstr "Media Nacional (g/kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:98
 msgid "Residus radioactius (&micro;g/kWh)"
-msgstr "Residuos radioactivos (&micro;g/kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:102
 msgid "Mitjana Nacional (&micro;g/kWh)"
-msgstr "Media Nacional (&micro;g/kWh)"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:110
 msgid "Més informació sobre l'origen de la seva electricitat a"
-msgstr "Más información sobre el origen de su electricidad en"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:7
 msgid "INFORMACIÓ DEL FLUX SOLAR"
-msgstr "INFORMACIÓN DEL FLUX SOLAR"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:12
 #, python-format
 msgid ""
-"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció, "
-"que tenen un valor de    <b>%s</b> €. A través de la compensació "
+"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció,"
+" que tenen un valor de    <b>%s</b> €. A través de la compensació "
 "simplificada se t’han compensat <b>%s</b> €, i els  <b>%s</b> € restants "
-"se’t convertiran en   <b>%s</b> Sols (cada euro no compensat equival a 0,8 "
-"Sols)."
-msgstr "En esta factura has generado <b>%s</b> kWh de excedentes de autoproducción, que tienen un valor de    <b>%s</b> €. A través de la compensación simplificada se te han compensado <b>%s</b> € y los  <b>%s</b> € restantes se convertirán en   <b>%s</b> Sols (cada euro no compensado equivale a 0,8 Sols)."
+"se’t convertiran en   <b>%s</b> Sols (cada euro no compensat equival a "
+"0,8 Sols)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:14
 msgid "A partir de demà s’actualitzaran els Sols que tens disponibles a l’"
-msgstr "A partir de mañana se actualizarán los Sols que tienes disponibles en la "
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:22
 msgid "Oficina Virtual"
-msgstr "Oficina Virtual"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:14
 msgid "i a les properes factures se’t transformaran en descomptes."
-msgstr "y en las próximas facturas se transformarán en descuentos."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:16
 #, python-format
 msgid ""
-"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció, "
-"que tenen un valor de    <b>%s</b> €. A través de la compensació "
-"simplificada se t’han compensat <b>%s</b> €  (la totalitat dels excedents "
-"generats)."
-msgstr "En esta factura has generado <b>%s</b> kWh de excedentes de autoproducción, que tienen un valor de    <b>%s</b> €. A través de la compensación simplificada se te han compensado  <b>%s</b> € (la totalidad de los excedentes generados)."
+"En aquesta factura has generat <b>%s</b> kWh d'excedents d’autoproducció,"
+" que tenen un valor de    <b>%s</b> €. A través de la compensació "
+"simplificada se t’han compensat <b>%s</b> €  (la totalitat dels excedents"
+" generats)."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:22
 msgid ""
 "Per tant, en aquesta factura no es generen Sols. Pots consultar els teus "
 "Sols disponibles a la teva"
-msgstr "Por tanto, en esta factura no se generan Sols. Puedes consultar tus Sols disponibles en tu"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:20
 msgid "En aquesta factura no han quedat"
-msgstr "En esta factura no han quedado"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:20
 msgid "excedents sense compensar"
-msgstr "excedentes sin compensar"
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:20
 msgid "Si has autoconsumit i compensat tota la generació, ben aprofitada!."
-msgstr "Si has autoconsumido y compensado toda la generación, ¡bien aprovechada!."
+msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/solar_flux_info/solar_flux_info.mako:25
 msgid ""
-"Al nostre Centre d’Ajuda tens més detalls del càlcul de Sols i del sistema "
-"de"
-msgstr "En nuestro Centro de Ayuda tienes más detalles del cálculo de Sols y del sistema de "
+"Al nostre Centre d’Ajuda tens més detalls del càlcul de Sols i del "
+"sistema de"
+msgstr ""

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2025-04-17 16:22+0000\n"
-"PO-Revision-Date: 2025-04-17 16:22+0000\n"
+"POT-Creation-Date: 2025-05-05 13:22+0000\n"
+"PO-Revision-Date: 2025-05-05 13:22+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3673
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3694
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -28,15 +28,21 @@ msgid "Signar Factures"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2669
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2673
+#: constraint:ir.ui.view:0
+msgid "Invalid XML for View Architecture!"
+msgstr ""
+
+#. module: giscedata_facturacio_comer_som
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2680
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2684
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2663
-msgid "estimada"
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3663
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
+msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
@@ -46,14 +52,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3703
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3724
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2713
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2724
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -64,55 +70,57 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2480
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2491
 msgid "(sense lectura)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:202
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:341
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:213
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:352
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:201
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2665
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:212
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2676
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3819
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3847
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
+msgid "Autoconsum compartit (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3577
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3594
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:988
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:999
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2411
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2422
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3609
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3626
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2478
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2489
 msgid "(estimada)"
 msgstr ""
 
@@ -122,18 +130,17 @@ msgid "Error ! You can not create recursive categories."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3642
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
-msgid "Energia Reactiva Inductiva (kVArh)"
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2674
+msgid "estimada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2412
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2423
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:203
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:214
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr ""
@@ -149,7 +156,7 @@ msgid "E-Mail factura adjunta"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2482
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2493
 msgid "(real)"
 msgstr ""
 
@@ -891,6 +898,7 @@ msgid "Número de comptador: %s"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:10
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:37
 msgid "Tipus"
 msgstr ""
 
@@ -899,24 +907,31 @@ msgid "Detall de lectures"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:13
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:11
 msgid "Punta"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:14
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:41
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:12
 msgid "Pla"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:15
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:13
 msgid "Vall"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:18
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:31
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:19
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:33
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:55
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:28
@@ -926,6 +941,9 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:62
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:73
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:85
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:10
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:25
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:45
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:15
@@ -996,17 +1014,39 @@ msgid "%s"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:7
 #, python-format
 msgid "Lectura inicial (%s) (%s)"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:19
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:21
 #, python-format
 msgid "Lectura final (%s) (%s)"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:43
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:38
 msgid "Total periode "
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:9
+msgid "Autoconsum (kWh)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:13
+#, python-format
+msgid "Generació segons coeficient de repartiment (periode del %s fins al %s)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:27
+#, python-format
+msgid "Energia autoconsumida (periode del %s fins al %s)"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:45
+msgid "Excedent"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako:10

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2025-05-05 13:22+0000\n"
-"PO-Revision-Date: 2025-05-05 13:22+0000\n"
+"POT-Creation-Date: 2025-05-05 16:35+0000\n"
+"PO-Revision-Date: 2025-05-05 16:35+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3694
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3696
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -40,7 +40,7 @@ msgid "calculada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3663
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3665
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
@@ -52,7 +52,7 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3724
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3726
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
@@ -89,14 +89,14 @@ msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3819
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3847
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3821
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3849
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
 msgid "Autoconsum compartit (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3594
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3596
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
@@ -114,7 +114,7 @@ msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3626
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3628
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""

--- a/giscedata_facturacio_comer_som/migrations/5.0.25.5.0/post-0001_load_translations.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.25.5.0/post-0001_load_translations.py
@@ -1,0 +1,22 @@
+import logging
+from tools import config
+from tools.translate import trans_load
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    module_name = 'giscedata_facturacio_comer_som'
+
+    logger.info("Updating translations")
+    trans_load(cursor, '{}/{}/i18n/es_ES.po'.format(config['addons_path'], module_name), 'es_ES')
+    logger.info("Translations succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.css
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.css
@@ -29,6 +29,7 @@
 
 #energy_consumption_detail_td .periods_td{
     text-align: center;
+    width: 70px;
 }
 
 .last_row {

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.css
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.css
@@ -24,6 +24,7 @@
 #energy_consumption_detail_td .detall_td{
     text-align: left;
     font-weight: bold;
+    width: 350px;
 }
 
 #energy_consumption_detail_td .periods_td{

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
@@ -21,7 +21,7 @@
                 <th class="info_td"></th>
             </tr>
             <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.active" />
-            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.surplus" />
+            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako" args="meter=meter.surplus" />
             <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.inductive" />
             <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.capacitive" />
             % if meter == id.meters[-1]:

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
@@ -35,7 +35,7 @@
         <table id="energy_consumption_detail_td">
             <tr>
                 <th class="concepte_td">${_(u"Tipus")}</th>
-                <th class="detall_td">${_(u"Detall de lectures")}</th>
+                <th class="detall_td"></th>
                 % if len(coll.showing_periods) == 3:
                     <th class="periods_td">${_(u"Punta")}</th>
                     <th class="periods_td">${_(u"Pla")}</th>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
@@ -30,6 +30,26 @@
     </table>
 </div>
 %  endfor
+%for coll in id.collectives:
+    <h1>${_(u"Autoconsum col·lectiu: %s") %(coll.name)}</h1>
+    <table id="energy_consumption_detail_td">
+        <tr>
+            <th class="concepte_td">${_(u"Tipus")}</th>
+            <th class="detall_td">${_(u"Detall de lectures")}</th>
+            % if len(coll.showing_periods) == 3:
+                <th class="periods_td">${_(u"Punta")}</th>
+                <th class="periods_td">${_(u"Pla")}</th>
+                <th class="periods_td">${_(u"Vall")}</th>
+            % else:
+                % for period in coll.showing_periods:
+                    <th class="periods_td">${_(u"%s") %(period)}</th>
+                % endfor
+            % endif
+            <th class="info_td"></th>
+        <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako" args="coll=coll.generated" />
+        </tr>
+    </table>
+%  endfor
 <div class="energy_consumption_detail_td_block">
     <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako" args="id_info=id.info" />
 </div>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
@@ -3,53 +3,55 @@
 <%include file="energy_consumption_detail_td.css" />
 </style>
 % for meter in id.meters:
-<div class="energy_consumption_detail_td_block">
-    <h1>${_(u"Número de comptador: %s") %(meter.name)}</h1>
-    <table id="energy_consumption_detail_td">
-        <tr>
-            <th class="concepte_td">${_(u"Tipus")}</th>
-            <th class="detall_td">${_(u"Detall de lectures")}</th>
-            % if len(meter.showing_periods) == 3:
-                <th class="periods_td">${_(u"Punta")}</th>
-                <th class="periods_td">${_(u"Pla")}</th>
-                <th class="periods_td">${_(u"Vall")}</th>
-            % else:
-                % for period in meter.showing_periods:
-                    <th class="periods_td">${_(u"%s") %(period)}</th>
-                % endfor
+    <div class="energy_consumption_detail_td_block">
+        <h1>${_(u"Número de comptador: %s") %(meter.name)}</h1>
+        <table id="energy_consumption_detail_td">
+            <tr>
+                <th class="concepte_td">${_(u"Tipus")}</th>
+                <th class="detall_td">${_(u"Detall de lectures")}</th>
+                % if len(meter.showing_periods) == 3:
+                    <th class="periods_td">${_(u"Punta")}</th>
+                    <th class="periods_td">${_(u"Pla")}</th>
+                    <th class="periods_td">${_(u"Vall")}</th>
+                % else:
+                    % for period in meter.showing_periods:
+                        <th class="periods_td">${_(u"%s") %(period)}</th>
+                    % endfor
+                % endif
+                <th class="info_td"></th>
+            </tr>
+            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.active" />
+            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.surplus" />
+            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.inductive" />
+            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.capacitive" />
+            % if meter == id.meters[-1]:
+                <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako" args="meter=meter.maximeter" />
             % endif
-            <th class="info_td"></th>
-        </tr>
-        <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.active" />
-        <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.surplus" />
-        <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.inductive" />
-        <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako" args="meter=meter.capacitive" />
-        % if meter == id.meters[-1]:
-            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako" args="meter=meter.maximeter" />
-        % endif
-    </table>
-</div>
+        </table>
+    </div>
 %  endfor
 %for coll in id.collectives:
-    <h1>${_(u"Autoconsum col·lectiu: %s") %(coll.name)}</h1>
-    <table id="energy_consumption_detail_td">
-        <tr>
-            <th class="concepte_td">${_(u"Tipus")}</th>
-            <th class="detall_td">${_(u"Detall de lectures")}</th>
-            % if len(coll.showing_periods) == 3:
-                <th class="periods_td">${_(u"Punta")}</th>
-                <th class="periods_td">${_(u"Pla")}</th>
-                <th class="periods_td">${_(u"Vall")}</th>
-            % else:
-                % for period in coll.showing_periods:
-                    <th class="periods_td">${_(u"%s") %(period)}</th>
-                % endfor
-            % endif
-            <th class="info_td"></th>
-        <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako" args="coll=coll.generated" />
-        </tr>
-    </table>
-%  endfor
+    <div class="energy_consumption_detail_td_block">
+        <h1>${_(u"Autoconsum col·lectiu: %s") %(coll.name)}</h1>
+        <table id="energy_consumption_detail_td">
+            <tr>
+                <th class="concepte_td">${_(u"Tipus")}</th>
+                <th class="detall_td">${_(u"Detall de lectures")}</th>
+                % if len(coll.showing_periods) == 3:
+                    <th class="periods_td">${_(u"Punta")}</th>
+                    <th class="periods_td">${_(u"Pla")}</th>
+                    <th class="periods_td">${_(u"Vall")}</th>
+                % else:
+                    % for period in coll.showing_periods:
+                        <th class="periods_td">${_(u"%s") %(period)}</th>
+                    % endfor
+                % endif
+                <th class="info_td"></th>
+            </tr>
+            <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako" args="coll=coll.generated" />
+        </table>
+    </div>
+% endfor
 <div class="energy_consumption_detail_td_block">
     <%include file="/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_info/energy_consumption_detail_td_info.mako" args="id_info=id.info" />
 </div>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td/energy_consumption_detail_td.mako
@@ -32,7 +32,6 @@
 %  endfor
 %for coll in id.collectives:
     <div class="energy_consumption_detail_td_block">
-        <h1>${_(u"Autoconsum col·lectiu: %s") %(coll.name)}</h1>
         <table id="energy_consumption_detail_td">
             <tr>
                 <th class="concepte_td">${_(u"Tipus")}</th>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
@@ -17,9 +17,9 @@
         <td class="detall_td">${_(u"Lectura inicial (%s) (%s)") % (meter.initial_date, _(meter.initial_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td>${_(u"%s") %(int(meter[p]["initial"]))}</td>
+                <td class="periods_td">${_(u"%s") %(int(meter[p]["initial"]))}</td>
             % else:
-                <td></td>
+                <td class="periods_td"></td>
             % endif
         % endfor
         <td></td>
@@ -28,9 +28,9 @@
         <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td>${_(u"%s") %(int(meter[p]["final"]))}</td>
+                <td class="periods_td">${_(u"%s") %(int(meter[p]["final"]))}</td>
             % else:
-                <td></td>
+                <td class="periods_td"></td>
             % endif
         % endfor
         <td></td>
@@ -47,12 +47,12 @@
         </td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td>${_(u"%s") %(int(round(meter[p]["total"])))}</td>
+                <td class="periods_td">${_(u"%s") %(int(round(meter[p]["total"])))}</td>
             % else:
-                <td></td>
+                <td class="periods_td"></td>
             % endif
         % endfor
-        <td>
+        <td class="periods_td">
         % if meter.adjust_reason != False:
             <sup>(2)</sup>
         % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -45,9 +45,6 @@
             % endif
         % endfor
         <td>
-        % if coll.adjust_reason != False:
-            <sup>(2)</sup>
-        % endif
         </td>
     </tr>
 % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -9,7 +9,9 @@
         <td class="detall_td">${_(u"Generació segons coeficient de repartiment (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:
-                <td>${_(u"%s") %(formatLang(coll[p]["generacio_neta"], digits=3))}</td>
+                % data = coll[p].get("generacio_neta", 0.0)
+                <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
+                ## <td>${_(u"%s") %(formatLang(coll[p]["generacio_neta"], digits=3))}</td>
             % else:
                 <td></td>
             % endif
@@ -20,7 +22,8 @@
         <td class="detall_td">${_(u"Energia autoconsumida (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:
-                <td>${_(u"%s") %(formatLang(coll[p]["autoconsum"], digits=3))}</td>
+                % data = coll[p].get("autoconsum", 0.0)
+                <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
                 <td></td>
             % endif
@@ -39,7 +42,8 @@
         </td>
         % for p in coll.showing_periods:
             % if p in coll:
-                <td>${_(u"%s") %(formatLang(coll[p]["generacio"], digits=3))}</td>
+                % data = coll[p].get("generacio", 0.0)
+                <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
                 <td></td>
             % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -9,7 +9,7 @@
         <td class="detall_td">${_(u"Generació segons coeficient de repartiment (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:
-                <td>${_(u"%s") %(int(coll[p]["generated_coef"]))}</td>
+                <td>${_(u"%s") %(formatLang(coll[p]["generacio_neta"], digits=3))}</td>
             % else:
                 <td></td>
             % endif
@@ -20,7 +20,7 @@
         <td class="detall_td">${_(u"Energia autoconsumida (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:
-                <td>${_(u"%s") %(int(coll[p]["auto_consumed"]))}</td>
+                <td>${_(u"%s") %(formatLang(coll[p]["autoconsum"], digits=3))}</td>
             % else:
                 <td></td>
             % endif
@@ -39,7 +39,7 @@
         </td>
         % for p in coll.showing_periods:
             % if p in coll:
-                <td>${_(u"%s") %(int(round(coll[p]["surplus"])))}</td>
+                <td>${_(u"%s") %(formatLang(coll[p]["generacio"], digits=3))}</td>
             % else:
                 <td></td>
             % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -12,11 +12,13 @@
         % endif
         <td class="detall_td">${_(u"Generació segons coeficient de repartiment (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
-            % if p in coll:
-                <% data = coll[p].get(u"generacio_neta", 0.0) %>
-                <td class="periods_td">${_(u"%s") %(formatLang(data, digits=3))}</td>
-            % else:
+            <% data = coll.get(p, {}).get(u"generacio_neta", 0.0) if p in coll else None %>
+            % if data is None:
                 <td class="periods_td"></td>
+            % elif data > 0:
+                <td class="periods_td">${_(u"%s") % formatLang(data, digits=3)}</td>
+            % else:
+                <td class="periods_td">-</td>
             % endif
         % endfor
         <td></td>
@@ -24,11 +26,13 @@
     <tr>
         <td class="detall_td">${_(u"Energia autoconsumida (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
-            % if p in coll:
-                <% data = coll[p].get(u"autoconsum", 0.0) %>
-                <td class="periods_td">${_(u"%s") %(formatLang(data, digits=3))}</td>
-            % else:
+            <% data = coll.get(p, {}).get(u"autoconsum", 0.0) if p in coll else None %>
+            % if data is None:
                 <td class="periods_td"></td>
+            % elif data > 0:
+                <td class="periods_td">${_(u"%s") % formatLang(data, digits=3)}</td>
+            % else:
+                <td class="periods_td">-</td>
             % endif
         % endfor
         <td></td>
@@ -44,11 +48,13 @@
         % endif
         </td>
         % for p in coll.showing_periods:
-            % if p in coll:
-                <% data = coll[p].get(u"generacio", 0.0) %>
-                <td class="periods_td">${_(u"%s") %(formatLang(data, digits=3))}</td>
-            % else:
+            <% data = coll.get(p, {}).get(u"generacio", 0.0) if p in coll else None %>
+            % if data is None:
                 <td class="periods_td"></td>
+            % elif data > 0:
+                <td class="periods_td">${_(u"%s") % formatLang(data, digits=3)}</td>
+            % else:
+                <td class="periods_td">-</td>
             % endif
         % endfor
         <td class="periods_td">

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -1,0 +1,53 @@
+<%page args="coll" />
+<%import locale%>
+% if False:
+    ${}
+% endif
+% if coll.is_visible:
+    <tr>
+        <td class="td_first concepte_td" rowspan="3">${_(u"Autoconsum compartit (kWh)")}</td>
+        <td class="detall_td">${_(u"Generació segons coeficient de repartiment (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
+        % for p in coll.showing_periods:
+            % if p in coll:
+                <td>${_(u"%s") %(int(coll[p]["generated_coef"]))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td></td>
+    </tr>
+    <tr>
+        <td class="detall_td">${_(u"Energia autoconsumida (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
+        % for p in coll.showing_periods:
+            % if p in coll:
+                <td>${_(u"%s") %(int(coll[p]["auto_consumed"]))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td></td>
+    </tr>
+    % if coll.last_visible:
+        <tr class="tr_bold">
+    % else:
+        <tr class="tr_bold last_row">
+    % endif
+        <td class="detall_td">${_(u"Excedent")}
+        % if coll.is_active:
+            <sup class="sup_bold">(1)</sup>
+        % endif
+        </td>
+        % for p in coll.showing_periods:
+            % if p in coll:
+                <td>${_(u"%s") %(int(round(coll[p]["surplus"])))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td>
+        % if coll.adjust_reason != False:
+            <sup>(2)</sup>
+        % endif
+        </td>
+    </tr>
+% endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -5,7 +5,11 @@
 % endif
 % if coll.is_visible:
     <tr>
-        <td class="td_first concepte_td" rowspan="3">${_(u"Autoconsum compartit (kWh)")}</td>
+        % if coll.hide_total_surplus:
+            <td class="td_first concepte_td" rowspan="3">${_(u"Autoconsum (kWh)")}</td>
+        % else:
+            <td class="td_first concepte_td" rowspan="3">${_(u"Autoconsum compartit (kWh)")}</td>
+        % endif
         <td class="detall_td">${_(u"Generació segons coeficient de repartiment (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -10,9 +10,9 @@
         % for p in coll.showing_periods:
             % if p in coll:
                 <% data = coll[p].get(u"generacio_neta", 0.0) %>
-                <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
-                <td></td>
+                <td class="periods_td"></td>
             % endif
         % endfor
         <td></td>
@@ -22,9 +22,9 @@
         % for p in coll.showing_periods:
             % if p in coll:
                 <% data = coll[p].get(u"autoconsum", 0.0) %>
-                <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
-                <td></td>
+                <td class="periods_td"></td>
             % endif
         % endfor
         <td></td>
@@ -42,12 +42,12 @@
         % for p in coll.showing_periods:
             % if p in coll:
                 <% data = coll[p].get(u"generacio", 0.0) %>
-                <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
-                <td></td>
+                <td class="periods_td"></td>
             % endif
         % endfor
-        <td>
+        <td class="periods_td">
         </td>
     </tr>
 % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako
@@ -9,9 +9,8 @@
         <td class="detall_td">${_(u"Generació segons coeficient de repartiment (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:
-                % data = coll[p].get("generacio_neta", 0.0)
+                <% data = coll[p].get(u"generacio_neta", 0.0) %>
                 <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
-                ## <td>${_(u"%s") %(formatLang(coll[p]["generacio_neta"], digits=3))}</td>
             % else:
                 <td></td>
             % endif
@@ -22,7 +21,7 @@
         <td class="detall_td">${_(u"Energia autoconsumida (periode del %s fins al %s)") % (coll.initial_date, coll.final_date)}</td>
         % for p in coll.showing_periods:
             % if p in coll:
-                % data = coll[p].get("autoconsum", 0.0)
+                <% data = coll[p].get(u"autoconsum", 0.0) %>
                 <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
                 <td></td>
@@ -42,7 +41,7 @@
         </td>
         % for p in coll.showing_periods:
             % if p in coll:
-                % data = coll[p].get("generacio", 0.0)
+                <% data = coll[p].get(u"generacio", 0.0) %>
                 <td>${_(u"%s") %(formatLang(data, digits=3))}</td>
             % else:
                 <td></td>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
@@ -20,7 +20,6 @@
         % else:
             <td class="detall_td last_row">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % endif
-        <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
                 <td class="periods_td">${_(u"%s") %(int(meter[p]["final"]))}</td>

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
@@ -1,0 +1,58 @@
+<%page args="meter" />
+<%import locale%>
+<%row_span = 2 if meter.hide_total_surplus else 3%>
+% if meter.is_visible:
+    <tr>
+        <td class="td_first concepte_td" rowspan=${row_span}>${_(meter.title)}</td>
+        <td class="detall_td">${_(u"Lectura inicial (%s) (%s)") % (meter.initial_date, _(meter.initial_type))}</td>
+        % for p in meter.showing_periods:
+            % if p in meter:
+                <td class="periods_td">${_(u"%s") %(int(meter[p]["initial"]))}</td>
+            % else:
+                <td class="periods_td"></td>
+            % endif
+        % endfor
+        <td></td>
+    </tr>
+    <tr>
+        % if meter.last_visible and meter.hide_total_surplus:
+            <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
+        % else:
+            <td class="detall_td last_row">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
+        % endif
+        <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
+        % for p in meter.showing_periods:
+            % if p in meter:
+                <td class="periods_td">${_(u"%s") %(int(meter[p]["final"]))}</td>
+            % else:
+                <td class="periods_td"></td>
+            % endif
+        % endfor
+        <td></td>
+    </tr>
+    % if not meter.hide_total_surplus:
+        % if meter.last_visible:
+            <tr class="tr_bold">
+        % else:
+            <tr class="tr_bold last_row">
+        % endif
+            <td class="detall_td">${_(u"Total periode ")}
+            % if meter.is_active:
+                <sup class="sup_bold">(1)</sup>
+            % endif
+            </td>
+            % for p in meter.showing_periods:
+                % if p in meter:
+                    <td class="periods_td">${_(u"%s") %(int(round(meter[p]["total"])))}</td>
+                % else:
+                    <td class="periods_td"></td>
+                % endif
+            % endfor
+            <td class="periods_td">
+            % if meter.adjust_reason != False:
+                <sup>(2)</sup>
+            % endif
+            </td>
+        </tr>
+    % endif
+% endif


### PR DESCRIPTION
## Objectiu

Mostrar la informació dels autoconsums col·lectius a la factura en pdf arrel de l'ntroducció de la millora dels multicaus en avançament a ATR3.0

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/309/activity

## Comportament antic

no es mostrava la informació

## Comportament nou

Es mostra la informació

## Notes de desenvolupament

Fer rebase abans de fer traduccions i aplicar per evitar col·lisions amb:
https://github.com/Som-Energia/openerp_som_addons/pull/685
https://github.com/Som-Energia/openerp_som_addons/pull/678

FET 02/09/2024

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
           giscedata_facturacio_comer_som
- [ ] Script de migració
- [x] Modifica traduccions
