### PR TITLE
🐛 (atr) Arreglar canvi de nom d'una funció "punxada"

### DIFF
--- a/som_atc/models/giscedata_switching_helpers.py
+++ b/som_atc/models/giscedata_switching_helpers.py
@@ -41,8 +41,8 @@ class GiscedataSwitchingHelpers(osv.osv):
         self._tmp_atc_ids = atc_ids  # Trick to temporally save the ATC_IDS
         return atc_ids
 
-    def _crear_autoconsum(self, cursor, uid, step, autoconsum_id, context=None):
-        res = super(GiscedataSwitchingHelpers, self)._crear_autoconsum(
+    def _crear_autoconsum_from_d1(self, cursor, uid, step, autoconsum_id, context=None):
+        res = super(GiscedataSwitchingHelpers, self)._crear_autoconsum_from_d1(
             cursor, uid, step, autoconsum_id, context
         )
         # We're in the same transaction, we can recover the case_ids from memory


### PR DESCRIPTION
## Objectiu
No es cridaven canvis fets pels D1 perquè el nom de la funció s'ha canviat

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/7906036?folder_id=87

## Comportament antic
Es cridava _crear_autoconsum

## Comportament nou
Es crida _crear_autoconsum_from_d1

## Comprovacions

- [ ] Reiniciar ERP
