### PR TITLE
Desempaquetar els fitxers baixats de la distri Constancia-Aren

### DIFF
--- a/som_crawlers/models/som_crawlers_task_step.py
+++ b/som_crawlers/models/som_crawlers_task_step.py
@@ -271,6 +271,13 @@ class SomCrawlersTaskStep(osv.osv):
                     new_zip_path = os.path.join(root, filename)
                     self.recursive_extract_zip(new_zip_path, root)
                     return True
+            for sub in dirs:
+                sub_path = os.path.join(root, sub)
+                for f in os.listdir(sub_path):
+                    src = os.path.join(sub_path, f)
+                    dst = os.path.join(root, f)
+                    shutil.move(src, dst)
+                os.rmdir(sub_path)
 
         for root, dirs, files in os.walk(destination_path):
             for filename in files:


### PR DESCRIPTION
## Objectiu
El portal de Constancia-Aren ha canviat i ara al baixar els fitxers, els baixa en carpetes. Per poder-los carregar correctament al ERP primer els hem de treure.

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/471/activity

## Comportament antic
No funcionava la càrrega de fitxes XML perquè estaven dins d'un zip amb carpetes

## Comportament nou
Carrega al ERP un zip de fitxers .xml sense carpetes intermitges

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
