### PR TITLE
✨ (gurb): Afegeix productora a la fitxa gurb

### DIFF
--- a/som_gurb/models/report_backend_som_gurb_documents.py
+++ b/som_gurb/models/report_backend_som_gurb_documents.py
@@ -40,8 +40,8 @@ class ReportBackendSomGurbAcordRepartiment(ReportBackend):
         data["compensacio"] = gurb.has_compensation
 
         data["productora"] = {
-            "nom": gurb.roof_owner_id.name,
-            "nif": gurb.roof_owner_id.vat.replace("ES", ""),
+            "nom": gurb.producer.name,
+            "nif": gurb.producer.vat.replace("ES", ""),
             "cil": gurb.cil,
             "cau": gurb.self_consumption_id.cau
         }

--- a/som_gurb/models/som_gurb.py
+++ b/som_gurb/models/som_gurb.py
@@ -251,6 +251,7 @@ class SomGurb(osv.osv):
         "name": fields.char("Nom GURB", size=60, required=True),
         "self_consumption_id": fields.many2one("giscedata.autoconsum", "CAU"),
         "code": fields.char("Codi GURB", size=60, readonly=True),
+        "producer": fields.many2one("res.partner", "Productora"),
         "cil": fields.char("Codi CIL", size=60),
         "roof_owner_id": fields.many2one("res.partner", "Propietari teulada"),
         "logo": fields.boolean("Logo"),

--- a/som_gurb/views/som_gurb_view.xml
+++ b/som_gurb/views/som_gurb_view.xml
@@ -69,6 +69,7 @@
                         <field name="max_power" />
                         <field name="min_power" />
                         <field name="cil" />
+                        <field name="producer" />
                     </group>
                     <group col="6" colspan="4" string="Autoconsum" icon="solar-panel">
                         <field name="self_consumption_id" select="1" />


### PR DESCRIPTION
## Objectiu

L'acord de repartiment sortia malament perquè posava la propietària de la teulada com a productora. Amb aquest nou camp solucionem aquest error

## Targeta on es demana o Incidència
Relacionada amb https://somenergia.openproject.com/wp/84

## Comportament antic
Sortia la propietària de la coberta

## Comportament nou
Surt l'empresa productora

## Comprovacions

Update de som_gurb
