### PR TITLE
Afegir nous camps al generador d'autoconsum

### DIFF
--- a/som_polissa/__init__.py
+++ b/som_polissa/__init__.py
@@ -5,3 +5,4 @@ import som_polissa_webforms_helpers
 import exceptions
 import giscedata_switching_helpers
 import giscedata_cups
+import giscedata_autoconsum

--- a/som_polissa/__terp__.py
+++ b/som_polissa/__terp__.py
@@ -40,6 +40,7 @@
         "giscedata_cups_view.xml",
         "wizard/wizard_import_ref_cadastral_from_csv_view.xml",
         "wizard/wizard_add_cut_off_to_polissa_from_csv_view.xml",
+        "giscedata_autoconsum_view.xml"
     ],
     "active": False,
     "installable": True,

--- a/som_polissa/giscedata_autoconsum.py
+++ b/som_polissa/giscedata_autoconsum.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+
+class GiscedataAutoconsumGenerador(osv.osv):
+    """Model de generador d'autoconsum."""
+
+    _name = 'giscedata.autoconsum.generador'
+    _inherit = 'giscedata.autoconsum.generador'
+
+    _columns = {
+        'emmagatzematge': fields.boolean('Te emmagatzematge'),
+        'potencia_sortida': fields.float(u'Potència de sortida (KW)'),
+        'energia_acumulable': fields.float(u'Energía acumulable'),
+    }
+
+    _defaults = {
+        'emmagatzematge': lambda *a: False,
+        'potencia_sortida': lambda *a: 0.0,
+        'energia_acumulable': lambda *a: 0.0,
+    }
+
+
+GiscedataAutoconsumGenerador()

--- a/som_polissa/giscedata_autoconsum_view.xml
+++ b/som_polissa/giscedata_autoconsum_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_autoconsum_generador_form_som">
+            <field name="name">giscedata.autoconsum.generador.som</field>
+            <field name="model">giscedata.autoconsum.generador</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="giscedata_cups.view_autoconsum_generador_form"/>
+            <field name="arch" type="xml">
+                <field name="emmagatzematge" position="replace">
+                    <field name="emmagatzematge" select="2" readonly="0"/>
+                </field>
+                <field name="emmagatzematge" position="after">
+                    <field name="energia_acumulable" select="2"/>
+                    <field name="potencia_sortida" select="2"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/som_polissa/migrations/5.0.24.9.0/post-0001_new_fields_on_generadors.py
+++ b/som_polissa/migrations/5.0.24.9.0/post-0001_new_fields_on_generadors.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+    if config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Creating pooler")
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Creating new fields on model giscedata.autoconsum.generador")
+    pool.get("giscedata.autoconsum.generador")._auto_init(
+        cursor, context={'module': 'som_polissa'}
+    )
+    logger.info("Fields created successfully")
+
+    logger.info("Updating XML giscedata_autoconsum_view.xml")
+    load_data(
+        cursor, 'som_polissa', 'giscedata_autoconsum_view.xml', idref=None,
+        mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Afegir nous camps al generador d'autoconsum

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/403/activity

## Comportament antic

N/D

## Comportament nou

Es creen nous camps al generador:
- Potencia sortida
- Energia acumulable

## Comprovacions

- [x] Reiniciar serveis
- [x] Actualitzar mòdul
    - som_polissa
- [x] Script de migració
    - som_polissa - post-0001_new_fields_on_generadors.py
