### PR TITLE
Adaptar `crear_lectura_data` de la classe `GiscedataPolissaCalculada` als canvis de wizard crear lectura desde cch

### DIFF
--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -153,7 +153,7 @@ class GiscedataPolissaCalculada(osv.osv):
         try:
             wiz_measures_curve_o.load_measures(cursor, uid, [wiz_id], context=ctx)
         except Exception as e:
-            if isinstance(e, osv.orm.except_orm):
+            if isinstance(e, osv.except_osv):
                 return False, "sense_corbes"
             else:
                 return False, "error"


### PR DESCRIPTION
## Necessita
https://github.com/gisce/erp/pull/21582
## Objectiu

La funció `crear_lectura_data` de la classe `GiscedataPolissaCalculada` ha de seguir funcionant com ho feia fins ara

## Targeta on es demana o Incidència

## Comportament antic
La funció `crear_lectura_data` de la classe `GiscedataPolissaCalculada` esperava que l'assistent `wizard.measures.from.curve` llances una excepció `osv.orm.except_orm` quan no es trobaven corbes per les dates proporcionades.

## Comportament nou
Ara l'assistent `wizard.measures.from.curve` llança una excepció del tipus `osv.except_osv` i s'ha canviat la funció `crear_lectura_data` perquè la tingui en compte.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
