### PR TITLE
🐛 (leads): Millor no activar els leads per defecte a l'assistent

### DIFF
--- a/som_leads_polissa/wizard/wizard_importador_leads_comercials.py
+++ b/som_leads_polissa/wizard/wizard_importador_leads_comercials.py
@@ -54,5 +54,9 @@ class WizardImportarLeadsComercials(osv.osv):
         "coeficient_k": fields.float("Coeficient K €/MWh", digits=(5, 3)),
     }
 
+    _defaults = {
+        'activate_leads': lambda *a: False,
+    }
+
 
 WizardImportarLeadsComercials()

--- a/som_leads_polissa/wizard/wizard_importador_leads_comercials_view.xml
+++ b/som_leads_polissa/wizard/wizard_importador_leads_comercials_view.xml
@@ -7,7 +7,7 @@
             <field name="type">form</field>
             <field name="inherit_id" ref="giscedata_crm_importador.view_wizard_importar_leads"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='activate_leads']" position="replace">
+                <xpath expr="//field[@name='activate_leads']" position="after">
                     <field name="llista_preus" colspan="2"/>
                     <field name="atr_proces_name" colspan="2"/>
                 </xpath>


### PR DESCRIPTION
## Objectiu
Els leads si tenien totes les dades possibles s'activaven i creaven la pòlissa

## Targeta on es demana o Incidència
És un comportament no desitjat

## Comportament antic
S'activava automàticament 

## Comportament nou
No l'activem automàticament

## Comprovacions
Reiniciar ERP
