### PR TITLE
Mode 0 de Flux Solar custom per a Som Energia

### DIFF
--- a/som_facturacio_flux_solar/__init__.py
+++ b/som_facturacio_flux_solar/__init__.py
@@ -3,4 +3,5 @@ import giscedata_bateria_virtual_origen
 import giscedata_bateria_virtual
 import giscedata_bateria_virtual_polissa
 import giscedata_polissa
+import giscedata_facturacio
 import wizard

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -119,4 +119,5 @@ class GiscedataFacturacioFacturador(osv.osv):
 
         return linies_utilitzades_ids, max_descompte
 
+
 GiscedataFacturacioFacturador()

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -27,8 +27,10 @@ class GiscedataFacturacioFacturador(osv.osv):
         # Si tenen bo social, les linies de bo social s'han de tenir en compte tot i ser de tipus "altres"
         # No es lo millor, pero per dependencies és infinitament més simple fer-ho aqui.
         tenen_bo_social = self.pool.get("ir.module.module").search(
-            cursor, uid, [("state", "=", "installed"), ('name', '=', 'giscedata_repercusio_bo_social')],
-            context=context
+            cursor, uid, [
+                ("state", "=", "installed"),
+                ('name', '=', 'giscedata_repercusio_bo_social')
+            ], context=context
         )
 
         pbosocial_id = None
@@ -72,7 +74,8 @@ class GiscedataFacturacioFacturador(osv.osv):
                 taxes_dict[tax.name] = tax.amount
             has_iese = [v for x, v in taxes_dict.items() if 'especial' in x.lower()]
             has_igic = [v for x, v in taxes_dict.items() if 'igic' in x.lower()]
-            other_taxes = [v for x, v in taxes_dict.items() if 'especial' not in x.lower() and 'igic' not in x.lower()]
+            other_taxes = [v for x, v in taxes_dict.items() if 'especial' not in x.lower()
+                           and 'igic' not in x.lower()]
 
             if has_iese:
                 # We asume there's only one IESE and only one VAT
@@ -95,7 +98,9 @@ class GiscedataFacturacioFacturador(osv.osv):
                 factor = 1.0
 
             fact = fact_obj.browse(cursor, uid, factura_id, context=context)
-            linies_energia = self.get_energy_lines_to_count_consume(cursor, uid, fact, context=context)
+            linies_energia = self.get_energy_lines_to_count_consume(
+                cursor, uid, fact, context=context
+            )
 
             total_energia = 0.0
             for linia in linies_energia:

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -77,7 +77,7 @@ class GiscedataFacturacioFacturador(osv.osv):
             if other_taxes:
                 # We asume there's only one IESE and only one VAT
                 iva_base += line.price_subtotal
-                iva_quota = has_iese[0]
+                iva_quota = other_taxes[0]
 
         if iese_base:
             iese_amount = iese_base * iese_quota

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from osv import osv
+
+class GiscedataFacturacioFacturador(osv.osv):
+    _name = 'giscedata.facturacio.facturador'
+    _inherit = 'giscedata.facturacio.facturador'
+
+    def get_max_descompte_total_factura_sense_impostos(self, cursor, uid, factura_id, line_vals, context=None):
+        if context is None:
+            context = {}
+
+        imd_obj = self.pool.get('ir,model.data')
+        linia_obj = self.pool.get('giscedata.facturacio.factura.linia')
+
+        # Es vol descomptar el total dels conceptes del sector electric
+        max_descompte = 0
+
+        # Producte de descompte de la bateria virtual
+        product_id = imd_obj.get_object_reference(
+            cursor, uid, "giscedata_facturacio_bateria_virtual",
+            "bateria_virtual_product"
+        )[1]
+
+        # Si tenen bo social, les linies de bo social s'han de tenir en compte tot i ser de tipus "altres"
+        # No es lo millor, pero per dependencies és infinitament més simple fer-ho aqui.
+        tenen_bo_social = self.pool.get("ir.module.module").search(
+            cursor, uid, [("state", "=", "installed"), ('name', '=', 'giscedata_repercusio_bo_social')],
+            context=context
+        )
+
+        pbosocial_id = None
+        if tenen_bo_social:
+            pbosocial_id = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_repercusio_bo_social', 'bosocial_BS01'
+            )[1]
+
+        linies_utilitzades_ids = []
+        for dict_vals in line_vals:
+            if dict_vals['tipus'] not in ('altres', 'subtotal_xml', 'subtotal_xml_ren', 'subtotal_xml_oth'):
+                max_descompte += dict_vals['price_subtotal']
+                if 'id' in dict_vals:
+                    linies_utilitzades_ids.append(dict_vals['id'])
+            elif tenen_bo_social and dict_vals['product_id'] and pbosocial_id == dict_vals['product_id'][0]:
+                max_descompte += dict_vals['price_subtotal']
+                linies_utilitzades_ids.append(dict_vals['id'])
+            elif product_id == dict_vals['product_id'][0]:
+                max_descompte += dict_vals['price_subtotal']
+                if 'id' in dict_vals:
+                    linies_utilitzades_ids.append(dict_vals['id'])
+            else:
+                # Si tenen IESE, son del sector electric
+                impostos_linia = dict_vals['invoice_line_tax_id']
+                for impostos_linia_info in self.pool.get("account.tax").read(cursor, uid, impostos_linia, ['name'],
+                                                                             context=context):
+                    if 'especial' in impostos_linia_info['name'].lower():
+                        max_descompte += dict_vals['price_subtotal']
+                        if 'id' in dict_vals:
+                            linies_utilitzades_ids.append(dict_vals['id'])
+
+        for line in linia_obj.browse(cursor, uid, linies_utilitzades_ids, context={'prefetch': False}):
+            if not line.name:  # Si el ID no existeix, al consultar el nom retornara False
+                continue
+
+            taxes_dict = {}
+            for tax in line.invoice_line_id.invoice_line_tax_id:
+                taxes_dict[tax.tax_id.name] = tax.tax_id.amount
+            has_iese = [v for x, v  in taxes_dict.items() if 'especial' in x.lower()]
+            other_taxes = [v for x, v  in taxes_dict.items() if 'especial' not in x.lower()]
+            if has_iese:
+                # We asume there's only one IESE and only one VAT
+                iese_amount = line.price_subtotal * has_iese[0]
+                max_descompte += iese_amount
+
+                base_iva = line.price_subtotal + iese_amount
+                iva_amount = base_iva * other_taxes[0]
+                max_descompte += iva_amount
+
+        return max_descompte, linies_utilitzades_ids
+
+GiscedataFacturacioFacturador()

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -7,7 +7,8 @@ class GiscedataFacturacioFacturador(osv.osv):
     _name = 'giscedata.facturacio.facturador'
     _inherit = 'giscedata.facturacio.facturador'
 
-    def get_max_descompte_total_factura_sense_impostos(self, cursor, uid, factura_id, line_vals, context=None):
+    def get_max_descompte_total_factura_sense_impostos(
+            self, cursor, uid, factura_id, line_vals, context=None):
         if context is None:
             context = {}
 
@@ -24,8 +25,10 @@ class GiscedataFacturacioFacturador(osv.osv):
             "bateria_virtual_product"
         )[1]
 
-        # Si tenen bo social, les linies de bo social s'han de tenir en compte tot i ser de tipus "altres"
-        # No es lo millor, pero per dependencies és infinitament més simple fer-ho aqui.
+        # Si tenen bo social, les linies de bo social s'han de tenir en
+        # compte tot i ser de tipus "altres"
+        # No es lo millor, pero per dependencies és infinitament més
+        # simple fer-ho aqui.
         tenen_bo_social = self.pool.get("ir.module.module").search(
             cursor, uid, [
                 ("state", "=", "installed"),
@@ -41,11 +44,14 @@ class GiscedataFacturacioFacturador(osv.osv):
 
         linies_utilitzades_ids = []
         for dict_vals in line_vals:
-            if dict_vals['tipus'] not in ('altres', 'subtotal_xml', 'subtotal_xml_ren', 'subtotal_xml_oth'):
+            if dict_vals['tipus'] not in (
+                    'altres', 'subtotal_xml', 'subtotal_xml_ren', 'subtotal_xml_oth'
+            ):
                 max_descompte += dict_vals['price_subtotal']
                 if 'id' in dict_vals:
                     linies_utilitzades_ids.append(dict_vals['id'])
-            elif tenen_bo_social and dict_vals['product_id'] and pbosocial_id == dict_vals['product_id'][0]:
+            elif (tenen_bo_social and dict_vals['product_id']
+                  and pbosocial_id == dict_vals['product_id'][0]):
                 max_descompte += dict_vals['price_subtotal']
                 linies_utilitzades_ids.append(dict_vals['id'])
             elif product_id == dict_vals['product_id'][0]:
@@ -55,8 +61,9 @@ class GiscedataFacturacioFacturador(osv.osv):
             else:
                 # Si tenen IESE, son del sector electric
                 impostos_linia = dict_vals['invoice_line_tax_id']
-                for impostos_linia_info in self.pool.get("account.tax").read(cursor, uid, impostos_linia, ['name'],
-                                                                             context=context):
+                for impostos_linia_info in self.pool.get("account.tax").read(
+                        cursor, uid, impostos_linia, ['name'], context=context
+                ):
                     if 'especial' in impostos_linia_info['name'].lower():
                         max_descompte += dict_vals['price_subtotal']
                         if 'id' in dict_vals:
@@ -65,7 +72,9 @@ class GiscedataFacturacioFacturador(osv.osv):
         iese_base = iese_quota = iese_amount = 0.0
         iva_base = iva_quota = iva_amount = 0.0
         igic_amount = 0.0
-        for line in linia_obj.browse(cursor, uid, linies_utilitzades_ids, context={'prefetch': False}):
+        for line in linia_obj.browse(
+                cursor, uid, linies_utilitzades_ids, context={'prefetch': False}
+        ):
             if not line.name:  # Si el ID no existeix, al consultar el nom retornara False
                 continue
 

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -9,7 +9,7 @@ class GiscedataFacturacioFacturador(osv.osv):
         if context is None:
             context = {}
 
-        imd_obj = self.pool.get('ir,model.data')
+        imd_obj = self.pool.get('ir.model.data')
         linia_obj = self.pool.get('giscedata.facturacio.factura.linia')
 
         # Es vol descomptar el total dels conceptes del sector electric
@@ -63,7 +63,7 @@ class GiscedataFacturacioFacturador(osv.osv):
 
             taxes_dict = {}
             for tax in line.invoice_line_id.invoice_line_tax_id:
-                taxes_dict[tax.tax_id.name] = tax.tax_id.amount
+                taxes_dict[tax.name] = tax.amount
             has_iese = [v for x, v  in taxes_dict.items() if 'especial' in x.lower()]
             other_taxes = [v for x, v  in taxes_dict.items() if 'especial' not in x.lower()]
             if has_iese:
@@ -75,6 +75,6 @@ class GiscedataFacturacioFacturador(osv.osv):
                 iva_amount = base_iva * other_taxes[0]
                 max_descompte += iva_amount
 
-        return max_descompte, linies_utilitzades_ids
+        return linies_utilitzades_ids, max_descompte
 
 GiscedataFacturacioFacturador()

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -7,7 +7,7 @@ class GiscedataFacturacioFacturador(osv.osv):
     _name = 'giscedata.facturacio.facturador'
     _inherit = 'giscedata.facturacio.facturador'
 
-    def get_max_descompte_total_factura_sense_impostos(
+    def get_max_descompte_total_factura_sense_impostos(  # noqa C901
             self, cursor, uid, factura_id, line_vals, context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
## Objectiu

Comptar en el mode 0 de Flux Solar només les línies dessitjades de la factura.

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/flux-solar/work_packages/438/activity

## Comportament antic

Es compensa la totalitat de la factura (com a màxim)

## Comportament nou

Es tenen en compte només les línies de:

- energia (totes les possibles)
- potència (totes les potències possibles)
- lloguer de comptador
- bo social
- Impostos (novetat)

## Comprovacions

- [x] Reiniciar serveis
- [x] Actualitzar mòdul
