### PR TITLE
Correcció de tipus d'autoconsum inactiu en carregar un F1

### DIFF
--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -45,7 +45,10 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
 
         tipus_autoconsum = re.findall("<TipoAutoconsumo>(.*)</TipoAutoconsumo>", xml_data)
         if tipus_autoconsum:
-            vals["tipus_autoconsum"] = tipus_autoconsum[0]
+            tipus = tipus_autoconsum[0]
+            if tipus in ["01", "2A", "2B", "2G"]:
+                tipus = "00"
+            vals["tipus_autoconsum"] = tipus
 
         tarifaATR = re.findall("<TarifaATRFact>(.*)</TarifaATRFact>", xml_data)
         if tarifaATR:


### PR DESCRIPTION
## Objectiu

Permetre carregar F1s amb tipus d'autoconsum inactius

## Targeta on es demana o Incidència

https://somenergia.openproject.com/work_packages/377/activity

## Comportament antic

No entrava el F1 per que petava per valors de camp selection

## Comportament nou

Es modifica el tipus d'autoconsum inactiu per 00

## Comprovacions

- [x] Reiniciar serveis
