### PR TITLE
fix checking consulta resolution

### DIFF
--- a/som_account_invoice_pending/models/som_consulta_pobresa.py
+++ b/som_account_invoice_pending/models/som_consulta_pobresa.py
@@ -29,6 +29,8 @@ class SomConsultaPobresa(osv.osv):
         for consulta in consultes:
             if consulta.state == 'done' and consulta.resolucio == 'positiva':
                 self.moure_factures_pobresa(cr, uid, consulta)
+            elif consulta.state == 'done' and consulta.resolucio == 'negativa':
+                self.moure_factures_impagament(cr, uid, consulta)
 
         return response
 
@@ -75,6 +77,24 @@ class SomConsultaPobresa(osv.osv):
         for gff in gffs:
             if gff.pending_state.weight > 0:
                 gff_obj.set_pending(cr, uid, [gff.id], pobresa_state_id)
+
+    def moure_factures_impagament(self, cr, uid, cas):
+        gff_obj = self.pool.get('giscedata.facturacio.factura')
+        imd_obj = self.pool.get("ir.model.data")
+
+        warning_cut_off_state = imd_obj.get_object_reference(
+            cr, uid, "giscedata_facturacio_comer_bono_social", "avis_tall_pending_state",
+        )[1]
+
+        search_params = [
+            ('partner_id', '=', cas.partner_id.id),
+            ('polissa_id', '=', cas.polissa_id.id),
+        ]
+        gff_ids = gff_obj.search(cr, uid, search_params)
+        gffs = gff_obj.browse(cr, uid, gff_ids)
+        for gff in gffs:
+            if gff.pending_state.weight > 0:
+                gff_obj.set_pending(cr, uid, [gff.id], warning_cut_off_state)
 
     def consulta_pobresa_activa(self, cr, uid, ids, partner_id, polissa_id, context=None):
         cfg_obj = self.pool.get('res.config')

--- a/som_account_invoice_pending/models/som_consulta_pobresa.py
+++ b/som_account_invoice_pending/models/som_consulta_pobresa.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 RESOLUTION_STATES = [
     ('positiva', 'Positiva'),
-    ('negaviva', 'Negativa'),
+    ('negativa', 'Negativa'),
 ]
 
 

--- a/som_account_invoice_pending/models/update_pending_states.py
+++ b/som_account_invoice_pending/models/update_pending_states.py
@@ -1001,7 +1001,7 @@ class UpdatePendingStates(osv.osv_memory):
                     wiz_obj.crear_consulta_pobresa(cursor, uid, wiz_id, context=context)
 
                 new_state = warning_cut_off_state
-                if scp_activa and scp_activa.resolucio:
+                if scp_activa and scp_activa.resolucio == 'positiva':
                     new_state = pobresa_certificada
 
                 fact_obj.set_pending(cursor, uid, [factura_id], new_state)


### PR DESCRIPTION
## Objectiu
Evitar marcar falsament factures com a pobresa quan no ho són

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/122000?folder_id=87

## Comportament antic
Es marcava sempre que hi havia una consulta recent com a pobresa

## Comportament nou
Només es marca com a pobresa en cas que el resultat de la consulta sigui positiu

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
