### PR TITLE
[CiF] Remesa Ajuntaments 1,5% per factura

### DIFF
--- a/som_municipal_taxes/__terp__.py
+++ b/som_municipal_taxes/__terp__.py
@@ -25,8 +25,9 @@
         'wizard/wizard_presentacio_redsaras.xml',
         'security/som_municipal_taxes_security.xml',
         'security/ir.model.access.csv',
+        'tests/som_municipal_taxes_demo.xml',
     ],
     'demo_xml': [
-        'tests/som_municipal_taxes_demo.xml',
+        'demo/som_municipal_taxes_demo.xml',
     ]
 }

--- a/som_municipal_taxes/__terp__.py
+++ b/som_municipal_taxes/__terp__.py
@@ -25,7 +25,6 @@
         'wizard/wizard_presentacio_redsaras.xml',
         'security/som_municipal_taxes_security.xml',
         'security/ir.model.access.csv',
-        'tests/som_municipal_taxes_demo.xml',
     ],
     'demo_xml': [
         'demo/som_municipal_taxes_demo.xml',

--- a/som_municipal_taxes/data/som_municipal_taxes_data.xml
+++ b/som_municipal_taxes/data/som_municipal_taxes_data.xml
@@ -1,8 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
  	<data>
-        <record id="res_partner_category_ajuntament" model="res.partner.category">
+        <record model="res.partner.category" id="res_partner_category_ajuntament">
             <field name="name">Ajuntament</field>
+        </record>
+        <record model="ir.sequence.type" id="seq_type_som_aportacions">
+            <field name="name">Tipus de seqüència per a les factures d'impostos municipals</field>
+            <field name="code">seq.som.municipal.taxes</field>
+        </record>
+        <record model="ir.sequence" id="seq_som_aportacions">
+            <field name="name">Seq. Factures Impost municipal taxa 1,5%</field>
+            <field name="code">seq.som.municipal.taxes</field>
+            <field name="padding">6</field>
+            <field name="number_increment">1</field>
+            <field name="prefix">MUN_TAX</field>
+        </record>
+        <record model="account.journal" id="municipal_tax_journal">
+            <field name="account_control_ids" eval="[(6,0,[])]"/>
+            <field name="active" eval="1"/>
+            <field name="cash_journal" eval="0"/>
+            <field name="centralisation" eval="0"/>
+            <field name="code">MUN_TAX</field>
+            <field name="default_credit_account_id" model="account.account" search="[('code','=','600000000300')]"/>
+            <field name="default_debit_account_id" model="account.account" search="[('code','=','600000000300')]"/>
+            <field name="entry_posted" eval="1"/>
+            <field name="group_invoice_lines" eval="0"/>
+            <field name="include_to_iva_book" eval="0"/>
+            <field name="invoice_sequence_id" eval="seq_som_aportacions"/>
+            <field name="name">Factures impost municipal 1,5%</field>
+            <field name="refund_journal" eval="0"/>
+            <field name="sequence_id" ref="account.sequence_journal"/>
+            <field name="sii_to_send" eval="False"/>
+            <field name="type">purchase</field>
+            <field name="type_control_ids" eval="[(6,0,[])]"/>
+            <field name="update_posted" eval="1"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="view_id" ref="account.account_journal_bank_view"/>
         </record>
     </data>
 </openerp>

--- a/som_municipal_taxes/demo/som_municipal_taxes_demo.xml
+++ b/som_municipal_taxes/demo/som_municipal_taxes_demo.xml
@@ -41,7 +41,7 @@
         </record>
         <record id="tax_account" model="account.account">
             <field name="name">Taxa 1,5%</field>
-            <field name="code">411000000000</field>
+            <field name="code">410000000000</field>
             <field name="type">payable</field>
             <field eval="ref('account.minimal_0')" name="parent_id"/>
             <field name="company_id" ref="base.main_company"/>

--- a/som_municipal_taxes/demo/som_municipal_taxes_demo.xml
+++ b/som_municipal_taxes/demo/som_municipal_taxes_demo.xml
@@ -39,5 +39,29 @@
             <field name="payment">quarter</field>
             <field name="bank_id" ref="catalunya_bank" />
         </record>
+        <record id="tax_account" model="account.account">
+            <field name="name">Taxa 1,5%</field>
+            <field name="code">411000000000</field>
+            <field name="type">payable</field>
+            <field eval="ref('account.minimal_0')" name="parent_id"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field eval="True" name="reconcile"/>
+            <field name="user_type" ref="l10n_chart_ES.terceros - pay"/>
+            <field name="note">
+                Compte comptable de les taxes
+            </field>
+        </record>
+        <record id="debt_account" model="account.account">
+            <field name="name">Taxa 1,5%</field>
+            <field name="code">600000000300</field>
+            <field name="type">other</field>
+            <field eval="ref('account.minimal_0')" name="parent_id"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field eval="False" name="reconcile"/>
+            <field name="user_type" ref="account.account_type_expense"/>
+            <field name="note">
+                Compte comptable de despesa
+            </field>
+        </record>
     </data>
 </openerp>

--- a/som_municipal_taxes/demo/som_municipal_taxes_demo.xml
+++ b/som_municipal_taxes/demo/som_municipal_taxes_demo.xml
@@ -10,12 +10,31 @@
             <field name="iban">ES7620382201213796191838</field>
             <field name="default_bank">True</field>
         </record>
+        <record model="res.partner.bank" id="castilla_bank">
+            <field name="name">Banc partner Castilla Mancha</field>
+            <field name="acc_number">14651298606461177215</field>
+            <field name="partner_id" ref="giscedata_switching.sw_ccaa_08_castilla_la_mancha"/>
+            <field name="state">iban</field>
+            <field name="bank" ref="base.partner_bank"/>
+            <field name="iban">ES6514651298606461177215</field>
+            <field name="default_bank">True</field>
+        </record>
         <record id="ajuntament_girona" model="som.municipal.taxes.config">
             <field name="name">Ajuntament Alegría-Dulantzi</field>
             <field name="municipi_id" ref="base_extended.ine_01001" />
             <field name="partner_id" ref="giscedata_switching.sw_ccaa_09_catalunya" />
             <field name="payment_order" eval="1" />
             <field name="red_sara" eval="1" />
+            <field name="active" eval="1" />
+            <field name="payment">quarter</field>
+            <field name="bank_id" ref="catalunya_bank" />
+        </record>
+        <record id="ajuntament_olot" model="som.municipal.taxes.config">
+            <field name="name">Ajuntament Olot</field>
+            <field name="municipi_id" ref="base_extended.ine_17114" />
+            <field name="partner_id" ref="giscedata_switching.sw_ccaa_08_castilla_la_mancha" />
+            <field name="payment_order" eval="1" />
+            <field name="red_sara" eval="0" />
             <field name="active" eval="1" />
             <field name="payment">quarter</field>
             <field name="bank_id" ref="catalunya_bank" />

--- a/som_municipal_taxes/migrations/5.0.24.9.0/post-00003_new_journal_som_municipal_taxes.py
+++ b/som_municipal_taxes/migrations/5.0.24.9.0/post-00003_new_journal_som_municipal_taxes.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Creating pooler")
+    pooler.get_pool(cursor.dbname)
+
+    views = [
+        'data/som_municipal_taxes_data.xml',
+    ]
+
+    for view in views:
+        # Crear les diferents vistes
+        logger.info("Updating XML {}".format(view))
+        load_data(cursor, 'som_municipal_taxes', view, idref=None, mode='update')
+        logger.info("XMLs succesfully updatd.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_municipal_taxes/migrations/5.0.24.9.0/post-00003_new_journal_som_municipal_taxes.py
+++ b/som_municipal_taxes/migrations/5.0.24.9.0/post-00003_new_journal_som_municipal_taxes.py
@@ -15,6 +15,8 @@ def up(cursor, installed_version):
 
     views = [
         'data/som_municipal_taxes_data.xml',
+        'wizard/wizard_creacio_remesa_pagament_taxes.xml',
+        'wizard/wizard_presentacio_redsaras.xml',
     ]
     for view in views:
         # Crear les diferents vistes

--- a/som_municipal_taxes/migrations/5.0.24.9.0/post-00003_new_journal_som_municipal_taxes.py
+++ b/som_municipal_taxes/migrations/5.0.24.9.0/post-00003_new_journal_som_municipal_taxes.py
@@ -9,19 +9,42 @@ def up(cursor, installed_version):
         return
 
     logger = logging.getLogger('openerp.migration')
-
     logger.info("Creating pooler")
-    pooler.get_pool(cursor.dbname)
+    pool = pooler.get_pool(cursor.dbname)
+    uid = 1
 
     views = [
         'data/som_municipal_taxes_data.xml',
     ]
-
     for view in views:
         # Crear les diferents vistes
         logger.info("Updating XML {}".format(view))
         load_data(cursor, 'som_municipal_taxes', view, idref=None, mode='update')
         logger.info("XMLs succesfully updatd.")
+
+    logger.info("Creating partner_address and vat for City Hall")
+    # Crear partner_address i vat per l'ajuntament
+    partner_obj = pool.get('res.partner')
+    partner_address_obj = pool.get('res.partner.address')
+    category_id = pool.get('ir.model.data').get_object_reference(
+        cursor, uid, 'som_municipal_taxes', 'res_partner_category_ajuntament')
+    # Search for a partner with category res_partner_category_ajuntament
+    partner_ids = partner_obj.search(cursor, uid, [('category_id', '=', category_id[1])])
+    for patner_id in partner_ids:
+        partner = partner_obj.browse(cursor, uid, patner_id)
+        if not partner.vat:
+            partner.write({
+                'vat': 'ES00000001R',
+                'comment': 'NIF fictici ES00000001R per a l\'ajuntament necessari per fer les \
+                    factures del 1,5%. Si necessiteu el real, el podeu \
+                    posar\n\n {}'.format(partner.comment),
+            })
+        if not partner_address_obj.search(cursor, uid, [('partner_id', '=', partner.id)]):
+            partner_address_obj.create(cursor, uid, {
+                'partner_id': partner.id,
+                'name': partner.name,
+                'is_default': True,
+            })
 
 
 def down(cursor, installed_version):

--- a/som_municipal_taxes/tests/test_wizard_creacio_remesa_pagament_taxes.py
+++ b/som_municipal_taxes/tests/test_wizard_creacio_remesa_pagament_taxes.py
@@ -87,6 +87,63 @@ class TestWizardCreacioRemesaPagamentTaxes(testing.OOTestCaseWithCursor):
             )
             self.assertIn("Ja s'ha pagat el trimestre", validate_error.exception.message)
 
+    @mock.patch.object(FacturacioExtra, "get_states_invoiced")
+    def test__crear_factures__ok(self, get_states_invoiced_mock):
+        get_states_invoiced_mock.return_value = ['draft', 'open', 'paid']
+        wiz_o = self.pool.get("wizard.creacio.remesa.pagament.taxes")
+        order_o = self.pool.get("payment.order")
+        payment_mode_id = self.pool.get("ir.model.data").get_object_reference(
+            self.cursor, self.uid, "account_invoice_som", "payment_mode_0001"
+        )[1]
+
+        # Create the wizard
+        wiz_o.create(
+            self.cursor,
+            self.uid,
+            {
+                "account": 7,
+                "payment_mode": payment_mode_id,
+                "year": 2016,
+                "quarter": 1,
+            },
+            context={},
+        )
+
+        # Mock totals_by_city data
+        totals_by_city = [
+            ["City1", "Province1", 1, 44001, 1500, "01001"],
+            ["City2", "Province2", 1, 2000, 2500, "17114"],
+        ]
+
+        # Call the method to create invoices
+        order_id, info = wiz_o.crear_factures(
+            self.cursor,
+            self.uid,
+            totals_by_city,
+            payment_mode_id,  # payment_mode_id
+            7,  # account_id
+            2016,  # year
+            context={},
+        )
+
+        # Verify the payment order was created
+        po = order_o.browse(self.cursor, self.uid, order_id)
+        self.assertIsNotNone(po)
+        self.assertEqual(po.state, 'draft')
+        self.assertEqual(po.mode.id, payment_mode_id)
+
+        # Verify the invoices were created and linked to the payment order
+        invoice_ids = po.line_ids
+        self.assertGreater(len(invoice_ids), 0)
+
+        for invoice in invoice_ids:
+            self.assertEqual(invoice.ml_inv_ref.state, 'open')
+            self.assertEqual(invoice.ml_inv_ref.account_id.id, 7)
+            self.assertEqual(invoice.ml_inv_ref.currency_id.code, 'EUR')
+
+        # Verify the info message
+        self.assertIn("S'ha creat la remesa amb", info)
+
     def test_get_dates_from_quarter(self):
         assert get_dates_from_quarter(2024, 1) == (
             datetime.date(2024, 1, 1),

--- a/som_municipal_taxes/tests/test_wizard_creacio_remesa_pagament_taxes.py
+++ b/som_municipal_taxes/tests/test_wizard_creacio_remesa_pagament_taxes.py
@@ -112,7 +112,7 @@ class TestWizardCreacioRemesaPagamentTaxes(testing.OOTestCaseWithCursor):
 
         # Mock totals_by_city data
         totals_by_city = [
-            ["City1", 2016, 1.0, 44001.0, 1500.0, "01001"],
+            ["City1", 2016, 1.0, 1230.0, 1500.0, "01001"],
             ["City2", 2016, 1.0, 2000.0, 2500.0, "17114"],
         ]
 
@@ -132,6 +132,7 @@ class TestWizardCreacioRemesaPagamentTaxes(testing.OOTestCaseWithCursor):
         self.assertIsNotNone(po)
         self.assertEqual(po.state, 'draft')
         self.assertEqual(po.mode.id, payment_mode_id)
+        self.assertEqual(po.total, 11.55)
 
         # Verify the invoices were created and linked to the payment order
         invoice_ids = po.line_ids

--- a/som_municipal_taxes/tests/test_wizard_creacio_remesa_pagament_taxes.py
+++ b/som_municipal_taxes/tests/test_wizard_creacio_remesa_pagament_taxes.py
@@ -18,6 +18,7 @@ class TestWizardCreacioRemesaPagamentTaxes(testing.OOTestCaseWithCursor):
         get_states_invoiced_mock.return_value = ['draft', 'open', 'paid']
         wiz_o = self.pool.get("wizard.creacio.remesa.pagament.taxes")
         order_o = self.pool.get("payment.order")
+
         payment_mode_id = self.pool.get("ir.model.data").get_object_reference(
             self.cursor, self.uid, "account_invoice_som", "payment_mode_0001"
         )[1]

--- a/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.py
+++ b/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.py
@@ -31,7 +31,7 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         wizard = self.browse(cursor, uid, ids, context=context)
 
         # Comptes comptables
-        invoice_account_id = acc_o.search(cursor, uid, [('code', '=', '411000000000')])[0]
+        invoice_account_id = acc_o.search(cursor, uid, [('code', '=', '410000000000')])[0]
         line_account_id = acc_o.search(cursor, uid, [('code', '=', '600000000300')])[0]
 
         municipi_conf_ids = self.buscar_municipis_remesar(cursor, uid, ids, wizard.quarter, context)

--- a/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.py
+++ b/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.py
@@ -204,15 +204,16 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         invoice_obj.afegeix_a_remesa(cursor, uid, invoice_ids, order_id)
         info = "S'ha creat la remesa amb {} línies\n\n".format(len(linia_creada))
         if linia_falta_partner:
-            info += """Atenció. Els següents ajuntaments no tenen un partner \
-            creat: \n {}\n\n""".format(", ".join(linia_falta_partner))
+            info += """Atenció. Els següents ajuntaments ({}) no tenen un partner
+            creat: \n {}\n\n""".format(len(linia_falta_partner), ", ".join(linia_falta_partner))
         if linia_ja_creada:
-            info += """Atenció. Els següents ajuntaments ja tenen una factura creada \
-              per aquest període:\n {}\n\n""".format(", ".join(linia_ja_creada))
+            info += """Atenció. Els següents ajuntaments ({}) ja tenen una factura creada
+              per aquest període:\n {}\n\n""".format(
+                len(linia_ja_creada), ", ".join(linia_ja_creada))
         if linia_falta_partner_address:
-            info += """Atenció. Els següents ajuntaments no tenen una adreça creada a la \
+            info += """Atenció. Els següents ajuntaments ({}) no tenen una adreça creada a la
               fitxa del partner i per tant no s'ha pogut crear la factura:\n {}\n\n""".format(
-                ", ".join(linia_falta_partner_address))
+                len(linia_falta_partner_address), ", ".join(linia_falta_partner_address))
 
         return order_id, info
 

--- a/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.py
+++ b/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.py
@@ -6,6 +6,7 @@ import datetime
 import netsvc
 from dateutil.relativedelta import relativedelta
 from giscedata_municipal_taxes.taxes.municipal_taxes_invoicing import MunicipalTaxesInvoicingReport
+from som_municipal_taxes.models.som_municipal_taxes_config import TAX_VALUE
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("wizard.importador.leads.comercials")
@@ -27,7 +28,7 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         config_obj = self.pool.get('som.municipal.taxes.config')
         wizard = self.browse(cursor, uid, ids, context=context)
 
-        municipi_conf_ids = self.buscar_municipis_remesar(cursor, uid, wizard.quarter, context)
+        municipi_conf_ids = self.buscar_municipis_remesar(cursor, uid, ids, wizard.quarter, context)
         if not municipi_conf_ids:
             vals = {
                 'info': "No hi ha municipis configurats per remesar",
@@ -42,8 +43,8 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         ]
 
         totals_by_city = self.calcul_imports(
-            cursor, uid, res_municipi_ids, wizard.year, wizard.quarter, context)
-        if not totals_by_city:
+            cursor, uid, ids, res_municipi_ids, wizard.year, wizard.quarter, context)
+        if totals_by_city.empty:
             vals = {
                 'info': "No hi ha factures dels municipis configurats en el període especificat",
                 'state': 'cancel',
@@ -52,7 +53,7 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
             return True
 
         order_id, info = self.crear_factures(
-            cursor, uid, totals_by_city, wizard.payment_mode.id,
+            cursor, uid, ids, totals_by_city, wizard.payment_mode.id,
             wizard.account.id, wizard.year, context)
 
         vals = {
@@ -63,7 +64,7 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         wizard.write(vals, context)
         return order_id
 
-    def buscar_municipis_remesar(self, cursor, uid, quarter, context=None):
+    def buscar_municipis_remesar(self, cursor, uid, ids, quarter, context=None):
         # Buscar els municipis que es remesen
         config_obj = self.pool.get('som.municipal.taxes.config')
 
@@ -82,7 +83,7 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
 
         return municipis_conf_ids
 
-    def calcul_imports(self, cursor, uid, res_municipi_ids, year, quarter, context=None):
+    def calcul_imports(self, cursor, uid, ids, res_municipi_ids, year, quarter, context=None):
         # Calcular els imports
         start_date, end_date = get_dates_from_quarter(year, quarter)
         polissa_categ_imu_ex_id = (
@@ -93,23 +94,18 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         invoiced_states = self.pool.get(
             'giscedata.facturacio.extra').get_states_invoiced(cursor, uid)
         taxes_invoicing_report = MunicipalTaxesInvoicingReport(
-            cursor, uid, start_date, end_date, False, False, 'tri', False,
+            cursor, uid, start_date, end_date, TAX_VALUE, False, 'tri', False,
             polissa_categ_imu_ex_id, False, invoiced_states,
             context=context
         )
         df_mun, df_gr, df_out, df_in, col_gr, col_mun = taxes_invoicing_report.build_dataframe_taxes_detallat(  # noqa: E501
             res_municipi_ids, context)
         if not col_mun:
-            vals = {
-                'info': "No hi ha factures dels municipis configurats en el període especificat",
-                'state': 'cancel',
-            }
-            wizard.write(vals, context)
-            return True
+            return False
 
-        return df_mun # ex totals_by_city
+        return df_gr  # ex totals_by_city
 
-    def crear_factures(self, cursor, uid, totals_by_city, payment_mode_id,
+    def crear_factures(self, cursor, uid, ids, df_gr, payment_mode_id,
                        account_id, year, context=None):
         config_obj = self.pool.get('som.municipal.taxes.config')
         order_obj = self.pool.get('payment.order')
@@ -118,7 +114,6 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         mun_obj = self.pool.get('res.municipi')
         invoice_obj = self.pool.get('account.invoice')
         invoice_line_obj = self.pool.get('account.invoice.line')
-        tax = 1.5
         euro_id = currency_obj.search(cursor, uid, [('code', '=', 'EUR')])[0]
         journal_id = self.pool.get('ir.model.data').get_object_reference(
             cursor, uid, 'som_municipal_taxes', 'municipal_tax_journal')[1]
@@ -137,13 +132,12 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
         linia_falta_partner = []
         linia_ja_creada = []
         linia_falta_partner_address = []
-        linia_no_creada = []
         for idx, mun in df_gr.iterrows():
-            total_tax = mun['TOVP']
+            city_tax = mun['TOVP']
             city_name = idx[0]
             city_ine = idx[1]
             quarter_name = idx[3]
-            municipi_id = mun_obj.search(cursor, uid, [('ine', '=', ine)])[0]
+            municipi_id = mun_obj.search(cursor, uid, [('ine', '=', city_ine)])[0]
             origin_name = '{}/{}{}'.format(city_ine, year, quarter_name)
             if invoice_obj.search(cursor, uid, [('origin', '=', origin_name)]):
                 linia_ja_creada.append(city_name)
@@ -182,19 +176,19 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
                 type='in_invoice',
                 origin=origin_name,
                 reference='',
-                origin_date_invoice=self.get_dates_from_quarter(year, quarter_number),
+                origin_date_invoice=self.get_invoice_date_from_quarter(year, quarter_name),
             ))
             invoice_line_obj.create(cursor, uid, dict(
                 invoice_id=invoice_id,
                 name='Ajuntament de {} taxa 1,5% pel trimestre {}-{}'.format(
                     city_name, year, quarter_name),
                 account_id=account_id,
-                price_unit=total_tax,
+                price_unit=city_tax,
                 quantity=1,
                 uom_id=1,
                 company_currency_id=euro_id,
             ))
-            invoice_obj.write(cursor, uid, [invoice_id], {'check_total': total_tax})
+            invoice_obj.write(cursor, uid, [invoice_id], {'check_total': city_tax})
             wf_service = netsvc.LocalService("workflow")
             wf_service.trg_validate(uid, 'account.invoice', invoice_id, 'invoice_open', cursor)
 
@@ -217,12 +211,12 @@ class WizardCreacioRemesaPagamentTaxes(osv.osv_memory):
 
         return order_id, info
 
-    def get_dates_from_quarter(self, year, quarter):
-        if quarter == ANUAL_VAL:
-            return datetime.date(year, 1, 1), datetime.date(year, 12, 31)
+    def get_invoice_date_from_quarter(self, year, quarter_name):
+        if quarter_name == 'Anual':
+            invoice_date = datetime.date(year + 1, 1, 1)
         else:
-            start_date = datetime.date(year, (quarter - 1) * 3 + 1, day=1)
-            return start_date.strftime('%Y-%m-%d')
+            invoice_date = datetime.date(year, (int(quarter_name[0]) - 1) * 3 + 1, day=1)
+        return invoice_date.strftime('%Y-%m-%d')
 
     def show_payment_order(self, cursor, uid, ids, context):
         wizard = self.browse(cursor, uid, ids[0], context)

--- a/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.xml
+++ b/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.xml
@@ -53,7 +53,7 @@
             <field name="view_id" ref="view_wizard_creacio_remesa_pagament_taxes_form"/>
             <field name="context">{'from_model': True}</field>
         </record>
-        <record model="ir.values" id="value_wizard_create_atc_from_polissa_gas">
+        <record model="ir.values" id="value_action_wizard_creacio_remesa_pagament_taxes_form_action">
             <field name="object" eval="1"/>
             <field name="name">Crear remesa pagament impost municipal</field>
             <field name="key2">client_action_multi</field>
@@ -61,6 +61,5 @@
             <field name="model">som.municipal.taxes.config</field>
             <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_creacio_remesa_pagament_taxes_form_action'))" />
         </record>
-
     </data>
 </openerp>

--- a/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.xml
+++ b/som_municipal_taxes/wizard/wizard_creacio_remesa_pagament_taxes.xml
@@ -10,7 +10,6 @@
                 	<field name="state" invisible="1"/>
                     <field name="info" nolabel="1" colspan="4" height="150" readonly="1"/>
                 	<group colspan="4" col="4" attrs="{'invisible':[('state', '!=', 'init')]}">
-                        <field name="account"/>
                         <field name="payment_mode"/>
                         <field name="year"/>
                         <field name="quarter"/>

--- a/som_municipal_taxes/wizard/wizard_presentacio_redsaras.xml
+++ b/som_municipal_taxes/wizard/wizard_presentacio_redsaras.xml
@@ -51,14 +51,13 @@
             <field name="view_id" ref="view_wizard_presentacio_redsaras_form"/>
             <field name="context">{'from_model': True}</field>
         </record>
-        <record model="ir.values" id="value_wizard_create_atc_from_polissa_gas">
+        <record model="ir.values" id="value_action_wizard_presentacio_redsaras_form_action">
             <field name="object" eval="1"/>
-            <field name="name">Enviar sol·licitud carta pagament</field>
+            <field name="name">Enviar sol·licitud carta pagament RedSaras</field>
             <field name="key2">client_action_multi</field>
             <field name="key">action</field>
             <field name="model">som.municipal.taxes.config</field>
             <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_presentacio_redsaras_form_action'))" />
         </record>
-
     </data>
 </openerp>


### PR DESCRIPTION
## Objectiu
Per poder pagar remeses de l'impost municipal des del ERP, ha d'haver-hi una factura pel mig.

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/551/activity

## Comportament antic
No es pot pagar la remesa perquè les línies no corresponen a factures

## Comportament nou
Les línies de la remesa són factures

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
