### PR TITLE
Fix som_informe more than 1 line when different years

### DIFF
--- a/som_informe/report/components/InvoiceF1NG/InvoiceF1NG.py
+++ b/som_informe/report/components/InvoiceF1NG/InvoiceF1NG.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-from ..component_utils import dateformat, get_description, get_invoice_line, get_unit_magnitude
+from ..component_utils import dateformat, get_description, get_invoice_lines, get_unit_magnitude
 
 
 class InvoiceF1NG:
@@ -78,11 +78,11 @@ class InvoiceF1NG:
                     dict_linia["lectura_final"] = linia.lectura_actual
                     dict_linia["consum_entre"] = linia.lectura_actual - linia.lectura_desde
                     dict_linia["ajust"] = linia.ajust
-                    i_line = get_invoice_line(invoice, linia.magnitud, linia.periode)
+                    i_lines = get_invoice_lines(invoice, linia.magnitud, linia.periode)
                     if dict_linia["magnitud_desc"] == "Excesos de potencia":
-                        dict_linia["total_facturat"] = i_line.price_unit if i_line else 0
+                        dict_linia["total_facturat"] = i_lines[0].price_unit if i_lines else 0
                     else:
-                        dict_linia["total_facturat"] = i_line.quantity if i_line else 0
+                        dict_linia["total_facturat"] = sum(i_line.quantity for i_line in i_lines)
                     dict_linia["unit"] = get_unit_magnitude(linia.magnitud)
                     result["linies"].append(dict_linia)
             elif f1.tipo_factura_f1 == "otros":

--- a/som_informe/report/components/InvoiceF1R/InvoiceF1R.py
+++ b/som_informe/report/components/InvoiceF1R/InvoiceF1R.py
@@ -1,4 +1,4 @@
-from ..component_utils import dateformat, get_description, get_invoice_line, get_unit_magnitude
+from ..component_utils import dateformat, get_description, get_invoice_lines, get_unit_magnitude
 
 
 class InvoiceF1R:
@@ -63,8 +63,10 @@ class InvoiceF1R:
                 dict_linia["lectura_final"] = linia.lectura_actual
                 dict_linia["consum_entre"] = linia.lectura_actual - linia.lectura_desde
                 dict_linia["ajust"] = linia.ajust
-                i_line = get_invoice_line(invoice, linia.magnitud, linia.periode)
-                dict_linia["total_facturat"] = i_line.quantity if i_line else ""
+                i_lines = get_invoice_lines(invoice, linia.magnitud, linia.periode)
+                dict_linia["total_facturat"] = ""
+                if i_lines:
+                    dict_linia["total_facturat"] = sum(i_line.quantity for i_line in i_lines)
                 dict_linia["unit"] = get_unit_magnitude(linia.magnitud)
 
                 result["linies"].append(dict_linia)

--- a/som_informe/report/components/component_utils.py
+++ b/som_informe/report/components/component_utils.py
@@ -42,19 +42,20 @@ def get_unit_magnitude(magnitud):
     return magnitud_a_unit.get(magnitud, "eV")
 
 
-def get_invoice_line(invoice, magnitud, periode):
+def get_invoice_lines(invoice, magnitud, periode):
     if magnitud == "PM" and periode == "93":
         periode = "9392"
 
     tipus = magnitud_a_tipus.get(magnitud, None)
     name = periode_a_name.get(periode, None)
     if not name or not tipus:
-        return None
+        return []
 
+    lines = []
     for l in invoice.linia_ids:  # noqa: E741
         if l.name == name and l.tipus == tipus:
-            return l
-    return None
+            lines.append(l)
+    return lines
 
 
 def to_date(str_date, hours=False):


### PR DESCRIPTION
## Objectiu
Arreglar part del informe on s'anava a buscar una linia de la factura, però en alguns casos en els quals una factura tenia un periode entre dos anys hi ha dos linies per el mateix periode (una per any), i en el informe per tant es veien dades incompletes (total facturat).

## Targeta on es demana o Incidència
https://hs.somenergia.coop/conversation/45710?folder_id=103


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
