### PR TITLE
No assignar pòlisses cancelades/baixa al servei de generacio al importar participants

### DIFF
--- a/som_auvidi/giscedata_polissa.py
+++ b/som_auvidi/giscedata_polissa.py
@@ -65,7 +65,7 @@ class GiscedataPolissaModcontractual(osv.osv):
             if current_te_auvidi:
                 polissa_obj.handle_polissa_sg_category(
                     cursor, uid, polissa_id, action='assign', context=context)
-                # # Actualitzem data inici si fa falta
+                # Actualitzem data inici si fa falta
                 info = sg_polissa_obj.check_actualitzar_data_inici(
                     cursor, uid, sg_pol_id, modcon.data_inici
                 )

--- a/som_auvidi/giscedata_polissa.py
+++ b/som_auvidi/giscedata_polissa.py
@@ -63,13 +63,15 @@ class GiscedataPolissaModcontractual(osv.osv):
         sg_pol_id = sg_polissa_obj.search(cursor, uid, [('polissa_id', '=', polissa_id)])
         if len(sg_pol_id):
             if current_te_auvidi:
-                polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='assign', context=context)
+                polissa_obj.handle_polissa_sg_category(
+                    cursor, uid, polissa_id, action='assign', context=context)
                 # # Actualitzem data inici si fa falta
                 info = sg_polissa_obj.check_actualitzar_data_inici(
                     cursor, uid, sg_pol_id, modcon.data_inici
                 )
             elif cancels_auvidi:
-                polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='unassign', context=context)
+                polissa_obj.handle_polissa_sg_category(
+                    cursor, uid, polissa_id, action='unassign', context=context)
                 # Actualitzem data sortida si fa falta
                 data_inici_modcon = datetime.strptime(modcon.data_inici, '%Y-%m-%d')
                 data_sortida_sg = data_inici_modcon - timedelta(days=1)
@@ -79,7 +81,7 @@ class GiscedataPolissaModcontractual(osv.osv):
                 )
 
             if info:
-                observacions = modcon.observacions + info
+                observacions = (modcon.observacions or '') + info
                 modcon.write({'observacions': observacions})
 
         return res

--- a/som_auvidi/giscedata_polissa.py
+++ b/som_auvidi/giscedata_polissa.py
@@ -48,7 +48,6 @@ class GiscedataPolissaModcontractual(osv.osv):
             cursor, uid, mod_id, polissa_id=polissa_id
         )
         polissa_obj = self.pool.get('giscedata.polissa')
-        servei_gen_obj = self.pool.get('giscedata.servei.generacio')
         sg_polissa_obj = self.pool.get('giscedata.servei.generacio.polissa')
 
         if not polissa_id:
@@ -64,13 +63,13 @@ class GiscedataPolissaModcontractual(osv.osv):
         sg_pol_id = sg_polissa_obj.search(cursor, uid, [('polissa_id', '=', polissa_id)])
         if len(sg_pol_id):
             if current_te_auvidi:
-                sg_polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='assign', context=context)
+                polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='assign', context=context)
                 # # Actualitzem data inici si fa falta
                 info = sg_polissa_obj.check_actualitzar_data_inici(
                     cursor, uid, sg_pol_id, modcon.data_inici
                 )
             elif cancels_auvidi:
-                sg_polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='unassign', context=context)
+                polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='unassign', context=context)
                 # Actualitzem data sortida si fa falta
                 data_inici_modcon = datetime.strptime(modcon.data_inici, '%Y-%m-%d')
                 data_sortida_sg = data_inici_modcon - timedelta(days=1)

--- a/som_auvidi/giscedata_polissa.py
+++ b/som_auvidi/giscedata_polissa.py
@@ -59,53 +59,30 @@ class GiscedataPolissaModcontractual(osv.osv):
         cancels_auvidi = (modcon.modcontractual_ant
                           and modcon.modcontractual_ant.te_auvidi
                           and not modcon.te_auvidi)
+        context = {}
+        info = ''
+        sg_pol_id = sg_polissa_obj.search(cursor, uid, [('polissa_id', '=', polissa_id)])
+        if len(sg_pol_id):
+            if current_te_auvidi:
+                sg_polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='assign', context=context)
+                # # Actualitzem data inici si fa falta
+                info = sg_polissa_obj.check_actualitzar_data_inici(
+                    cursor, uid, sg_pol_id, modcon.data_inici
+                )
+            elif cancels_auvidi:
+                sg_polissa_obj.handle_polissa_sg_category(cursor, uid, polissa_id, action='unassign', context=context)
+                # Actualitzem data sortida si fa falta
+                data_inici_modcon = datetime.strptime(modcon.data_inici, '%Y-%m-%d')
+                data_sortida_sg = data_inici_modcon - timedelta(days=1)
+                data_sortida_sg_str = data_sortida_sg.strftime('%Y-%m-%d')
+                info = sg_polissa_obj.check_actualitzar_data_sortida(
+                    cursor, uid, sg_pol_id, data_sortida_sg_str
+                )
 
-        if current_te_auvidi or cancels_auvidi:
-            sg_pol_id = sg_polissa_obj.search(cursor, uid, [('polissa_id', '=', polissa_id)])
-            if len(sg_pol_id):
-                sg_pol_data = sg_polissa_obj.read(
-                    cursor, uid, sg_pol_id[0], ['servei_generacio_id'])
-                if sg_pol_data.get('servei_generacio_id'):
-                    servei_gen_id = sg_pol_data.get('servei_generacio_id', [False])[0]
-                    if servei_gen_id:
-                        categoria_polissa = servei_gen_obj.read(
-                            cursor, uid, servei_gen_id, ['categoria_polissa']
-                        ).get('categoria_polissa')
-                        polissa_current_categories = polissa_obj.read(
-                            cursor, uid, polissa_id, ['category_id']
-                        ).get('category_id', [])
-                        polissa_current_categories = list(set(polissa_current_categories))
-                        new_categories = []
-                        # If AUVIDI is cancelled we must remove category
-                        if (cancels_auvidi
-                                and categoria_polissa
-                                and categoria_polissa[0] in polissa_current_categories):
-                            polissa_current_categories.remove(categoria_polissa[0])
-                            new_categories = polissa_current_categories
-                        # If AUVIDI and there's no category we must add it
-                        elif (current_te_auvidi
-                              and categoria_polissa
-                              and categoria_polissa[0] not in polissa_current_categories):
-                            new_categories = polissa_current_categories + [categoria_polissa[0]]
+            if info:
+                observacions = modcon.observacions + info
+                modcon.write({'observacions': observacions})
 
-                        if new_categories:
-                            polissa_obj.write(cursor, uid, polissa_id, {
-                                'category_id': [(6, 0, new_categories)]})
-                info = ''
-                if current_te_auvidi:
-                    info = sg_polissa_obj.check_actualitzar_data_inici(
-                        cursor, uid, sg_pol_id, modcon.data_inici
-                    )
-                elif cancels_auvidi:
-                    data_inici_modcon = datetime.strptime(modcon.data_inici, '%Y-%m-%d')
-                    data_sortida_sg = data_inici_modcon - timedelta(days=1)
-                    data_sortida_sg_str = data_sortida_sg.strftime('%Y-%m-%d')
-                    info = sg_polissa_obj.check_actualitzar_data_sortida(
-                        cursor, uid, sg_pol_id, data_sortida_sg_str
-                    )
-                if info:
-                    observacions = modcon.observacions + info
-                    modcon.write({'observacions': observacions})
         return res
 
     _columns = {

--- a/som_auvidi/wizard/wizard_load_servei_gen_records_from_file.py
+++ b/som_auvidi/wizard/wizard_load_servei_gen_records_from_file.py
@@ -7,20 +7,6 @@ class WizardLoadServeiGenRecordsFromFile(osv.osv_memory):
     _name = 'wizard.load.servei.gen.records.from.file'
     _inherit = 'wizard.load.servei.gen.records.from.file'
 
-    def get_polissa_from_record_data(self, cursor, uid, cups_name, data, context=None):
-        if context is None:
-            context = {}
-
-        pol_obj = self.pool.get('giscedata.polissa')
-
-        ctx = context.copy()
-        ctx.update({'active_test': False})
-        polissa_id = pol_obj.search(cursor, uid, [
-            ('cups.name', '=', cups_name),
-        ], order='id desc', context=ctx)
-
-        return polissa_id
-
     def get_aux_dict_from_row(self, cursor, uid, row, tipus='contracte', context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
## Objectiu

No assignar pòlisses cancelades/baixa al servei de generacio al importar participants

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/517/activity

## Comportament antic

- Es buscava qualssevol pòlissa amb el mateix CUPS

## Comportament nou

- S'ignoren les pòlisses `cancel·lades` o en estat de `baixa`

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
