### PR TITLE
No agrupar línies en cas de factures que tinguin periode entre el canvi d'any (2)

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio.py
+++ b/som_facturacio_comer/giscedata_facturacio.py
@@ -60,8 +60,8 @@ class GiscedataFacturacioFacturador(osv.osv):
 
         if factura_id or 'factura_id' in vals:
             factura_obj = self.pool.get('giscedata.facturacio.factura')
-            factura_info = factura_obj.read(cursor, uid, factura_id, ['data_inici', 'data_final'])
-            if factura_info and 'data_inici' in factura_info and 'data_final' in factura_info:
+            factura_info = factura_obj.read(cursor, uid, factura_id, ['type', 'data_inici', 'data_final'])
+            if factura_info and factura_info['type'] in ('out_invoice', 'out_refund') and factura_info.get("data_inici") and factura_info.get("data_final"):
                 any_desde = datetime.strptime(factura_info['data_inici'], '%Y-%m-%d').year
                 any_fins = datetime.strptime(factura_info['data_final'], '%Y-%m-%d').year
                 if any_desde != any_fins:


### PR DESCRIPTION


## Objectiu

Continuació de https://github.com/Som-Energia/openerp_som_addons/pull/788

Evita que falli quan es creen linies en factures sense data inicio i/o fi (F1 de linies extra, per exemple).

