### PR TITLE
Incrementa a 2 cèntims el llidar de flux solar

### DIFF
--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -145,7 +145,7 @@ class GiscedataFacturacioFacturador(osv.osv):
         max_descompte = uber_round(max_descompte)
 
         # Last check:
-        if max_descompte - 0.02 < fact.amount_total < max_descompte + 0.02:
+        if max_descompte - 0.02 <= fact.amount_total <= max_descompte + 0.02:
             max_descompte = fact.amount_total
 
         return linies_utilitzades_ids, max_descompte


### PR DESCRIPTION
## Objectiu

Incrementa a 2 cèntims el llidar de flux solar

## Targeta on es demana o Incidència

240685

## Comportament antic

Es limitava el llindar per a recalcular el total a descomptar de Flux Solar a 1 cèntim.

## Comportament nou

Es limita a 2 cèntims per que per temes d'arrodoniment de Python pot desquadrar d'un cèntim al càlcul de l'IVA i per un altre cèntim al càlcul de l'IESE.

