### PR TITLE
Arreglar la visualització del bo social partit a la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3266,28 +3266,32 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_invoice_details_td_bo_social_2023_data(self, fact, pol):
-        days = 0.0
-        price_per_day = 0.0
-        subtotal = 0.0
         visible = False
-        iva = ""
-
+        rbs_price_per_days = {}
+        rbs_lines = []
         for l in fact.linia_ids:  # noqa: E741
             if l.tipus in "altres" and l.invoice_line_id.product_id.code == "RBS":
-                days += l.quantity
-                price_per_day = l.price_unit
-                subtotal += l.price_subtotal
-                iva = get_iva_line(l)
+                if l.price_unit not in rbs_price_per_days:
+                    line = {
+                        "days": l.quantity,
+                        "price_per_day": l.price_unit,
+                        "subtotal": l.price_subtotal,
+                        "iva": get_iva_line(l),
+                    }
+                    rbs_price_per_days[l.price_unit] = line
+                    rbs_lines.append(line)
+                else:
+                    line = rbs_price_per_days[l.price_unit]
+                    line["days"] += l.quantity
+                    line["subtotal"] += l.price_subtotal
                 visible = True
 
         data = {
             "is_visible": visible,
             "number_of_columns": len(self.get_matrix_show_periods(pol)) + 1,
-            "days": days,
-            "price_per_day": price_per_day,
-            "subtotal": subtotal,
             "iva_column": has_iva_column(fact),
-            "iva": iva,
+            "lines": rbs_lines,
+            "header_multi": len(rbs_lines),
         }
         return data
 

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako
@@ -2,13 +2,19 @@
 %if bs.is_visible:
 <%
 import locale
+first_pass = True
 %>
-    <tr class="tr_bold last_row">
-        <td class="td_first concepte_td">${_(u"Bo social")}</td>
-        <td class="detall_td" colspan="${bs.number_of_columns}">${_(u"%s dies x %s €/dia") % (int(bs.days), locale.str(locale.atof(formatLang(bs.price_per_day, digits=6))))}</td>
-        <td class="subtotal">${_(u"%s €") % formatLang(bs.subtotal)}</td>
-        % if bs.iva_column:
-            <td>${_(u"%s") % (bs.iva) }</td>
+% for l in bs.lines:
+    <tr class="tr_bold ${'last_row' if bs.lines[-1] == l else ''}">
+        % if first_pass:
+            <td class="td_first concepte_td" rowspan=${bs.header_multi}>${_(u"Bo social")}</td>
+            <%first_pass = False%>
         % endif
+            <td class="detall_td" colspan="${bs.number_of_columns}">${_(u"%s dies x %s €/dia") % (int(l['days']), locale.str(locale.atof(formatLang(l['price_per_day'], digits=6))))}</td>
+            <td class="subtotal">${_(u"%s €") % formatLang(l['subtotal'])}</td>
+            % if bs.iva_column:
+                <td>${_(u"%s") % (l['iva']) }</td>
+            % endif
     </tr>
+% endfor
 %endif


### PR DESCRIPTION
## Objectiu

Amb el canvi d'any arribe linies de repercusió del bo social dividides per dates, cal arreglar la visualització del bo social partit a la factura en pdf

NOTA: es modifica el mako amb compte de no tocar les línies per no tenir que refer les traduccions

## Targeta on es demana o Incidència

Incidència facturació #2025 #happynewyear

## Comportament antic

Es mostra una única línia sumat els conceptes però mostra malament el preu

## Comportament nou

Es mostren 2 línies separades

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
