### PR TITLE
Indicar ESIOS Token en el cálcul per Balears i Canàries

### DIFF
--- a/som_indexada/giscedata_hourly_energy_price.py
+++ b/som_indexada/giscedata_hourly_energy_price.py
@@ -314,6 +314,7 @@ class GiscedataNextDaysEnergyPrice(osv.osv):
         pc3_ree = classname('A1_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         si = SIFree('A1_sifree_%(postfix)s' % locals(), esios_token)  # noqa: F405 [€/MWh]
         ree = Tarifa.get_coeficient_component(data_inici_dt, 'om')  # [€/MWh]
+        Tarifa.get_perdclass()
         perdfname = Tarifa.perdclass.name
         perdues = Tarifa.perdclass('A1_%(perdfname)s_%(postfix)s' % locals(), esios_token)  # [%]
 

--- a/som_indexada/giscedata_hourly_energy_price.py
+++ b/som_indexada/giscedata_hourly_energy_price.py
@@ -148,8 +148,8 @@ class GiscedataNextDaysEnergyPrice(osv.osv):
         perdues = Tarifa.perdclass('A1_%(perdfname)s_%(postfix)s' % locals(), esios_token)  # [%]
 
         # Desvios
-        scdsvdem = Scdsvdem('C2_Scdsvdem_%(postfix)s' % locals())  # noqa: F405 [€/MWh]
-        factor_dsv = self.get_coeficient_component(data_inici_dt, 'factor_dsv')  # [%]
+        scdsvdem = Scdsvdem('C2_Scdsvdem_%(postfix)s' % locals(), esios_token)  # noqa: F405 [€/MWh]
+        factor_dsv = Tarifa.get_coeficient_component(data_inici_dt, 'factor_dsv')  # [%]
         dsv = scdsvdem * (factor_dsv * 0.01)
 
         # NON-VARIABLE COMPONENTS PRICE OBTENTION
@@ -158,7 +158,7 @@ class GiscedataNextDaysEnergyPrice(osv.osv):
         pa = Tarifa.get_peaje_component(data_inici_dt, holidays)  # [€/kWh]
         k = Tarifa.get_coeficient_component(data_inici_dt, 'k')  # [€/kWh]
         d = Tarifa.get_coeficient_component(data_inici_dt, 'd')  # [€/kWh]
-        gdos = self.get_coeficient_component(data_inici_dt, 'gdos')  # [€/MWh]
+        gdos = Tarifa.get_coeficient_component(data_inici_dt, 'gdos')  # [€/MWh]
 
         A = ((sphdem + pc3_ree + dsv + ree + gdos) * 0.001)
         B = (1 + (perdues * 0.01))
@@ -306,7 +306,7 @@ class GiscedataNextDaysEnergyPrice(osv.osv):
 
         # Desvios
         scdsvdem = Scdsvdem('C2_Scdsvdem_%(postfix)s' % locals())  # noqa: F405 [€/MWh]
-        factor_dsv = self.get_coeficient_component(data_inici_dt, 'factor_dsv')  # [%]
+        factor_dsv = Tarifa.get_coeficient_component(data_inici_dt, 'factor_dsv')  # [%]
         dsv = scdsvdem * (factor_dsv * 0.01)
 
         filename = 'Sprpcap{}_{}'.format(Tarifa.code.replace('.', ''), 'CANARIAS')
@@ -323,7 +323,7 @@ class GiscedataNextDaysEnergyPrice(osv.osv):
         pa = Tarifa.get_peaje_component(data_inici_dt, holidays)  # [€/kWh]
         k = Tarifa.get_coeficient_component(data_inici_dt, 'k')  # [€/kWh]
         d = Tarifa.get_coeficient_component(data_inici_dt, 'd')  # [€/kWh]
-        gdos = self.get_coeficient_component(data_inici_dt, 'gdos')  # [€/MWh]
+        gdos = Tarifa.get_coeficient_component(data_inici_dt, 'gdos')  # [€/MWh]
 
         A = ((sphdem + pc3_ree + ree + gdos + dsv) * 0.001)
         B = (1 + (perdues * 0.01))


### PR DESCRIPTION
## Objectiu

Habilitar al càlcul del preu mensual pels subsistemes CAN i BAL

## Targeta on es demana o Incidència

Incidència comunicada a través d'Slack

## Comportament antic

No es calculava en cas de no tenir els fitxers en cache

## Comportament nou

S'indica l'ESIOS Token a fer servir per a la descàrrega.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
