### PR TITLE
FIX arreglar enviament de correus quan les dades venen en unicode

### DIFF
--- a/som_autoreclama/som_autoreclama_state_updater.py
+++ b/som_autoreclama/som_autoreclama_state_updater.py
@@ -227,7 +227,12 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
 
         subject = _(u"Resultat accions batch d'autoreclama")
         msg = self.state_updater(cursor, uid, context)
-        emails_to = filter(lambda a: bool(a), map(str.strip, data.get("emails_to", "").split(",")))  # noqa: E501
+        emails_to = data.get("emails_to", "").split(",")
+        emails = []
+        for email_to in emails_to:
+            if email_to:
+                emails.append(email_to.strip())
+        emails_to = emails
 
         if emails_to:
             user_obj = self.pool.get("res.users")

--- a/som_infoenergia/giscedata_polissa.py
+++ b/som_infoenergia/giscedata_polissa.py
@@ -238,7 +238,12 @@ class GiscedataPolissaInfoenergia(osv.osv):
 
         subject = _(u"Resultat accions update de consum anual")
         msg = self._conany_updater(cursor, uid, context)
-        emails_to = filter(lambda a: bool(a), map(str.strip, data.get("emails_to", "").split(",")))
+        emails_to = data.get("emails_to", "").split(",")
+        emails = []
+        for email_to in emails_to:
+            if email_to:
+                emails.append(email_to.strip())
+        emails_to = emails
         if emails_to:
             user_obj = self.pool.get("res.users")
             email_from = user_obj.browse(cursor, uid, uid).address_id.email


### PR DESCRIPTION
## Objectiu

A partir de la intervenció, les cadenes son unicode i el codi existent falla

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/7905822?folder_id=87

## Comportament antic

Falla i fa rollback

## Comportament nou

No falla i envia el que ha d'enviar

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
      - ERP crons
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
