### PR TITLE
Corregir arrodoniment en el total d'energia

### DIFF
--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -115,7 +115,7 @@ class GiscedataFacturacioFacturador(osv.osv):
                 total_energia += linia.quantity
 
             # Mirem si s'ha de fer el mínim segons article 99
-            calcul = total_energia / 1000 * factor
+            calcul = round(total_energia / 1000 * factor, 2)
             import_iese = iese_base * iese_quota
             import_iese = round(import_iese, 2)
             iese_amount = max(calcul, import_iese)

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -116,14 +116,14 @@ class GiscedataFacturacioFacturador(osv.osv):
 
             # Mirem si s'ha de fer el mínim segons article 99
             calcul = round(total_energia / 1000 * factor, 2)
-            import_iese = iese_base * iese_quota
+            import_iese = round(iese_base, 2) * iese_quota
             import_iese = round(import_iese, 2)
             iese_amount = max(calcul, import_iese)
         if iva_base:
-            iva_amount = (iva_base + iese_amount) * iva_quota
+            iva_amount = (round(iva_base, 2) + iese_amount) * iva_quota
             iva_amount = round(iva_amount, 2)
 
-        max_descompte += iese_amount + iva_amount + igic_amount
+        max_descompte += round(iese_amount + iva_amount + igic_amount, 2)
 
         return linies_utilitzades_ids, max_descompte
 


### PR DESCRIPTION
## Objectiu

Corregir el comportament de l'ERP a l'hora d'arrodonir el "total_energia"

## Targeta on es demana o Incidència
 SAC: `240685`

## Comportament antic
 N/A

## Comportament nou
S'arrodoneix el total d'energia al segon decimal.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
