### PR TITLE
somutils torna a ser compatible amb Python 2.7

### DIFF
--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -133,13 +133,13 @@ jobs:
           cd $ROOT_DIR_SRC
           pip install -r $ROOT_DIR_SRC/erp/requirements-dev.txt
           pip install -r $ROOT_DIR_SRC/erp/requirements.txt
+          pip install somutils
 
       - name: Install dependecies for Python 3
         if: matrix.python-version != '2.7'
         run: |
           export ROOT_DIR_SRC=${{github.workspace}}/..
           . $ROOT_DIR_SRC/venv/bin/activate
-          pip install somutils
           pip install dm.xmlsec.binding
 
       - name: Install dependencies for Python 2.7
@@ -147,9 +147,6 @@ jobs:
         run: |
           export ROOT_DIR_SRC=${{github.workspace}}/..
           . $ROOT_DIR_SRC/venv/bin/activate
-          git clone --depth 1 https://github.com/Som-Energia/somenergia-utils.git -b py2 $ROOT_DIR_SRC/somenergia-utils
-          cd $ROOT_DIR_SRC/somenergia-utils
-          pip install -e . || "Not installing somenergia-utils Python package"
           pip install "dm.xmlsec.binding<=1.3.2"
 
       - name: Link Addons


### PR DESCRIPTION
## Objectiu
Desfer el hack per poder instal·lar versions diferents de somutils segons versió de python, ja que s'ha publicat nova versió del paquet que restaura la compatibilitat amb Python 2.7 https://github.com/Som-Energia/somenergia-utils/releases/tag/somutils-1.10.0

## Targeta on es demana o Incidència
Xat

## Comportament antic
S'instal·lava la última versió de somutils compatible per python 2.7

## Comportament nou
S'instal·la sempre la última versió de somutils