### PR TITLE
Emmagatzemar les factures en pdf  i recuperar les ja guardades

### DIFF
--- a/giscedata_facturacio_comer_som/__init__.py
+++ b/giscedata_facturacio_comer_som/__init__.py
@@ -1,2 +1,3 @@
 import report
 import giscedata_facturacio_report
+import giscedata_facturacio_factura

--- a/giscedata_facturacio_comer_som/__terp__.py
+++ b/giscedata_facturacio_comer_som/__terp__.py
@@ -19,7 +19,11 @@
     ],
     "init_xml": [],
     "demo_xml": ["giscedata_facturacio_comer_som_demo.xml"],
-    "update_xml": ["giscedata_facturacio_comer_data.xml", "giscedata_facturacio_comer_report.xml"],
+    "update_xml": [
+        "giscedata_facturacio_comer_data.xml",
+        "giscedata_facturacio_comer_report.xml",
+        "giscedata_facturacio_factura.xml"
+    ],
     "active": False,
     "installable": True,
 }

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_comer_data.xml
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_comer_data.xml
@@ -84,10 +84,15 @@ div.back{
             <field name="description">Valors de la taula de Garantia d'Origen (gdo)</field>
             <field name="value">{'wind_power':151153,'photovoltaic':160497,'hydraulics':56298,'biomassa':6378,'biogas':0,'total': 374326,'year': '2023'}</field>
         </record>
-        <record model="res.config" id="fatura_pdf_cache_flags">
+        <record model="res.config" id="factura_pdf_cache_flags">
             <field name="name">factura_pdf_cache_flags</field>
             <field name="description">Flags per activar/desactivar el guardat de factures via adjunts del correus o adjunts de les factures\n - Enabled --> Activat, sense aquest flag no funciona el sistema de cache, la factura es genera i s'entrega on the fly\n - No_mongo --> No hi ha base de dades documental present, no tenim fitxers (per desenvolupar/testejar)\n - Dont_store --> No guarda la factura en pdf com adjunt directe de la factura </field>
             <field name="value">['Disabled']</field>
+        </record>
+        <record model="res.config" id="factura_pdf_unsent_store_days">
+            <field name="name">factura_pdf_unsent_store_days</field>
+            <field name="description">Dies que poden passar abans de que es forci guardar el PDF d'una factura que no s'ha enviat i guardat</field>
+            <field name="value">60</field>
         </record>
     </data>
 </openerp>

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_comer_data.xml
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_comer_data.xml
@@ -84,5 +84,10 @@ div.back{
             <field name="description">Valors de la taula de Garantia d'Origen (gdo)</field>
             <field name="value">{'wind_power':151153,'photovoltaic':160497,'hydraulics':56298,'biomassa':6378,'biogas':0,'total': 374326,'year': '2023'}</field>
         </record>
+        <record model="res.config" id="fatura_pdf_cache_flags">
+            <field name="name">factura_pdf_cache_flags</field>
+            <field name="description">Flags per activar/desactivar el guardat de factures via adjunts del correus o adjunts de les factures\n - Enabled --> Activat, sense aquest flag no funciona el sistema de cache, la factura es genera i s'entrega on the fly\n - No_mongo --> No hi ha base de dades documental present, no tenim fitxers (per desenvolupar/testejar)\n - Dont_store --> No guarda la factura en pdf com adjunt directe de la factura </field>
+            <field name="value">['Disabled']</field>
+        </record>
     </data>
 </openerp>

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
@@ -19,7 +19,7 @@ class GiscedataFacturacioFactura(osv.osv):
         if not isinstance(ids, (tuple, list)):
             ids = [ids]
 
-        if 'pe_callback_origin_ids' in context:
+        if 'folder' in vals and vals['folder'] == 'sent' and 'pe_callback_origin_ids' in context:
             for fact_id in ids:
                 fact_data = self.read(
                     cursor,

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
@@ -8,37 +8,47 @@ class GiscedataFacturacioFactura(osv.osv):
     _inherit = 'giscedata.facturacio.factura'
 
     # Poweremails hooks
-    def poweremail_create_callback(self, cursor, uid, ids, vals, context=None):
-        if hasattr(super(GiscedataFacturacioFactura, self), 'poweremail_create_callback'):
-            super(GiscedataFacturacioFactura, self).poweremail_create_callback(
-                cursor, uid, ids, vals, context=context
-            )
-
-        if vals['id']:
-            self.write(cursor, uid, ids, {'enviat_mail_id': vals['id']})
-        return True
-
-    def poweremail_unlink_callback(self, cursor, uid, ids, context=None):
-        if hasattr(super(GiscedataFacturacioFactura, self), 'poweremail_unlink_callback'):
-            super(GiscedataFacturacioFactura, self).poweremail_unlink_callback(
-                cursor, uid, ids, context=context
-            )
-        self.write(cursor, uid, ids, {'enviat_mail_id': None})
-        return True
-
     def poweremail_write_callback(self, cursor, uid, ids, vals, context=None):
+        res = True
         if hasattr(super(GiscedataFacturacioFactura, self), 'poweremail_write_callback'):
-            super(GiscedataFacturacioFactura, self).poweremail_write_callback(
+            res = super(GiscedataFacturacioFactura, self).poweremail_write_callback(
                 cursor, uid, ids, vals, context=context
             )
-        if vals['id']:
-            self.write(cursor, uid, ids, {'enviat_mail_id': vals['id']})
-        return True
+        mail_obj = self.pool.get('poweremail.mailbox')
+
+        if not isinstance(ids, (tuple, list)):
+            ids = [ids]
+
+        if 'pe_callback_origin_ids' in context:
+            for fact_id in ids:
+                fact_data = self.read(
+                    cursor,
+                    uid,
+                    fact_id,
+                    ['enviat_mail_id', 'number']
+                )
+                fact_number = fact_data['number']
+                if not fact_number:  # Not open invoice
+                    continue
+                fact_enviat_mail_id = fact_data['enviat_mail_id']
+                if fact_enviat_mail_id:  # There is a previous one
+                    continue
+
+                new_mail_id = context['pe_callback_origin_ids'].get(fact_id, None)
+                if not new_mail_id:  # no new mail
+                    continue
+
+                new_mail = mail_obj.browse(cursor, uid, new_mail_id)
+                if (new_mail.pem_attachments_ids
+                        and new_mail.pem_attachments_ids[0].datas_fname == fact_number + '.pdf'):
+                    self.write(cursor, uid, fact_id, {'enviat_mail_id': new_mail_id})
+
+        return res
 
     _columns = {
         'enviat_mail_id': fields.many2one(
             "poweremail.mailbox",
-            "E-Mail",
+            "E-Mail factura adjunta",
             readonly=True,
             ondelete="set null"
         ),

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+
+class GiscedataFacturacioFactura(osv.osv):
+    """Classe per la factura de comercialitzadora."""
+    _name = 'giscedata.facturacio.factura'
+    _inherit = 'giscedata.facturacio.factura'
+
+    # Poweremails hooks
+    def poweremail_create_callback(self, cursor, uid, ids, vals, context=None):
+        if hasattr(super(GiscedataFacturacioFactura, self), 'poweremail_create_callback'):
+            super(GiscedataFacturacioFactura, self).poweremail_create_callback(
+                cursor, uid, ids, vals, context=context
+            )
+
+        if vals['id']:
+            self.write(cursor, uid, ids, {'enviat_mail_id': vals['id']})
+        return True
+
+    def poweremail_unlink_callback(self, cursor, uid, ids, context=None):
+        if hasattr(super(GiscedataFacturacioFactura, self), 'poweremail_unlink_callback'):
+            super(GiscedataFacturacioFactura, self).poweremail_unlink_callback(
+                cursor, uid, ids, context=context
+            )
+        self.write(cursor, uid, ids, {'enviat_mail_id': None})
+        return True
+
+    def poweremail_write_callback(self, cursor, uid, ids, vals, context=None):
+        if hasattr(super(GiscedataFacturacioFactura, self), 'poweremail_write_callback'):
+            super(GiscedataFacturacioFactura, self).poweremail_write_callback(
+                cursor, uid, ids, vals, context=context
+            )
+        if vals['id']:
+            self.write(cursor, uid, ids, {'enviat_mail_id': vals['id']})
+        return True
+
+    _columns = {
+        'enviat_mail_id': fields.many2one(
+            "poweremail.mailbox",
+            "E-Mail",
+            readonly=True,
+            ondelete="set null"
+        ),
+    }
+
+
+GiscedataFacturacioFactura()

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import netsvc
+from datetime import datetime, timedelta
 from osv import osv, fields
+from addons import get_module_resource
 
 
 class GiscedataFacturacioFactura(osv.osv):
@@ -44,6 +47,37 @@ class GiscedataFacturacioFactura(osv.osv):
                     self.write(cursor, uid, fact_id, {'enviat_mail_id': new_mail_id})
 
         return res
+
+    def store_unsent_pdf_invoices(self, cursor, uid, context=None):
+        conf_obj = self.pool.get("res.config")
+        unsent_store_days = conf_obj.get(cursor, uid, "factura_pdf_unsent_store_days", 60)
+        date_search = datetime.today() - timedelta(days=unsent_store_days)
+
+        query_file = get_module_resource(
+            'giscedata_facturacio_comer_som', 'sql', "query_fact_to_pdf_store.sql")
+        query = open(query_file).read()
+
+        cursor.execute(query, (date_search.strftime('%Y-%m-%d'), ))
+        unstored_fact_ids = [x[0] for x in cursor.fetchall()]
+
+        error_ids = []
+        for fact_id in unstored_fact_ids:
+            try:
+                report = netsvc.service_exist("report.giscedata.facturacio.factura")
+                values = {
+                    "model": "giscedata.facturacio.factura",
+                    "id": [fact_id],
+                    "report_type": "pdf",
+                }
+                report.create(
+                    cursor, uid, [fact_id], values,
+                    {'save_pdf_in_invoice_attachments': True}
+                )[0]
+            except Exception:
+                error_ids.append(fact_id)
+
+        total_successful = len(unstored_fact_ids) - len(error_ids)
+        return total_successful, error_ids
 
     _columns = {
         'enviat_mail_id': fields.many2one(

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_factura.xml
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_factura.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_factura_form_sent_email">
+            <field name="name">giscedata.facturacio.factura.view.form.sent.email</field>
+            <field name="model">giscedata.facturacio.factura</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="giscedata_facturacio_comer.view_factura_form_energia_comer_email"/>
+            <field name="arch" type="xml">
+                <field name="enviat_data" position="after">
+                    <field name="enviat_mail_id" select="2"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -26,7 +26,7 @@ class InvoicePdfStorer():
         if 'Enabled' not in self.flags:
             return False
 
-        if self.context.get("regenerate_pdf", False):
+        if self.context.get("do_not_use_stored_pdf", False):
             return False
 
         return True
@@ -49,11 +49,12 @@ class InvoicePdfStorer():
 
     def append_and_store(self, fact_id, result):
         self.result.append(result)
-        fact_number = self.get_storable_fact_number(fact_id)
-        if fact_number:
-            file_name = self.get_store_filename(fact_number)
-            if not self.exists_file(file_name, fact_id):
-                self.store_file(result[0], file_name, fact_id)
+        if self.context.get("save_pdf_in_invoice_attachments", False):
+            fact_number = self.get_storable_fact_number(fact_id)
+            if fact_number:
+                file_name = self.get_store_filename(fact_number)
+                if not self.exists_file(file_name, fact_id):
+                    self.store_file(result[0], file_name, fact_id)
 
     def retrieve(self):
         if len(self.result) == 1:

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -9,7 +9,7 @@ import tempfile
 
 class InvoicePdfStorer():
 
-    def __init__(self, cursor, uid, context):
+    def __init__(self, cursor, uid, context=None):
         self.cursor = cursor
         self.uid = uid
         self.pool = pooler.get_pool(cursor.dbname)

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -83,9 +83,6 @@ class InvoicePdfStorer():
         return [merged_pdf, u'pdf']
 
     def get_storable_fact_number(self, fact_id):
-        if self.context.get("regenerate_pdf", False):
-            return False
-
         fact_data = self.fact_obj.read(
             self.cursor,
             self.uid,

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import pooler
+import base64
+
+
+class InvoicePdfStorer():
+
+    def __init__(self, cursor, uid, context):
+        self.cursor = cursor
+        self.uid = uid
+        self.pooler = pooler.get_pool(cursor.dbname)
+        self.context = {} if context is None else context
+        self.result = []
+        self.fact_obj = self.pool.get("giscedata.facturacio.factura")
+        self.att_obj = self.pool.get("ir.attachment")
+
+    def search_stored_and_append(self, fact_id):
+        fact_number = self.get_storable_fact_number(fact_id)
+        if not fact_number:
+            return False
+
+        found = False
+        att_id = None
+
+        # ToDo: search it in the mails
+        if not found:
+            # ToDo: search it in the attachements
+            if not found:
+                return False
+
+        result = self.read_file(att_id)
+        self.result.append(result)
+        return True
+
+    def append_and_store(self, fact_id, result):
+        self.result.append(result)
+        fact_number = self.get_storable_fact_number(fact_id)
+        if fact_number:
+            file_name = self.get_store_filename(fact_number)
+            if not self.exists_file(file_name, fact_id):
+                self.store_file(result[0], file_name, fact_id)
+
+    def retrieve(self):
+        if len(self.result) == 1:
+            return self.result[0]
+        # ToDo: pdf concatenation if n results
+
+    def get_storable_fact_number(self, ids):
+        if len(ids) != 1:
+            return False
+
+        if self.context.get("regenerate_pdf", False):
+            return False
+
+        fact_id = ids[0]
+        fact_number = self.fact_obj.read(
+            self.cursor,
+            self.uid,
+            fact_id,
+            ['number'],
+            context=self.context
+        )['number']
+        if not fact_number:
+            return False
+
+        # ToDo: add more contitions
+        return fact_number
+
+    def get_store_filename(self, fact_number):
+        return 'STORED_{}.pdf'.format(fact_number)
+
+    def exists_file(self, file_name, fact_id):
+        att_ids = self.att_obj.search(
+            self.cursor,
+            self.uid,
+            [
+                ('name', '=', file_name),
+                ('res_model', '=', 'giscedata.facturacio.factura'),
+                ('res_id', '=', fact_id),
+            ],
+            context=self.context
+        )
+        return att_ids
+
+    def store_file(self, content, file_name, fact_id):
+        b64_content = base64.b64encode(content)
+        attachment = {
+            "name": file_name,
+            "datas": b64_content,
+            "datas_fname": file_name,
+            "res_model": "giscedata.facturacio.factura",
+            "res_id": fact_id,
+        }
+        with pooler.get_db(self.cursor.dbname).cursor() as w_cursor:
+            attachment_id = self.att_obj.create(
+                w_cursor, self.uid, attachment, context=self.context
+            )
+        return attachment_id
+
+    def read_file(self, att_id):
+        b64_content = self.att_obj.read(
+            self.cursor,
+            self.uid,
+            att_id,
+            ["datas"],
+            context=self.context
+        )["datas"]
+        content = base64.b64decode(b64_content)
+        return [content, u'pdf']

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -119,7 +119,7 @@ class InvoicePdfStorer():
 
     def store_file(self, content, file_name, fact_id):
         if 'Dont_store' in self.flags:
-            return []
+            return False
         b64_content = base64.b64encode(content)
         attachment = {
             "name": file_name,

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -23,7 +23,13 @@ class InvoicePdfStorer():
         self.flags = eval(flags) if flags else []
 
     def is_enabled(self):
-        return 'Enabled' in self.flags
+        if 'Enabled' not in self.flags:
+            return False
+
+        if self.context.get("regenerate_pdf", False):
+            return False
+
+        return True
 
     def search_stored_and_append(self, fact_id):
         fact_number = self.get_storable_fact_number(fact_id)

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -8,7 +8,7 @@ class InvoicePdfStorer():
     def __init__(self, cursor, uid, context):
         self.cursor = cursor
         self.uid = uid
-        self.pooler = pooler.get_pool(cursor.dbname)
+        self.pool = pooler.get_pool(cursor.dbname)
         self.context = {} if context is None else context
         self.result = []
         self.fact_obj = self.pool.get("giscedata.facturacio.factura")
@@ -45,14 +45,10 @@ class InvoicePdfStorer():
             return self.result[0]
         # ToDo: pdf concatenation if n results
 
-    def get_storable_fact_number(self, ids):
-        if len(ids) != 1:
-            return False
-
+    def get_storable_fact_number(self, fact_id):
         if self.context.get("regenerate_pdf", False):
             return False
 
-        fact_id = ids[0]
         fact_number = self.fact_obj.read(
             self.cursor,
             self.uid,

--- a/giscedata_facturacio_comer_som/invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/invoice_pdf_storer.py
@@ -165,6 +165,4 @@ class InvoicePdfStorer():
             context=self.context,
         )['pem_attachments_ids']
 
-        if 'No_mongo' in self.flags:
-            return []
         return result

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/manual_migration.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/manual_migration.py
@@ -19,6 +19,7 @@ fact_obj = O.GiscedataFacturacioFactura
 DOIT = False
 
 not_found_ab_invoices = []
+not_found_fe_invoices = []
 not_found_xx_invoices = []
 subjects = [
     u'Factura XX',
@@ -48,6 +49,11 @@ subjects = [
     u'Factura XX - Import elevat',
     u'Facturación atrasada + Factura XX',
     u'Factura XX - diciembre',
+    u'Factura XX amb estimacions reiterades de la distribuïdora',
+    u'Factura XX con lectura estimada por la distribuidora',
+    u'Factura XX amb lectura estimada per la distribuïdora',
+    u'Factura XX amb lectures estimades de la distribuïdora',
+    u'Factura XX amb estimacions de la ditribuïdora',
 ]
 
 
@@ -80,10 +86,13 @@ def search_email(fact_id, fact_number, sent_date):
 
     if fact_number.startswith('AB'):
         not_found_ab_invoices.append(fact_id)
-        step('Not found --> {}', fact_number)
+        step('Not found AB --> {}', fact_number)
+    elif fact_number.startswith('FE'):
+        not_found_fe_invoices.append(fact_id)
+        success('Not found FE --> {}', fact_number)
     else:
         not_found_xx_invoices.append(fact_id)
-        success('not found --> {}', fact_number)
+        success('not found OTHER --> {}', fact_number)
     return mail_ids
 
 
@@ -152,6 +161,7 @@ def migrate():
     step("Column succesfuly filled")
     step("Status found/not found {} / {}", found, not_found)
     write_as_csv_assist(not_found_ab_invoices, 'not_found_AB_inv')
+    write_as_csv_assist(not_found_fe_invoices, 'not_found_FE_inv')
     write_as_csv_assist(not_found_xx_invoices, 'not_found_XX_inv')
 
 
@@ -160,5 +170,6 @@ if __name__ == '__main__':
         migrate()
     except (KeyboardInterrupt, SystemError):
         write_as_csv_assist(not_found_ab_invoices, 'not_found_AB_inv')
+        write_as_csv_assist(not_found_fe_invoices, 'not_found_FE_inv')
         write_as_csv_assist(not_found_xx_invoices, 'not_found_XX_inv')
         success("Bye!")

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/manual_migration.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/manual_migration.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+from erppeek import Client
+import dbconfig
+from tqdm import tqdm
+from consolemsg import step, success
+import csv
+import StringIO
+
+"""_summary_
+Executa la migració un cop creat el camp enviat_mail_id a giscedata_facturacio_factura pot trigar mes de 24 h
+"""  # noqa: E501
+
+O = Client(**dbconfig.erppeek)  # noqa: E741
+
+mail_obj = O.PoweremailMailbox
+fact_obj = O.GiscedataFacturacioFactura
+
+
+DOIT = False
+
+not_found_ab_invoices = []
+not_found_xx_invoices = []
+subjects = [
+    u'Factura XX',
+    u'Som Energia: Factura XX',
+    u'Factura electricitat XX',
+    u'Factura electricidad XX',
+    u'Abonament factura electricitat XX \\ Abono factura electricidad XX',
+    u'Reenviament XX (adjunt correcte) / Reenvío XX (adjunto correcto)',
+    u'Reenvío de factura XX',
+    u'Reenviament Factura XX',
+    u'Reenvío Factura XX',
+    u'Factura complementària per expedient XX',
+    u'Factura complementaria por expediente XX',
+    u'Factura XX - Factura expedient distribuïdora',
+    u'Factura XX - factura expedient distribuïdora',
+    u'Factura XX - Factura expediente distribuidora',
+    u'Factura XX - factura expediente distribuidora',
+    u'Factura XX associada a expedient',
+    u'Factura XX de expediente de la empresa distribuidora',
+    u'Factura XX per expedient distribuïdora',
+    u'Factura abonadora XX',
+    u'Factura XX amb facturació complementària de la distribuïdora',
+    u'Factura XX con expediente de la empresa distribuidora',
+    u'Factura XX amb expedient distribuïdora',
+    u'Factura XX amb expedient empresa distribuïdora',
+    u'Factura XX amb lectures estimades per la distribuïdora',
+    u'Factura XX - Import elevat',
+    u'Facturación atrasada + Factura XX',
+    u'Factura XX - diciembre',
+]
+
+
+def get_fact_to_update():
+    fact_ids = fact_obj.search([
+        ('number', '!=', None),
+        ('enviat', '=', True),
+        ('enviat_carpeta', '=', 'sent'),
+        ('type', 'in', ['out_invoice', 'out_refund']),
+        ('enviat_mail_id', '=', None),
+    ])
+    return fact_ids
+
+
+def search_email(fact_id, fact_number, sent_date):
+    query = [
+        ('folder', '=', 'sent'),
+        ('reference', '=', 'giscedata.facturacio.factura,{}'.format(fact_id)),
+        ('date_mail', '<=', sent_date),
+    ]
+
+    # Let's try the fastest ones
+    for subject in subjects:
+        full_subject = subject.replace("XX", fact_number)
+        mail_ids = mail_obj.search(
+            [('pem_subject', '=', full_subject)] + query
+        )
+        if mail_ids:
+            return mail_ids
+
+    if fact_number.startswith('AB'):
+        not_found_ab_invoices.append(fact_id)
+        step('Not found --> {}', fact_number)
+    else:
+        not_found_xx_invoices.append(fact_id)
+        success('not found --> {}', fact_number)
+    return mail_ids
+
+
+def update_field(fact_id):
+    fact_data = fact_obj.read(fact_id, ['number', 'enviat_data'])
+    mail_ids = search_email(fact_id, fact_data['number'], fact_data['enviat_data'])
+    if not mail_ids:
+        return False
+
+    if DOIT:
+        fact_obj.write(fact_id, {'enviat_mail_id': mail_ids[0]})
+    return True
+
+
+def write_as_csv(header, data, filename):
+    csv_doc = StringIO.StringIO()
+    writer_report = csv.writer(csv_doc, delimiter=';')
+    writer_report.writerow(header)
+    writer_report.writerows(data)
+    doc = csv_doc.getvalue()
+    with open(filename + ".csv", 'w') as f:
+        f.write(doc)
+
+
+def write_as_csv_assist(fact_ids, filename):
+    O = Client(**dbconfig.erppeek)  # noqa: E741
+    f_obj = O.GiscedataFacturacioFactura
+
+    header = ['id', 'numero', 'polissa', 'enviat', 'carpeta mail', 'data enviament']
+    data = []
+    for fact_id in fact_ids:
+        val = f_obj.read(
+            fact_id,
+            [
+                'number',
+                'polissa_id',
+                'enviat',
+                'enviat_carpeta',
+                'enviat_data'
+            ]
+        )
+        data.append([
+            val['id'],
+            val['number'],
+            val['polissa_id'][1],
+            val['enviat'],
+            val['enviat_carpeta'],
+            val['enviat_data']
+        ])
+    write_as_csv(header, data, filename)
+
+
+def migrate():
+    found = 0
+    not_found = 0
+    step("Starting migration: reading the id's")
+    fact_ids = get_fact_to_update()
+    step("{} id's found...", len(fact_ids))
+    for count, fact_id in enumerate(tqdm(fact_ids)):
+        if update_field(fact_id):
+            found += 1
+        else:
+            not_found += 1
+        if count % 5000 == 0:
+            step("Status found/not found {} / {}", found, not_found)
+    step("Column succesfuly filled")
+    step("Status found/not found {} / {}", found, not_found)
+    write_as_csv_assist(not_found_ab_invoices, 'not_found_AB_inv')
+    write_as_csv_assist(not_found_xx_invoices, 'not_found_XX_inv')
+
+
+if __name__ == '__main__':
+    try:
+        migrate()
+    except (KeyboardInterrupt, SystemError):
+        write_as_csv_assist(not_found_ab_invoices, 'not_found_AB_inv')
+        write_as_csv_assist(not_found_xx_invoices, 'not_found_XX_inv')
+        success("Bye!")

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/migration_query.sql
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/migration_query.sql
@@ -2,7 +2,7 @@ with CTE as (
 	select pm.id as mail_id, gff.id as fact_id
 	from poweremail_mailbox pm
 	inner join giscedata_facturacio_factura gff on gff.id = split_part(pm.reference, ',', 2)::integer
-	where pm.reference like 'giscedata.facturacio.factura,%'
+	where pm.reference like 'giscedata.facturacio.factura,%' and gff.enviat_mail_id is null
 	and (
 		pm.pem_subject like 'Factura %'
 		or pm.pem_subject like 'Som Energia: Factura %'
@@ -43,4 +43,4 @@ with CTE as (
 update giscedata_facturacio_factura gff
 SET enviat_mail_id = CTE.mail_id
 from CTE
-where CTE.fact_id = gff.id and gff.enviat_mail_id is null;
+where CTE.fact_id = gff.id;

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/migration_query.sql
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/migration_query.sql
@@ -1,0 +1,46 @@
+with CTE as (
+	select pm.id as mail_id, gff.id as fact_id
+	from poweremail_mailbox pm
+	inner join giscedata_facturacio_factura gff on gff.id = split_part(pm.reference, ',', 2)::integer
+	where pm.reference like 'giscedata.facturacio.factura,%'
+	and (
+		pm.pem_subject like 'Factura %'
+		or pm.pem_subject like 'Som Energia: Factura %'
+		or pm.pem_subject like 'Factura electricitat %'
+		or pm.pem_subject like 'Factura electricidad %'
+		or pm.pem_subject like 'Abonament factura electricitat % \\ Abono factura electricidad %'
+		or pm.pem_subject like 'Reenviament % (adjunt correcte) / Reenvío % (adjunto correcto)'
+		or pm.pem_subject like 'Reenvío de factura %'
+		or pm.pem_subject like 'Reenviament Factura %'
+		or pm.pem_subject like 'Reenvío Factura %'
+		or pm.pem_subject like 'Factura complementària per expedient %'
+		or pm.pem_subject like 'Factura complementaria por expediente %'
+		or pm.pem_subject like 'Factura % - Factura expedient distribuïdora'
+		or pm.pem_subject like 'Factura % - factura expedient distribuïdora'
+		or pm.pem_subject like 'Factura % - Factura expediente distribuidora'
+		or pm.pem_subject like 'Factura % - factura expediente distribuidora'
+		or pm.pem_subject like 'Factura % associada a expedient'
+		or pm.pem_subject like 'Factura % de expediente de la empresa distribuidora'
+		or pm.pem_subject like 'Factura % per expedient distribuïdora'
+		or pm.pem_subject like 'Factura abonadora %'
+		or pm.pem_subject like 'Factura % amb facturació complementària de la distribuïdora'
+		or pm.pem_subject like 'Factura % con expediente de la empresa distribuidora'
+		or pm.pem_subject like 'Factura % amb expedient distribuïdora'
+		or pm.pem_subject like 'Factura % amb expedient empresa distribuïdora'
+		or pm.pem_subject like 'Factura % amb lectures estimades per la distribuïdora'
+		or pm.pem_subject like 'Factura % - Import elevat'
+		or pm.pem_subject like 'Facturación atrasada + Factura %'
+		or pm.pem_subject like 'Factura % - diciembre'
+		or pm.pem_subject like 'Factura % amb estimacions reiterades de la distribuïdora'
+		or pm.pem_subject like 'Factura % con lectura estimada por la distribuidora'
+		or pm.pem_subject like 'Factura % amb lectura estimada per la distribuïdora'
+		or pm.pem_subject like 'Factura % amb lectures estimades de la distribuïdora'
+		or pm.pem_subject like 'Factura % amb estimacions de la ditribuïdora'
+	)
+	order by pm.id
+	limit 100000 -- remove this limit to make a full migration
+)
+update giscedata_facturacio_factura gff
+SET enviat_mail_id = CTE.mail_id
+from CTE
+where CTE.fact_id = gff.id and gff.enviat_mail_id is null;

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from tools import config
+from oopgrade.oopgrade import add_columns_fk, column_exists
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    if not column_exists(cursor, 'giscedata_facturacio_factura', 'enviat_mail_id'):
+        new_column_spec = [('enviat_mail_id', 'int', 'poweremail_mailbox', 'id', 'set null')]
+        add_columns_fk(cursor, {'giscedata_facturacio_factura': new_column_spec})
+    else:
+        return
+
+    # ToDo load the view
+    # view = "ir/ir.xml"
+    # view_record = ["act_report_xml_view"]
+    # load_data_records(cursor, 'base', view, view_record, mode='update')
+
+    # ToDo migrate the data
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
@@ -30,7 +30,7 @@ def up(cursor, installed_version):
         cursor,
         'giscedata_facturacio_comer_som',
         'giscedata_facturacio_comer_data.xml',
-        ["fatura_pdf_cache_flags"],
+        ["factura_pdf_cache_flags"],
         mode='update'
     )
     logger.info("XMLs succesfully updated.")

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
@@ -1,24 +1,85 @@
 # -*- coding: utf-8 -*-
+import logging
+import pooler
 from tools import config
-from oopgrade.oopgrade import add_columns_fk, column_exists
+from oopgrade.oopgrade import add_columns_fk, column_exists, load_data
+from tqdm import tqdm
+
+
+def search_email(pool, cursor, uid, fact_id, fact_number, sent_date=None):
+    mail_obj = pool.get("poweremail.mailbox")
+
+    query = [
+        ('pem_subject', 'like', '%{}%'.format(fact_number)),
+        ('folder', '=', 'sent'),
+        ('reference', '=', 'giscedata.facturacio.factura,{}'.format(fact_id)),
+    ]
+    if sent_date:
+        query.append(
+            ('date_mail', '=', sent_date)
+        )
+
+    return mail_obj.search(cursor, uid, query)
+
+
+def update_field(pool, cursor, uid, fact_id):
+    fact_obj = pool.get("giscedata.facturacio.factura")
+
+    fact_data = fact_obj.read(cursor, uid, ['number', 'enviat_data'])
+
+    mail_ids = search_email(pool, cursor, uid, fact_id,
+                            fact_data['number'], fact_data['enviat_data'])
+    if not mail_ids:
+        mail_ids = search_email(pool, cursor, uid, fact_id, fact_data['number'])
+
+    if mail_ids:
+        fact_obj.write(cursor, uid, fact_id, {'enviat_mail_id': mail_ids[0]})
+
+
+def get_fact_to_update(pool, cursor, uid):
+    fact_obj = pool.get("giscedata.facturacio.factura")
+    fact_ids = fact_obj.search(cursor, uid, [
+        ('number', '!=', None),
+        ('enviat', '=', True),
+        ('enviat_carpeta', '=', 'sent'),
+        ('type', 'in', ['out_invoice', 'out_refund']),
+    ])
+    return fact_ids
 
 
 def up(cursor, installed_version):
     if not installed_version or config.updating_all:
         return
 
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Creating pooler")
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Create enviat_mail_id column  in giscedata_facturacio_factura")
     if not column_exists(cursor, 'giscedata_facturacio_factura', 'enviat_mail_id'):
         new_column_spec = [('enviat_mail_id', 'int', 'poweremail_mailbox', 'id', 'set null')]
         add_columns_fk(cursor, {'giscedata_facturacio_factura': new_column_spec})
+        logger.info("Column created succesfully.")
     else:
-        return
+        logger.info("Column already created!!.")
 
-    # ToDo load the view
-    # view = "ir/ir.xml"
-    # view_record = ["act_report_xml_view"]
-    # load_data_records(cursor, 'base', view, view_record, mode='update')
+    logger.info("Updating giscedata_facturacio_factura.xml")
+    load_data(
+        cursor,
+        'giscedata_facturacio_comer_som',
+        'giscedata_facturacio_factura.xml',
+        idref=None,
+        mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
 
-    # ToDo migrate the data
+    logger.info("Starting the migration: Fill the column")
+    uid = 1
+    fact_ids = get_fact_to_update(pool, cursor, uid)
+    for fact_id in tqdm(fact_ids):
+        update_field(pool, cursor, uid, fact_id)
+    logger.info("Column succesfuly filled")
 
 
 def down(cursor, installed_version):

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
@@ -2,7 +2,7 @@
 import logging
 import pooler
 from tools import config
-from oopgrade.oopgrade import add_columns_fk, column_exists, load_data
+from oopgrade.oopgrade import add_columns_fk, column_exists, load_data, load_data_records
 from tqdm import tqdm
 
 
@@ -89,6 +89,13 @@ def up(cursor, installed_version):
         'giscedata_facturacio_comer_som',
         'giscedata_facturacio_factura.xml',
         idref=None,
+        mode='update'
+    )
+    load_data_records(
+        cursor,
+        'giscedata_facturacio_comer_som',
+        'giscedata_facturacio_comer_data.xml',
+        ["fatura_pdf_cache_flags"],
         mode='update'
     )
     logger.info("XMLs succesfully updated.")

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import pooler
 from tools import config
 from oopgrade.oopgrade import add_columns_fk, column_exists, load_data, load_data_records
 
@@ -10,9 +9,6 @@ def up(cursor, installed_version):
         return
 
     logger = logging.getLogger('openerp.migration')
-
-    logger.info("Creating pooler")
-    pooler.get_pool(cursor.dbname)
 
     logger.info("Create enviat_mail_id column  in giscedata_facturacio_factura")
     if not column_exists(cursor, 'giscedata_facturacio_factura', 'enviat_mail_id'):

--- a/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.24.11.0/post-0001_create_enviat_mail_id_field_in_factura.py
@@ -3,67 +3,6 @@ import logging
 import pooler
 from tools import config
 from oopgrade.oopgrade import add_columns_fk, column_exists, load_data, load_data_records
-from tqdm import tqdm
-
-
-def search_email(pool, cursor, uid, fact_id, fact_number, sent_date):
-    mail_obj = pool.get("poweremail.mailbox")
-
-    query = [
-        ('folder', '=', 'sent'),
-        ('reference', '=', 'giscedata.facturacio.factura,{}'.format(fact_id)),
-        ('date_mail', '=', sent_date),
-    ]
-
-    subjects = [
-        u'Factura XX',
-        u'Som Energia: Factura XX',
-        u'Factura pagada XX',
-        u'Factura electricitat XX',
-        u'Factura electricidad XX',
-        u'Reenviament XX (adjunt correcte) / Reenvío XX (adjunto correcto)',
-        u'Reenvío de factura XX',
-        u'Reenviament Factura XX',
-        u'Reenvío Factura XX',
-    ]
-
-    # Let's try the fastest ones
-    for subject in subjects:
-        full_subject = subject.replace("XX", fact_number)
-        mail_ids = mail_obj.search(
-            cursor, uid,
-            [('pem_subject', '=', full_subject)] + query
-        )
-        if mail_ids:
-            return mail_ids
-
-    # The slowest one
-    return mail_obj.search(
-        cursor, uid,
-        [('pem_subject', 'like', '%{}%'.format(fact_number))] + query
-    )
-
-
-def update_field(pool, cursor, uid, fact_id):
-    fact_obj = pool.get("giscedata.facturacio.factura")
-
-    fact_data = fact_obj.read(cursor, uid, ['number', 'enviat_data'])
-
-    mail_ids = search_email(pool, cursor, uid, fact_id,
-                            fact_data['number'], fact_data['enviat_data'])
-    if mail_ids:
-        fact_obj.write(cursor, uid, fact_id, {'enviat_mail_id': mail_ids[0]})
-
-
-def get_fact_to_update(pool, cursor, uid):
-    fact_obj = pool.get("giscedata.facturacio.factura")
-    fact_ids = fact_obj.search(cursor, uid, [
-        ('number', '!=', None),
-        ('enviat', '=', True),
-        ('enviat_carpeta', '=', 'sent'),
-        ('type', 'in', ['out_invoice', 'out_refund']),
-    ])
-    return fact_ids
 
 
 def up(cursor, installed_version):
@@ -73,7 +12,7 @@ def up(cursor, installed_version):
     logger = logging.getLogger('openerp.migration')
 
     logger.info("Creating pooler")
-    pool = pooler.get_pool(cursor.dbname)
+    pooler.get_pool(cursor.dbname)
 
     logger.info("Create enviat_mail_id column  in giscedata_facturacio_factura")
     if not column_exists(cursor, 'giscedata_facturacio_factura', 'enviat_mail_id'):
@@ -100,12 +39,7 @@ def up(cursor, installed_version):
     )
     logger.info("XMLs succesfully updated.")
 
-    logger.info("Starting the migration: Fill the column")
-    uid = 1
-    fact_ids = get_fact_to_update(pool, cursor, uid)
-    for fact_id in tqdm(fact_ids):
-        update_field(pool, cursor, uid, fact_id)
-    logger.info("Column succesfuly filled")
+    # Run the script: manual_migration.py
 
 
 def down(cursor, installed_version):

--- a/giscedata_facturacio_comer_som/report/giscedata_facturacio_comer_som.py
+++ b/giscedata_facturacio_comer_som/report/giscedata_facturacio_comer_som.py
@@ -36,10 +36,13 @@ class FacturaReportSomWebkitParserHTML(webkit_report.WebKitParser):
         )
 
     def create(self, cursor, uid, ids, data, context=None):
+        storer = InvoicePdfStorer(cursor, uid, context)
+        if not storer.is_enabled():
+            return self.sub_create(cursor, uid, ids, data, context=context)
+
         if not isinstance(ids, (tuple, list)):
             ids = [ids]
 
-        storer = InvoicePdfStorer(cursor, uid, context)
         for f_id in ids:
             if not storer.search_stored_and_append(f_id):
                 res = self.sub_create(cursor, uid, [f_id], data, context=context)

--- a/giscedata_facturacio_comer_som/report/giscedata_facturacio_comer_som.py
+++ b/giscedata_facturacio_comer_som/report/giscedata_facturacio_comer_som.py
@@ -42,7 +42,7 @@ class FacturaReportSomWebkitParserHTML(webkit_report.WebKitParser):
         storer = InvoicePdfStorer(cursor, uid, context)
         for f_id in ids:
             if not storer.search_stored_and_append(f_id):
-                res = self.sub_create(cursor, uid, f_id, data, context=context)
+                res = self.sub_create(cursor, uid, [f_id], data, context=context)
                 storer.append_and_store(f_id, res)
 
         return storer.retrieve()

--- a/giscedata_facturacio_comer_som/requirements.txt
+++ b/giscedata_facturacio_comer_som/requirements.txt
@@ -3,3 +3,4 @@ https://github.com/AxiaCore/number-to-letters/archive/master.zip
 bankbarcode
 https://github.com/oriolpiera/nombres-a-lletres/archive/master.zip
 yamlns==0.7
+pypdftk==0.4

--- a/giscedata_facturacio_comer_som/requirements.txt
+++ b/giscedata_facturacio_comer_som/requirements.txt
@@ -2,4 +2,4 @@ progressbar==2.5
 https://github.com/AxiaCore/number-to-letters/archive/master.zip
 bankbarcode
 https://github.com/oriolpiera/nombres-a-lletres/archive/master.zip
-yamlns
+yamlns==0.7

--- a/giscedata_facturacio_comer_som/sql/query_fact_to_pdf_store.sql
+++ b/giscedata_facturacio_comer_som/sql/query_fact_to_pdf_store.sql
@@ -7,7 +7,7 @@ WHERE
   i.number IS NOT NULL
   AND f.enviat_mail_id IS NULL
   AND i.type IN ('out_invoice', 'out_refund')
-  AND i.date_invoice >= '2021-01-01'
+  AND i.date_invoice >= '2020-01-01'
   AND i.date_invoice < %s
   AND (
     SELECT id

--- a/giscedata_facturacio_comer_som/sql/query_fact_to_pdf_store.sql
+++ b/giscedata_facturacio_comer_som/sql/query_fact_to_pdf_store.sql
@@ -1,0 +1,18 @@
+SELECT
+  f.id
+FROM giscedata_facturacio_factura f
+INNER JOIN account_invoice i
+  ON i.id = f.invoice_id
+WHERE
+  i.number IS NOT NULL
+  AND f.enviat_mail_id IS NULL
+  AND i.type IN ('out_invoice', 'out_refund')
+  AND i.date_invoice >= '2021-01-01'
+  AND i.date_invoice < %s
+  AND (
+    SELECT id
+    FROM ir_attachment a
+    WHERE a.res_model = 'giscedata.facturacio.factura' AND a.res_id = f.id
+    AND a.datas_fname = ('STORED_' || i."number" || '.pdf')
+  ) IS NULL
+ORDER BY i.date_invoice

--- a/giscedata_facturacio_comer_som/tests/__init__.py
+++ b/giscedata_facturacio_comer_som/tests/__init__.py
@@ -1,1 +1,2 @@
 from tests_FacturacioFacturaReport_some import *
+from tests_invoice_pdf_storer import *

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -286,7 +286,7 @@ class Tests_FacturacioFacturaReport_company_component(Tests_FacturacioFacturaRep
                 "city": u"Girona",
                 "email": u"info@somenergia.coop",
                 "name": u"Som Energia, SCCL",
-                "street": u"Pic de Peguera, 11 A 2 8",
+                "street": u"Pic de Peguera, 11 ESC. A 2 8",
                 "zip": u"17003",
             },
         )
@@ -630,7 +630,7 @@ class Tests_FacturacioFacturaReport_contract_data_component(Tests_FacturacioFact
                 "pricelist": u"TARIFAS ELECTRICIDAD",
                 "autoconsum_cau": "",
                 "is_autoconsum_colectiu": False,
-                "cups_direction": u"carrer inventat 1 1 1 1 aclaridor 00001 (Poble de Prova)",
+                "cups_direction": u"carrer inventat ,  1  ESC.  1 1 1 aclaridor 00001 (Poble de Prova)",  # noqa: E501
                 "autoconsum_colectiu_repartiment": 100.0,
                 "cnae": u"0111",
                 "power_invoicing_type": True,
@@ -679,7 +679,7 @@ class Tests_FacturacioFacturaReport_contract_data_component(Tests_FacturacioFact
                 "pricelist": u"TARIFAS ELECTRICIDAD",
                 "autoconsum_cau": u"ES0318363477145938GEA000",
                 "is_autoconsum_colectiu": False,
-                "cups_direction": u"carrer inventat 1 1 1 1 aclaridor 00001 (Poble de Prova)",
+                "cups_direction": u"carrer inventat ,  1  ESC.  1 1 1 aclaridor 00001 (Poble de Prova)",  # noqa: E501
                 "autoconsum_colectiu_repartiment": 0.0,
                 "cnae": u"0111",
                 "power_invoicing_type": False,
@@ -2098,7 +2098,7 @@ class Tests_FacturacioFacturaReport_invoice_info(Tests_FacturacioFacturaReport_b
                 "start_date": "01/01/2016",
                 "end_date": "29/02/2016",
                 "contract_number": u"0001C",
-                "address": u"carrer inventat 1 1 1 1 aclaridor 00001 (Poble de Prova)",
+                "address": u"carrer inventat ,  1  ESC.  1 1 1 aclaridor 00001 (Poble de Prova)",
                 "due_date": "01/01/2016",
             },
         )

--- a/giscedata_facturacio_comer_som/tests/tests_invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/tests/tests_invoice_pdf_storer.py
@@ -6,6 +6,31 @@ from destral.transaction import Transaction
 from ..invoice_pdf_storer import InvoicePdfStorer
 
 
+_BLANK_PDF = """
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f
+0000000010 00000 n
+0000000054 00000 n
+0000000103 00000 n
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+165
+%%EOF
+"""
+
+
 class TestInvoicePdfStorer(testing.OOTestCase):
 
     def setUp(self):
@@ -14,6 +39,8 @@ class TestInvoicePdfStorer(testing.OOTestCase):
         self.uid = self.txn.user
 
         self.conf_obj = self.openerp.pool.get("res.config")
+        self.imd_obj = self.openerp.pool.get("ir.model.data")
+        self.fact_obj = self.openerp.pool.get("giscedata.facturacio.factura")
 
     def tearDown(self):
         self.txn.stop()
@@ -29,3 +56,98 @@ class TestInvoicePdfStorer(testing.OOTestCase):
 
         storer = InvoicePdfStorer(self.cursor, self.uid, {"do_not_use_stored_pdf": True})
         self.assertFalse(storer.is_enabled())
+
+    def test_get_storable_fact_number(self):
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+
+        # Draft invoice without number
+        fact_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "giscedata_facturacio", "factura_0001")[1]
+        self.assertFalse(storer.get_storable_fact_number(fact_id))
+
+        self.fact_obj.write(self.cursor, self.uid, fact_id, {"state": "open"})
+        self.assertFalse(storer.get_storable_fact_number(fact_id))
+
+        self.fact_obj.write(self.cursor, self.uid, fact_id, {"number": "FE123"})
+        self.assertEqual(storer.get_storable_fact_number(fact_id), "FE123")
+
+    def test_get_store_filename(self):
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+        self.assertEqual(storer.get_store_filename("FE123"), "STORED_FE123.pdf")
+
+    def test_store_file(self):
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+
+        fact_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "giscedata_facturacio", "factura_0001")[1]
+
+        # Asserts than some attachment ID is returned (non 0 integers eval to True)
+        self.assertTrue(storer.store_file(_BLANK_PDF, "STORED_FE123.pdf", fact_id))
+
+        self.conf_obj.set(self.cursor, self.uid, "factura_pdf_cache_flags", "['Dont_store']")
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+        self.assertFalse(storer.store_file(_BLANK_PDF, "STORED_FE123.pdf", fact_id))
+
+    def test_read_file(self):
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+
+        fact_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "giscedata_facturacio", "factura_0001")[1]
+
+        att_id = storer.store_file(_BLANK_PDF, "STORED_FE123.pdf", fact_id)
+        content, filetype = storer.read_file(att_id)
+
+        self.assertEqual(filetype, "pdf")
+        self.assertEqual(content, _BLANK_PDF)
+
+    def test_search_and_retrieve_use_case(self):
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+
+        fact_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "giscedata_facturacio", "factura_0001")[1]
+        self.fact_obj.write(
+            self.cursor, self.uid, fact_id, {"state": "open", "number": "FE123"})
+
+        storer.store_file(_BLANK_PDF, "STORED_FE123.pdf", fact_id)
+
+        storer.search_stored_and_append(fact_id)
+        content, filetype = storer.retrieve()
+
+        self.assertEqual(filetype, "pdf")
+        self.assertEqual(content, _BLANK_PDF)
+
+    def test_store_and_retrieve_use_case(self):
+        storer = InvoicePdfStorer(
+            self.cursor, self.uid, {"save_pdf_in_invoice_attachments": True})
+
+        fact_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "giscedata_facturacio", "factura_0001")[1]
+        self.fact_obj.write(
+            self.cursor, self.uid, fact_id, {"state": "open", "number": "FE123"})
+
+        storer.append_and_store(fact_id, (_BLANK_PDF, 'pdf'))
+
+        content, filetype = storer.retrieve()
+
+        self.assertEqual(filetype, "pdf")
+        self.assertEqual(content, _BLANK_PDF)
+
+    def test_multiple_pdf_use_case(self):
+        storer = InvoicePdfStorer(
+            self.cursor, self.uid, {"save_pdf_in_invoice_attachments": True})
+
+        fact_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "giscedata_facturacio", "factura_0001")[1]
+        self.fact_obj.write(
+            self.cursor, self.uid, fact_id, {"state": "open", "number": "FE123"})
+
+        storer.append_and_store(fact_id, (_BLANK_PDF, 'pdf'))
+
+        # Here we find the last stored PDF and we append it in the result again
+        storer.search_stored_and_append(fact_id)
+
+        content, filetype = storer.retrieve()
+        self.assertEqual(filetype, "pdf")
+
+        # We check thant the content is larger than the original PDF (there are two pages now)
+        self.assertGreater(len(content), len(_BLANK_PDF))

--- a/giscedata_facturacio_comer_som/tests/tests_invoice_pdf_storer.py
+++ b/giscedata_facturacio_comer_som/tests/tests_invoice_pdf_storer.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from destral import testing
+from destral.transaction import Transaction
+
+from ..invoice_pdf_storer import InvoicePdfStorer
+
+
+class TestInvoicePdfStorer(testing.OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+        self.conf_obj = self.openerp.pool.get("res.config")
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test_is_enabled(self):
+        self.conf_obj.set(self.cursor, self.uid, "factura_pdf_cache_flags", "")
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+        self.assertFalse(storer.is_enabled())
+
+        self.conf_obj.set(self.cursor, self.uid, "factura_pdf_cache_flags", "['Enabled']")
+        storer = InvoicePdfStorer(self.cursor, self.uid)
+        self.assertTrue(storer.is_enabled())
+
+        storer = InvoicePdfStorer(self.cursor, self.uid, {"do_not_use_stored_pdf": True})
+        self.assertFalse(storer.is_enabled())

--- a/scripts/store_unsent_pdf_invoices.py
+++ b/scripts/store_unsent_pdf_invoices.py
@@ -1,0 +1,19 @@
+import configdb
+from erppeek import Client as Client
+
+
+def main():
+    c = Client(**configdb.erppeek)
+    fact_obj = c.model("giscedata.facturacio.factura")
+
+    total_successful, failed_ids = fact_obj.store_unsent_pdf_invoices()
+
+    print("Successfuly stored {} invoices".format(total_successful))
+    if failed_ids:
+        print("Some errors ocurred:")
+        print(failed_ids)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Objectiu

Permetre emmagatzemar i recuperar les factures en pdf sense forçar la regeneració agafant les emmagatzemades amb anterioritat com adjunts als correus

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/488/activity

## Comportament antic

Les factures es regeneraven cada cop, companyes han de recuperar-les de HS o de adjunts del correu

## Comportament nou

Es recupera dels correus prèviament enviats o s'emmagatzemen

## Spike de codi anterior
https://github.com/Som-Energia/openerp_som_addons/pull/747

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
         giscedata_facturacio_comer_som
- [x] Script de migració
- [ ] Modifica traduccions
