### PR TITLE
🐛 No moure l'estat pendent de les factures quan la consulta pobresa es negativa

### DIFF
--- a/som_account_invoice_pending/models/som_consulta_pobresa.py
+++ b/som_account_invoice_pending/models/som_consulta_pobresa.py
@@ -84,8 +84,8 @@ class SomConsultaPobresa(osv.osv):
         gff_ids = gff_obj.search(cr, uid, search_params)
         gffs = gff_obj.browse(cr, uid, gff_ids)
         for gff in gffs:
-            weight_polissa_state = gff.pending_state.weight
-            if weight_polissa_state < weight_consulta or weight_polissa_state > weight_tall:
+            weight_invoice_state = gff.pending_state.weight
+            if weight_invoice_state > weight_consulta and weight_invoice_state < weight_tall:
                 gff_obj.set_pending(cr, uid, [gff.id], pobresa_state_id)
 
     def consulta_pobresa_activa(self, cr, uid, ids, partner_id, polissa_id, context=None):

--- a/som_account_invoice_pending/models/som_consulta_pobresa.py
+++ b/som_account_invoice_pending/models/som_consulta_pobresa.py
@@ -27,10 +27,10 @@ class SomConsultaPobresa(osv.osv):
 
         consultes = self.browse(cr, uid, ids)
         for consulta in consultes:
-            if consulta.state == 'done' and consulta.resolucio == 'positiva':
+            if (consulta.state == 'done'
+                and consulta.resolucio == 'positiva'
+                    and consulta.polissa_id.state == 'activa'):
                 self.moure_factures_pobresa(cr, uid, consulta)
-            elif consulta.state == 'done' and consulta.resolucio == 'negativa':
-                self.moure_factures_impagament(cr, uid, consulta)
 
         return response
 
@@ -65,27 +65,18 @@ class SomConsultaPobresa(osv.osv):
     def moure_factures_pobresa(self, cr, uid, cas):
         gff_obj = self.pool.get('giscedata.facturacio.factura')
         imd_obj = self.pool.get("ir.model.data")
+        aips_obj = self.pool.get('account.invoice.pending.state')
         pobresa_state_id = imd_obj.get_object_reference(
             cr, uid, "som_account_invoice_pending", "probresa_energetica_certificada_pending_state"
         )[1]
-        search_params = [
-            ('partner_id', '=', cas.partner_id.id),
-            ('polissa_id', '=', cas.polissa_id.id),
-        ]
-        gff_ids = gff_obj.search(cr, uid, search_params)
-        gffs = gff_obj.browse(cr, uid, gff_ids)
-        for gff in gffs:
-            if gff.pending_state.weight > 0:
-                gff_obj.set_pending(cr, uid, [gff.id], pobresa_state_id)
-
-    def moure_factures_impagament(self, cr, uid, cas):
-        gff_obj = self.pool.get('giscedata.facturacio.factura')
-        imd_obj = self.pool.get("ir.model.data")
-
-        warning_cut_off_state = imd_obj.get_object_reference(
-            cr, uid, "giscedata_facturacio_comer_bono_social", "avis_tall_pending_state",
+        consulta_state_id = imd_obj.get_object_reference(
+            cr, uid, 'som_account_invoice_pending', 'pendent_consulta_probresa_pending_state',
         )[1]
-
+        tall_state_id = imd_obj.get_object_reference(
+            cr, uid, 'giscedata_facturacio_comer_bono_social', 'tall_pending_state',
+        )[1]
+        weight_consulta = aips_obj.read(cr, uid, consulta_state_id, ['weight'])['weight']
+        weight_tall = aips_obj.read(cr, uid, tall_state_id, ['weight'])['weight']
         search_params = [
             ('partner_id', '=', cas.partner_id.id),
             ('polissa_id', '=', cas.polissa_id.id),
@@ -93,8 +84,9 @@ class SomConsultaPobresa(osv.osv):
         gff_ids = gff_obj.search(cr, uid, search_params)
         gffs = gff_obj.browse(cr, uid, gff_ids)
         for gff in gffs:
-            if gff.pending_state.weight > 0:
-                gff_obj.set_pending(cr, uid, [gff.id], warning_cut_off_state)
+            weight_polissa_state = gff.pending_state.weight
+            if weight_polissa_state < weight_consulta or weight_polissa_state > weight_tall:
+                gff_obj.set_pending(cr, uid, [gff.id], pobresa_state_id)
 
     def consulta_pobresa_activa(self, cr, uid, ids, partner_id, polissa_id, context=None):
         cfg_obj = self.pool.get('res.config')

--- a/som_account_invoice_pending/tests/test_som_consulta_pobresa.py
+++ b/som_account_invoice_pending/tests/test_som_consulta_pobresa.py
@@ -90,6 +90,7 @@ class TestConsultaPobresa(testing.OOTestCase):
         gff_obj = self.openerp.pool.get('giscedata.facturacio.factura')
         imd_obj = self.openerp.pool.get('ir.model.data')
         cups_obj = self.openerp.pool.get('giscedata.cups.ps')
+        pending_obj = self.openerp.pool.get("update.pending.states")
         pol_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', 'polissa_0002'
         )[1]
@@ -133,6 +134,7 @@ class TestConsultaPobresa(testing.OOTestCase):
             'pending_state': correcte_state_id,
             'partner_id': partner_id,
         })
+        gff_obj.set_pending(cursor, uid, [fact3_id], correcte_state_id)
         fact = gff_obj.browse(cursor, uid, fact_id)
         fact.write({
             'state': 'open',
@@ -145,6 +147,7 @@ class TestConsultaPobresa(testing.OOTestCase):
                        'resolucio': 'positiva'})
         cons_obj.case_close_pobresa(cursor, uid, [consulta_id], ({}))
 
+        pending_obj.update_pending_ask_poverty(cursor, uid)
         fact = gff_obj.browse(cursor, uid, fact_id)
         fact3 = gff_obj.browse(cursor, uid, fact3_id)
         self.assertEqual(fact.pending_state.id, pobresa_state_id)
@@ -158,6 +161,7 @@ class TestConsultaPobresa(testing.OOTestCase):
         gff_obj = self.openerp.pool.get('giscedata.facturacio.factura')
         imd_obj = self.openerp.pool.get('ir.model.data')
         cups_obj = self.openerp.pool.get('giscedata.cups.ps')
+        pending_obj = self.openerp.pool.get("update.pending.states")
         pol_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', 'polissa_0002'
         )[1]
@@ -211,6 +215,7 @@ class TestConsultaPobresa(testing.OOTestCase):
         cons_obj.write(cursor, uid, consulta_id, {
                        'resolucio': 'negativa'})
         cons_obj.case_close_pobresa(cursor, uid, [consulta_id], ({}))
+        pending_obj.update_pending_ask_poverty(cursor, uid)
 
         fact = gff_obj.browse(cursor, uid, fact_id)
         fact3 = gff_obj.browse(cursor, uid, fact3_id)


### PR DESCRIPTION
## Objectiu
Arreglar el funcionament dels estats pendents, en el moment de tancar les consultes de pobresa energètica.

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/6290097?folder_id=283

## Comportament antic
Es movien factures que no s'havien de moure.

## Comportament nou

- No moure l'estat pendent de les factures quan la consulta pobresa es negativa.
- Quan la consulta és positiva, moure les factures que estan en un estat posterior a "Consulta pobresa" i anterior als estats calaixos, a l'estat "Pobresa energètica"


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
