### PR TITLE
Adaptació a ATR 3.0

### DIFF
--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -106,6 +106,7 @@ jobs:
           git clone --depth 1 https://github.com/gisce/poweremail-modules.git $ROOT_DIR_SRC/poweremail-modules
           git clone --depth 1 https://github.com/gisce/crm_poweremail.git $ROOT_DIR_SRC/crm_poweremail
           git clone --depth 1 https://github.com/gisce/ooop.git $ROOT_DIR_SRC/ooop
+          git clone --depth 1 https://github.com/gisce/gestionatr.git -b 65118_adaptar_gestionatr_atr3.0 $ROOT_DIR_SRC/gestionatr
 
       - name: Install dependencies
         run: |
@@ -123,6 +124,8 @@ jobs:
           pip install -e . || "Not installing plantmeter Python package"
           pip install -r $ROOT_DIR_SRC/erp/requirements-dev.txt
           pip install -r $ROOT_DIR_SRC/erp/requirements.txt
+          cd $ROOT_DIR_SRC/gestionatr
+          pip install -e . || "Not installing custom gestionatr Python package"
 
       - name: Install dependecies for Python 3
         if: matrix.python-version != '2.7'

--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -106,7 +106,6 @@ jobs:
           git clone --depth 1 https://github.com/gisce/poweremail-modules.git $ROOT_DIR_SRC/poweremail-modules
           git clone --depth 1 https://github.com/gisce/crm_poweremail.git $ROOT_DIR_SRC/crm_poweremail
           git clone --depth 1 https://github.com/gisce/ooop.git $ROOT_DIR_SRC/ooop
-          git clone --depth 1 https://github.com/gisce/gestionatr.git -b 65118_adaptar_gestionatr_atr3.0 $ROOT_DIR_SRC/gestionatr
 
       - name: Install dependencies
         run: |
@@ -124,8 +123,6 @@ jobs:
           pip install -e . || "Not installing plantmeter Python package"
           pip install -r $ROOT_DIR_SRC/erp/requirements-dev.txt
           pip install -r $ROOT_DIR_SRC/erp/requirements.txt
-          cd $ROOT_DIR_SRC/gestionatr
-          pip install -e . || "Not installing custom gestionatr Python package"
 
       - name: Install dependecies for Python 3
         if: matrix.python-version != '2.7'

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1180,7 +1180,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 key=lambda l: l[0],  # noqa: E741
             ),
             "is_autoconsum": te_autoconsum(fact, pol),  # fact.te_autoconsum
-            "autoconsum": pol.tipus_autoconsum,
+            "autoconsum": pol.autoconsum,
             "autoconsum_cau": pol.autoconsum_id.cau if pol.autoconsum_id else "",
             "is_autoconsum_colectiu": te_autoconsum_collectiu(
                 fact, pol

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3827,7 +3827,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     return True
             return False
 
-        if not(te_autoconsum_amb_excedents(fact, pol) or pol.tipus_subseccio == '33'):
+        if not(te_autoconsum_amb_excedents(fact, pol) or pol.tipus_subseccio == '11'):
             return {"is_visible": False}
 
         if not has_active_flux_solar(fact, pol):

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1180,7 +1180,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 key=lambda l: l[0],  # noqa: E741
             ),
             "is_autoconsum": te_autoconsum(fact, pol),  # fact.te_autoconsum
-            "autoconsum": pol.autoconsumo,
+            "autoconsum": pol.tipus_subseccio,
             "autoconsum_cau": pol.autoconsum_id.cau if pol.autoconsum_id else "",
             "is_autoconsum_colectiu": te_autoconsum_collectiu(
                 fact, pol
@@ -3827,7 +3827,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     return True
             return False
 
-        if not(te_autoconsum_amb_excedents(fact, pol) or pol.autoconsumo == '33'):
+        if not(te_autoconsum_amb_excedents(fact, pol) or pol.tipus_subseccio == '33'):
             return {"is_visible": False}
 
         if not has_active_flux_solar(fact, pol):

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1180,7 +1180,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 key=lambda l: l[0],  # noqa: E741
             ),
             "is_autoconsum": te_autoconsum(fact, pol),  # fact.te_autoconsum
-            "autoconsum": pol.autoconsumo,
+            "autoconsum": pol.tipus_autoconsum,
             "autoconsum_cau": pol.autoconsum_id.cau if pol.autoconsum_id else "",
             "is_autoconsum_colectiu": te_autoconsum_collectiu(
                 fact, pol

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1180,7 +1180,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 key=lambda l: l[0],  # noqa: E741
             ),
             "is_autoconsum": te_autoconsum(fact, pol),  # fact.te_autoconsum
-            "autoconsum": pol.autoconsum,
+            "autoconsum": pol.autoconsumo,
             "autoconsum_cau": pol.autoconsum_id.cau if pol.autoconsum_id else "",
             "is_autoconsum_colectiu": te_autoconsum_collectiu(
                 fact, pol

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -6,13 +6,13 @@
 #   <>, 2017, 2018, 2019, 2020.
 # Agustí Fita <afita@gisce.net>, 2018.
 # GISCE-TI, S.L. <devel@gisce.net>, 2014, 2017.
-# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022, 2023, 2024.
+# Som Energia  <itcrowd@somenergia.coop>, 2020, 2021, 2022, 2023, 2024, 2025.
 msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2024-08-01 16:20+0000\n"
-"PO-Revision-Date: 2024-08-01 15:11+0000\n"
+"POT-Creation-Date: 2025-03-06 16:36+0000\n"
+"PO-Revision-Date: 2025-03-06 15:48+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3748
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3672
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -35,15 +35,14 @@ msgid "Signar Factures"
 msgstr "Signar Facuras"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:340
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2753
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2757
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2669
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2673
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2747
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2663
 msgid "estimada"
 msgstr "estimada"
 
@@ -54,14 +53,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3778
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3702
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2797
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2713
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -72,49 +71,55 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2564
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2480
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:338
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:202
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:341
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:333
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2749
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:201
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2665
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3652
+#: constraint:ir.ui.view:0
+msgid "Invalid XML for View Architecture!"
+msgstr "Invalid XML for View Architecture!"
+
+#. module: giscedata_facturacio_comer_som
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3576
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1078
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:988
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2495
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2411
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3684
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3608
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2562
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2478
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -124,18 +129,18 @@ msgid "Error ! You can not create recursive categories."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3717
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3641
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2496
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2412
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:336
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:203
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr "calculada por Som Energía"
@@ -146,7 +151,12 @@ msgid "Error ! No pots crear categories recursives."
 msgstr "Error ! You can not create recursive categories."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2566
+#: field:giscedata.facturacio.factura,enviat_mail_id:0
+msgid "E-Mail factura adjunta"
+msgstr "E-Mail factura adjunta"
+
+#. module: giscedata_facturacio_comer_som
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2482
 msgid "(real)"
 msgstr "(real)"
 
@@ -369,291 +379,329 @@ msgid "Sense Autoconsum"
 msgstr "Sin Autoconsumo"
 
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:9
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:9
-msgid "Autoconsum Tipus 1"
-msgstr "Autoconsumo Tipo 1"
-
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:10
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:10
-msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. a) RD 900/2015)"
-msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. a) RD 900/2015)"
-
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:11
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:11
-msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. b) RD 900/2015)"
-msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. b) RD 900/2015)"
-
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:12
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:12
-msgid "Serveis auxiliars de generació lligada a un autoconsum tipus 2"
-msgstr "Servicios auxiliares de generación ligada a un autoconsumo tipo 2"
-
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:13
 msgid "Sense Excedents Individual - Consum"
 msgstr "Sin Excedentes Individual – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:14
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:14
 msgid "Sense Excedents Col·lectiu - Consum"
 msgstr "Sin Excedentes Colectivo – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:15
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:15
 msgid "Sense Excedents Col·lectiu amb acord de compensació – Consum"
 msgstr "Sin Excedentes Colectivo con acuerdo de compensación – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:16
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:12
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:16
 msgid "Amb excedents i compensació Individual-Consum"
 msgstr "Con excedentes y compensación Individual - Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:17
 msgid "Amb excedents i compensació Col·lectiu-Consum"
 msgstr "Con excedentes y compensación Colectivo– Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:18
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:18
 msgid "Amb excedents i compensació Col·lectiu a través de xarxa - Consum"
 msgstr "Con excedentes y compensación Colectivo a través de red - Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:19
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:19
 msgid ""
 "Amb excedents sense compensació Individual sense cte. de Serv. Aux. en Xarxa"
 " Interior - Consum"
 msgstr "Con excedentes sin compensación Individual sin cto de SSAA en Red Interior– Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:20
 msgid ""
 "Amb excedents sense compensació Col·lectiu sense cte. de Serv. Aux. en Xarxa"
 " Interior - Consum"
 msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA en Red Interior– Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:21
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:17
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:21
 msgid ""
 "Amb excedents sense compensació Individual amb cte. de Serv. Aux. en Xarxa "
 "Interior - Consum"
 msgstr "Con excedentes sin compensación Individual con cto SSAA en Red Interior– Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:22
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:18
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:22
 msgid ""
 "Amb excedents sense compensació individual amb cte. de Serv. Aux. en Xarxa "
 "Interior - Serv. Aux."
 msgstr "Con excedentes sin compensación individual con cto SSAA en Red Interior– SSAA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:23
 msgid ""
 "Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"
 msgstr "Con excedentes sin compensación Colectivo/en Red Interior– Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:24
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:20
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:24
 msgid ""
 "Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. Aux."
 msgstr "Con excedentes sin compensación Colectivo/en Red Interior - SSAA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:25
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:21
+msgid ""
+"Amb excedents sense compensació Col·lectiu sense cte de Serv. Aux. "
+"(menyspreable) en Xarxa Interior – Consum')"
+msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA (despreciable) en red interior – Consumo')"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:22
+msgid ""
+"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a través "
+"de xarxa - Consum')"
+msgstr "Con excedentes sin compensación Colectivo sin cto de SSAA a través de red - Consumo"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:23
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:25
 msgid ""
 "Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través "
 "de xarxa - Consum"
 msgstr "Con excedentes sin compensación Individual con cto SSAA a través de red – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:24
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:26
 msgid ""
 "Amb excedents sense compensació individual amb cte. de Serv. Aux. a través "
 "de xarxa - Serv. Aux."
 msgstr "Con excedentes sin compensación individual con cto SSAA a través de red – SSAA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:27
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:25
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:27
 msgid "Amb excedents sense compensació Col·lectiu a través de xarxa - Consum"
 msgstr "Con excedentes sin compensación Colectivo a través de red – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:28
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:26
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:28
 msgid ""
 "Amb excedents sense compensació Col·lectiu a través de xarxa - Serv. Aux."
 msgstr "Con excedentes sin compensación Colectivo a través de red - SSAA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:29
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:27
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:29
 msgid ""
 "Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través "
 "de xarxa i xarxa interior - Consum"
 msgstr "Con excedentes sin compensación Individual con cto SSAA a través de red y red interior – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:30
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:28
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:30
 msgid ""
 "Amb excedents sense compensació individual amb cte. de Serv. Aux. a través "
 "de xarxa i xarxa interior - Serv. Aux."
 msgstr "Con excedentes sin compensación individual con cto SSAA a través de red y red interior – SSAA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:31
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:31
 msgid ""
 "Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través "
 "de xarxa i xarxa interior - Consum"
 msgstr "Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:32
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:30
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:32
 msgid ""
 "Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través "
 "de xarxa i xarxa interior - SSAA"
 msgstr "Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:33
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:35
+msgid "Sense excedents No acollit a compensació"
+msgstr "Sin excedentes No acogido a compensación"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:34
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:36
+msgid "Sense excedents acollit a compensació"
+msgstr "Sin excedentes acogido a compensación"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:35
 #: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:37
+msgid "Amb excedents no acollits a compensació"
+msgstr "Con excedentes no acogidos a compensación"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:36
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:38
+msgid "Amb excedents acollits a compensació"
+msgstr "Con excedentes acogidos a compensación"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:37
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:39
+msgid "Sense autoconsum"
+msgstr "Sin autoconsumo"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:40
+msgid "Baixa com a membre d'autoconsum col·lectiu"
+msgstr "Baja como miembro de autoconsumo colectivo"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:43
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:45
 msgid "DADES DEL CONTRACTE"
 msgstr "DATOS DEL CONTRATO"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:40
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:40
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:48
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_info/invoice_info.mako:19
 msgid "Adreça de subministrament:"
 msgstr "Dirección de suministro:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:41
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:46
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:48
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:54
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:56
 msgid "Potència contractada (kW):"
 msgstr "Potencia contratada (kW):"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:41
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 msgid "facturació per maxímetre"
 msgstr "facturación por maxímetro"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:41
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
 msgid "facturació per ICP"
 msgstr "facturación por ICP"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:42
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:48
 msgid "Tarifa contractada:"
 msgstr "Tarifa contratada:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:43
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:62
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:70
 msgid "CUPS:"
 msgstr "CUPS:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:44
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "Comptador telegestionat:"
 msgstr "Contador telegestionado:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:44
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "Sí"
 msgstr "Sí"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:44
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:50
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
 msgid "No"
 msgstr "No"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:45
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:68
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:51
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:76
 msgid "CNAE:"
 msgstr "CNAE:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:52
 #, python-format
 msgid ""
 "Data d'alta del contracte: <span style=\"font-weight: bold;\">%s</span>, "
 "sense condicions de permanència"
 msgstr "Fecha de alta del contrato: <span style=\"font-weight: bold;\">%s</span>, sin condiciones de permanencia"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:47
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:53
 msgid "Forma de pagament: rebut domiciliat"
 msgstr "Forma de pago: recibo domiciliado"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:48
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:54
 #, python-format
 msgid "Data de renovació automàtica: <span style=\"font-weight: bold;\">%s</span>"
 msgstr "Fecha de renovación automática: <span style=\"font-weight: bold;\">%s</span>"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:53
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:73
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:59
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:81
 msgid "Autoproducció tipus:"
 msgstr "Autoproducción tipo:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:54
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:60
 msgid "Codi d'autoconsum unificat (CAU):"
 msgstr "Código de autoconsumo unificado (CAU):"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:56
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako:62
 msgid "Percentatge de repartiment de l'autoproducció compartida:"
 msgstr "Porcentaje de reparto de la autoproducción compartida:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:9
+msgid "Autoconsum Tipus 1"
+msgstr "Autoconsumo Tipo 1"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:10
+msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. a) RD 900/2015)"
+msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. a) RD 900/2015)"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:11
+msgid "Autoconsum tipus 2 (segons l'Art. 13. 2. b) RD 900/2015)"
+msgstr "Autoconsumo tipo 2 (según el Art. 13. 2. b) RD 900/2015)"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:12
+msgid "Serveis auxiliars de generació lligada a un autoconsum tipus 2"
+msgstr "Servicios auxiliares de generación ligada a un autoconsumo tipo 2"
+
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:54
 #, python-format
 msgid "Punta: <b><i>%s</i></b> - Vall: <b><i>%s</i></b>"
 msgstr "Punta: <b><i>%s</i></b> - Valle: <b><i>%s</i></b>"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:51
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:53
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:55
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:59
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:61
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
 msgid "Facturació potència:"
 msgstr "Facturación potencia:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:51
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:59
 msgid "Facturació per maxímetre"
 msgstr "Facturación por maxímetro"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:53
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:61
 msgid "Facturació per potència quarthorari"
 msgstr "Facturación por potencia cuartohorario"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:55
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:63
 msgid "Facturació per ICP"
 msgstr "Facturación por ICP"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:57
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:65
 msgid "Peatge de transport i distribució:"
 msgstr "Peaje de transporte y distribución:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:58
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:66
 msgid "Segment tarifari:"
 msgstr "Segmento tarifario:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:60
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:68
 msgid "Tarifa:"
 msgstr "Tarifa:"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:69
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:77
 #, python-format
 msgid "Data d'alta del contracte: <span style=\"font-weight: bold;\">%s</span>"
 msgstr "Fecha de alta del contrato: <span style=\"font-weight: bold;\">%s</span>"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:70
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:78
 msgid ""
 "Forma de pagament: <span style=\"font-weight: bold;\">Rebut "
 "domiciliat</span>"
 msgstr "Forma de pago: <span style=\"font-weight: bold;\">Recibo domiciliado</span>"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 #, python-format
 msgid "Data final del contracte: <span style=\"font-weight: bold;\">%s</span> %s"
 msgstr "Fecha final del contrato: <span style=\"font-weight: bold;\">%s</span> %s"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 msgid "sense condicions de permanència"
 msgstr "sin condiciones de permanencia"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:71
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:79
 msgid "pròrroga automàtica per períodes d'un any"
 msgstr "prórroga automática por periodos de un año"
 
-#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:75
+#: rml:giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako:83
 msgid "CAU (Codi d'autoconsum unificat):"
 msgstr "CAU (Código de autoconsumo unificado):"
 
@@ -890,7 +938,7 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:73
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:85
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:16
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:11
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:16
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:50
@@ -1039,7 +1087,7 @@ msgid "Maximetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:15
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:14
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:15
 #, python-format
 msgid ""
 "La despesa mitjana diària en els últims %.0f mesos (%s dies) ha estat de "
@@ -1051,13 +1099,13 @@ msgstr "El gasto medio diario en los últimos %.0f meses (%s días)  ha sido de 
 msgid "L'electricitat utilitzada durant el darrer any: <b>%s</b> kWh."
 msgstr "La electricidad utilizada durante el último año: <b>%s</b> kWh."
 
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:16
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:17
 #, python-format
 msgid ""
 "L'electricitat utilitzada durant el darrer any ha estat de <b>%s</b> kWh."
 msgstr "La electricidad utilizada durante el último año ha sido de <b>%s</b> kWh."
 
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:30
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:31
 #, python-format
 msgid ""
 "La potència màxima que has fet servir en el període que va del %s fins al %s"
@@ -1065,21 +1113,21 @@ msgid ""
 "dades rebudes per l’empresa distribuïdora)"
 msgstr "La potencia máxima que has utilizado en el período que va del %s hasta el %s és de: Punta: <b><i>%s</i></b> kW - Valle: <b><i>%s</i></b> kW (últimos datos recibidos por la empresa distribuidora)"
 
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:33
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:34
 #, python-format
 msgid ""
 "Potència màxima demandada: (ho sentim, %s encara no ens ha facilitat "
 "aquestes dades)."
 msgstr "Potencia máxima demandada: (lo sentimos, %s aún no nos ha facilitado este dato)."
 
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:38
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:39
 #, python-format
 msgid ""
 "El consum mitjà de la teva zona (CP %s) durant l'últim mes ha estat de "
 "<b>%s</b> kWh."
 msgstr "El consumo medio de tu zona (CP %s) durante el último mes ha sido de <b>%s</b> kWh."
 
-#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:40
+#: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic_td/energy_consumption_graphic_td.mako:41
 #, python-format
 msgid ""
 "Ho sentim, %s no ens ha facilitat el consum mitjà de la teva zona (CP %s) de"
@@ -1285,7 +1333,7 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:47
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:9
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:48
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:63
@@ -1478,7 +1526,7 @@ msgstr "Bono social (RD 7/2016 23 diciembre)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_other_concepts/invoice_details_other_concepts.mako:41
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:8
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:113
 #, python-format
 msgid "%s dies x %s €/dia"
@@ -1603,7 +1651,7 @@ msgstr "IVA"
 msgid "TOTAL FACTURA"
 msgstr "TOTAL FACTURA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:7
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:23
 msgid "Bo social"
 msgstr "Bono social"
@@ -1771,7 +1819,7 @@ msgid "Flux Solar"
 msgstr "Flux Solar"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_flux_solar/invoice_details_td_flux_solar.mako:8
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:37
 msgid "Descompte per Flux Solar"
 msgstr "Descuento por Flux Solar"
 
@@ -1803,7 +1851,7 @@ msgstr "Precio energía reactiva inductiva [€/kVArh]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:35
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_summary/invoice_summary.mako:22
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:34
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_summary_td/invoice_summary_td.mako:31
 msgid "Altres conceptes"
 msgstr "Otros conceptos"
 

--- a/giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako
@@ -6,10 +6,6 @@
 import locale
 TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not imported due translations issues
     '00': _(u"Sense Autoconsum"), # Sin Autoconsumo
-    '01': _(u"Autoconsum Tipus 1"), # Autoconsumo Tipo 1
-    '2A': _(u"Autoconsum tipus 2 (segons l'Art. 13. 2. a) RD 900/2015)"), # Autoconsumo tipo 2 (según el Art. 13. 2. a) RD 900/2015)
-    '2B': _(u"Autoconsum tipus 2 (segons l'Art. 13. 2. b) RD 900/2015)"), # Autoconsumo tipo 2 (según el Art. 13. 2. b) RD 900/2015)
-    '2G': _(u"Serveis auxiliars de generació lligada a un autoconsum tipus 2"), # Servicios auxiliares de generación ligada a un autoconsumo tipo 2
     '31': _(u"Sense Excedents Individual - Consum"), # Sin Excedentes Individual – Consumo
     '32': _(u"Sense Excedents Col·lectiu - Consum"), # Sin Excedentes Colectivo – Consumo
     '33': _(u"Sense Excedents Col·lectiu amb acord de compensació – Consum"), # Sin Excedentes Colectivo con acuerdo de compensación – Consumo
@@ -22,6 +18,8 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
     '54': _(u"Amb excedents sense compensació individual amb cte. de Serv. Aux. en Xarxa Interior - Serv. Aux."), # Con excedentes sin compensación individual con cto SSAA en Red Interior– SSAA
     '55': _(u"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"), # Con excedentes sin compensación Colectivo/en Red Interior– Consumo
     '56': _(u"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. Aux."), # Con excedentes sin compensación Colectivo/en Red Interior - SSAA
+    '57': _(u"Amb excedents sense compensació Col·lectiu sense cte de Serv. Aux. (menyspreable) en Xarxa Interior – Consum')"), # Con excedentes sin compensación Colectivo sin cto de SSAA (despreciable) en red interior – Consumo')
+    '58': _(u"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a través de xarxa - Consum')"), # Con excedentes sin compensación Colectivo sin cto de SSAA a través de red - Consumo
     '61': _(u"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través de xarxa - Consum"), # Con excedentes sin compensación Individual con cto SSAA a través de red – Consumo
     '62': _(u"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través de xarxa - Serv. Aux."), # Con excedentes sin compensación individual con cto SSAA a través de red – SSAA
     '63': _(u"Amb excedents sense compensació Col·lectiu a través de xarxa - Consum"), # Con excedentes sin compensación Colectivo a través de red – Consumo
@@ -30,7 +28,7 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
     '72': _(u"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través de xarxa i xarxa interior - Serv. Aux."), # Con excedentes sin compensación individual con cto SSAA a través de red y red interior – SSAA
     '73': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - Consum"), # Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo
     '74': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - SSAA"), # Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA
-    }
+}
 autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_dict else _("")
 %>
     <div class="contract_data${cd.small_text and '_small' or ''}">

--- a/giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data/contract_data.mako
@@ -29,7 +29,15 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
     '73': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - Consum"), # Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo
     '74': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - SSAA"), # Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA
 }
-autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_dict else _("")
+TABLA_133_dict = { # Table extracted from gestionatr.defs TABLA_133, not imported due translations issues
+    '10': _(u"Sense excedents No acollit a compensació"), # Sin excedentes No acogido a compensación
+    '11': _(u"Sense excedents acollit a compensació"), # Sin excedentes acogido a compensación
+    '20': _(u"Amb excedents no acollits a compensació"), # Con excedentes no acogidos a compensación
+    '21': _(u"Amb excedents acollits a compensació"), # Con excedentes acogidos a compensación
+    '00': _(u"Sense autoconsum"), # Sin autoconsumo
+    '0C': _(u"Baixa com a membre d'autoconsum col·lectiu"), # Baja como miembro de autoconsumo colectivo
+}
+autoconsum_text = TABLA_133_dict[cd.autoconsum] if cd.autoconsum in TABLA_133_dict else _("")
 %>
     <div class="contract_data${cd.small_text and '_small' or ''}">
         <h1>${_(u"DADES DEL CONTRACTE")}</h1>

--- a/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/contract_data_td/contract_data_td.mako
@@ -31,7 +31,15 @@ TABLA_113_dict = { # Table extracted from gestionatr.defs TABLA_113, not importe
     '73': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - Consum"), # Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo
     '74': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - SSAA"), # Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA
     }
-autoconsum_text = TABLA_113_dict[cd.autoconsum] if cd.autoconsum in TABLA_113_dict else _("")
+TABLA_133_dict = { # Table extracted from gestionatr.defs TABLA_133, not imported due translations issues
+    '10': _(u"Sense excedents No acollit a compensació"), # Sin excedentes No acogido a compensación
+    '11': _(u"Sense excedents acollit a compensació"), # Sin excedentes acogido a compensación
+    '20': _(u"Amb excedents no acollits a compensació"), # Con excedentes no acogidos a compensación
+    '21': _(u"Amb excedents acollits a compensació"), # Con excedentes acogidos a compensación
+    '00': _(u"Sense autoconsum"), # Sin autoconsumo
+    '0C': _(u"Baixa com a membre d'autoconsum col·lectiu"), # Baja como miembro de autoconsumo colectivo
+}
+autoconsum_text = TABLA_133_dict[cd.autoconsum] if cd.autoconsum in TABLA_133_dict else _("")
 %>
     <div class="contract_data${cd.small_text and '_small' or ''}">
         <h1>${_(u"DADES DEL CONTRACTE")}</h1>

--- a/som_atc/migrations/5.0.24.10.0/post-0001_afegir_seccio_defecte_factura_subtipus_075.py
+++ b/som_atc/migrations/5.0.24.10.0/post-0001_afegir_seccio_defecte_factura_subtipus_075.py
@@ -20,10 +20,10 @@ def up(cursor, installed_version):
     )[1]
     ccs_xml_id = "atc_section_factura"
     ccs_id = imd_obj.get_object_reference(
-        cursor, uid, "giscedata_atc", ccs_xml_id
+        cursor, uid, "som_switching", ccs_xml_id
     )[1]
 
-    gsr_obj.write(cursor, uid, gsr_id, {"section_id": ccs_id})
+    gsr_obj.write(cursor, uid, gsr_id, {"section_id": [(4, ccs_id)]})
 
     logger.info("XMLs succesfully updated.")
 

--- a/som_atc/migrations/5.0.24.10.0/post-0001_afegir_seccio_defecte_factura_subtipus_075.py
+++ b/som_atc/migrations/5.0.24.10.0/post-0001_afegir_seccio_defecte_factura_subtipus_075.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+
+    logger.info("Updating XMLs")
+    uid = 1
+    pool = pooler.get_pool(cursor.dbname)
+    gsr_obj = pool.get("giscedata.subtipus.reclamacio")
+    imd_obj = pool.get("ir.model.data")
+    gsr_xml_id = "subtipus_reclamacio_075"
+    gsr_id = imd_obj.get_object_reference(
+        cursor, uid, "giscedata_subtipus_reclamacio", gsr_xml_id
+    )[1]
+    ccs_xml_id = "atc_section_factura"
+    ccs_id = imd_obj.get_object_reference(
+        cursor, uid, "giscedata_atc", ccs_xml_id
+    )[1]
+
+    gsr_obj.write(cursor, uid, gsr_id, {"section_id": ccs_id})
+
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_atc/models/giscedata_atc.py
+++ b/som_atc/models/giscedata_atc.py
@@ -39,7 +39,7 @@ class GiscedataAtc(osv.osv):
         ),
         "tipus_autoconsum": fields.related(
             "polissa_id",
-            "autoconsumo",
+            "tipus_subseccio",
             type="selection",
             selection=TIPO_AUTOCONSUMO_SEL,
             string="tipus autoconsum",

--- a/som_atc/models/giscedata_atc.py
+++ b/som_atc/models/giscedata_atc.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from osv import osv, fields
 
-from gestionatr.defs import TABLA_113
-
-TIPO_AUTOCONSUMO_SEL = [(ac[0], "[{}] - {}".format(ac[0], ac[1])) for ac in TABLA_113]
+from giscedata_polissa.giscedata_polissa import TIPO_AUTOCONSUMO_SEL
 
 
 class GiscedataAtc(osv.osv):
@@ -41,7 +39,7 @@ class GiscedataAtc(osv.osv):
         ),
         "tipus_autoconsum": fields.related(
             "polissa_id",
-            "autoconsumo",
+            "tipus_autoconsum",
             type="selection",
             selection=TIPO_AUTOCONSUMO_SEL,
             string="tipus autoconsum",

--- a/som_atc/models/giscedata_atc.py
+++ b/som_atc/models/giscedata_atc.py
@@ -39,7 +39,7 @@ class GiscedataAtc(osv.osv):
         ),
         "tipus_autoconsum": fields.related(
             "polissa_id",
-            "tipus_autoconsum",
+            "autoconsumo",
             type="selection",
             selection=TIPO_AUTOCONSUMO_SEL,
             string="tipus autoconsum",

--- a/som_atc/models/giscedata_atc.py
+++ b/som_atc/models/giscedata_atc.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from osv import osv, fields
+from gestionatr.defs import TABLA_133
 
-from giscedata_polissa.giscedata_polissa import TIPO_AUTOCONSUMO_SEL
+TIPO_SUBSECCION_SEL = [
+    (ac[0], u'[{}] - {}'.format(ac[0], ac[1])) for ac in TABLA_133
+]
 
 
 class GiscedataAtc(osv.osv):
@@ -41,7 +44,7 @@ class GiscedataAtc(osv.osv):
             "polissa_id",
             "tipus_subseccio",
             type="selection",
-            selection=TIPO_AUTOCONSUMO_SEL,
+            selection=TIPO_SUBSECCION_SEL,
             string="tipus autoconsum",
             readonly=True,
         ),

--- a/som_atc/models/giscedata_switching_helpers.py
+++ b/som_atc/models/giscedata_switching_helpers.py
@@ -41,9 +41,9 @@ class GiscedataSwitchingHelpers(osv.osv):
         self._tmp_atc_ids = atc_ids  # Trick to temporally save the ATC_IDS
         return atc_ids
 
-    def _crear_autoconsum_from_d1(self, cursor, uid, step, autoconsum_id, context=None):
-        res = super(GiscedataSwitchingHelpers, self)._crear_autoconsum_from_d1(
-            cursor, uid, step, autoconsum_id, context
+    def _crear_autoconsum_from_datos_cau(self, cursor, uid, step, dades_cau=None, context=None):
+        res = super(GiscedataSwitchingHelpers, self)._crear_autoconsum_from_datos_cau(
+            cursor, uid, step, dades_cau, context
         )
         # We're in the same transaction, we can recover the case_ids from memory
         atc_ids = getattr(self, '_tmp_atc_ids', None)

--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -47,7 +47,7 @@ class GiscedataPolissaCalculada(osv.osv):
             return False, _(u"no es 2.0TD")
         if pol.te_assignacio_gkwh:
             return False, _(u"té GenerationKWh")
-        if pol.tipus_autoconsum != "00":
+        if pol.autoconsumo != "00":
             return False, _(u"té Autoconsum")
         if pol.facturacio_potencia == "max":  # != 'icp'
             return False, _(u"té Maximetre")

--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -47,7 +47,7 @@ class GiscedataPolissaCalculada(osv.osv):
             return False, _(u"no es 2.0TD")
         if pol.te_assignacio_gkwh:
             return False, _(u"té GenerationKWh")
-        if pol.autoconsumo != "00":
+        if pol.tipus_subseccio != "00":
             return False, _(u"té Autoconsum")
         if pol.facturacio_potencia == "max":  # != 'icp'
             return False, _(u"té Maximetre")

--- a/som_facturacio_calculada/giscedata_polissa.py
+++ b/som_facturacio_calculada/giscedata_polissa.py
@@ -47,7 +47,7 @@ class GiscedataPolissaCalculada(osv.osv):
             return False, _(u"no es 2.0TD")
         if pol.te_assignacio_gkwh:
             return False, _(u"té GenerationKWh")
-        if pol.autoconsumo != "00":
+        if pol.tipus_autoconsum != "00":
             return False, _(u"té Autoconsum")
         if pol.facturacio_potencia == "max":  # != 'icp'
             return False, _(u"té Maximetre")

--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
@@ -207,7 +207,7 @@ class GiscedataFacturacioContracteLot(osv.osv):
         ),
         "autoconsum": fields.related(
             "polissa_id",
-            "tipus_autoconsum",
+            "autoconsumo",
             type="selection",
             selection=TIPO_AUTOCONSUMO_SEL,
             string="Autoconsum",

--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
@@ -4,8 +4,9 @@ from osv import osv, fields
 from tools.translate import _
 import re
 import logging
+from gestionatr.defs import TABLA_133
 
-from giscedata_polissa.giscedata_polissa import TIPO_AUTOCONSUMO_SEL
+TIPO_SUBSECCIO_SEL = [(ac[0], "[{}] - {}".format(ac[0], ac[1])) for ac in TABLA_133]
 
 
 class GiscedataFacturacioContracteLot(osv.osv):
@@ -208,7 +209,7 @@ class GiscedataFacturacioContracteLot(osv.osv):
             "polissa_id",
             "tipus_subseccio",
             type="selection",
-            selection=TIPO_AUTOCONSUMO_SEL,
+            selection=TIPO_SUBSECCIO_SEL,
             string="Autoconsum",
             readonly=True,
         ),

--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
@@ -2,11 +2,10 @@
 from __future__ import absolute_import
 from osv import osv, fields
 from tools.translate import _
-from gestionatr.defs import TABLA_113
 import re
 import logging
 
-TIPO_AUTOCONSUMO_SEL = [(ac[0], "[{}] - {}".format(ac[0], ac[1])) for ac in TABLA_113]
+from giscedata_polissa.giscedata_polissa import TIPO_AUTOCONSUMO_SEL
 
 
 class GiscedataFacturacioContracteLot(osv.osv):
@@ -207,7 +206,7 @@ class GiscedataFacturacioContracteLot(osv.osv):
         ),
         "autoconsum": fields.related(
             "polissa_id",
-            "autoconsumo",
+            "tipus_subseccio",
             type="selection",
             selection=TIPO_AUTOCONSUMO_SEL,
             string="Autoconsum",

--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
@@ -207,7 +207,7 @@ class GiscedataFacturacioContracteLot(osv.osv):
         ),
         "autoconsum": fields.related(
             "polissa_id",
-            "autoconsumo",
+            "tipus_autoconsum",
             type="selection",
             selection=TIPO_AUTOCONSUMO_SEL,
             string="Autoconsum",

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -2,12 +2,12 @@
 from osv import osv, fields
 import re
 from tools.translate import _
-from gestionatr.defs import TABLA_113, TABLA_17
+from gestionatr.defs import TABLA_17
 from datetime import datetime, timedelta
 from tools import cache
 import logging
 
-TIPO_AUTOCONSUMO_SEL = [(ac[0], "[{}] - {}".format(ac[0], ac[1])) for ac in TABLA_113]
+from giscedata_polissa.giscedata_polissa import TIPO_AUTOCONSUMO_SEL
 IMPORT_PHASE_1 = 10  # 10 = Fase de càrrega XML
 
 

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -2,13 +2,17 @@
 from osv import osv, fields
 import re
 from tools.translate import _
-from gestionatr.defs import TABLA_17
+from gestionatr.defs import TABLA_17, TABLA_113_NEW
 from datetime import datetime, timedelta
 from tools import cache
 import logging
 
-from giscedata_polissa.giscedata_polissa import TIPO_AUTOCONSUMO_SEL
 IMPORT_PHASE_1 = 10  # 10 = Fase de càrrega XML
+
+TIPO_AUTOCONSUMO_NEW = TABLA_113_NEW
+TIPO_AUTOCONSUMO_SEL_NEW = [
+    (ac[0], u'[{}] - {}'.format(ac[0], ac[1])) for ac in TIPO_AUTOCONSUMO_NEW
+]
 
 
 class GiscedataFacturacioImportacioLinia(osv.osv):
@@ -220,7 +224,7 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
 
     _columns = {
         "tipus_autoconsum": fields.selection(
-            TIPO_AUTOCONSUMO_SEL,
+            TIPO_AUTOCONSUMO_SEL_NEW,
             u"Autoconsum",
             readonly=True,
             help=u"Tipus de autoconsum informat a l'F1",

--- a/som_gurb/tests/tests_gurb_switching.py
+++ b/som_gurb/tests/tests_gurb_switching.py
@@ -234,7 +234,7 @@ class TestsGurbSwitching(TestsGurbBase):
             cursor, uid, "giscedata_polissa", "polissa_0001"
         )[1]
         polissa_obj.write(cursor, uid, [polissa_id], {
-            "autoconsumo": autoconsumo_mode,
+            "tipus_subseccio": autoconsumo_mode,
         })
 
     def test_do_not_notify_m1_02_auto_gurb_category(self):
@@ -730,7 +730,7 @@ class TestsGurbSwitching(TestsGurbBase):
         self.assertEqual(m1.state, "done")
         self.assertEqual(m1.notificacio_pendent, False)
 
-        self.assertEqual(pol.autoconsumo, "41")
+        self.assertEqual(pol.tipus_subseccio, "41")
 
     def test_notify_m1_03_gurb_category(self):
         pol_obj = self.openerp.pool.get("giscedata.polissa")

--- a/som_gurb/tests/tests_gurb_switching.py
+++ b/som_gurb/tests/tests_gurb_switching.py
@@ -730,7 +730,7 @@ class TestsGurbSwitching(TestsGurbBase):
         self.assertEqual(m1.state, "done")
         self.assertEqual(m1.notificacio_pendent, False)
 
-        self.assertEqual(pol.tipus_subseccio, "41")
+        self.assertEqual(pol.tipus_subseccio, "21")
 
     def test_notify_m1_03_gurb_category(self):
         pol_obj = self.openerp.pool.get("giscedata.polissa")

--- a/som_indexada/tests/test_wizard_change_to_indexada.py
+++ b/som_indexada/tests/test_wizard_change_to_indexada.py
@@ -214,7 +214,7 @@ class TestChangeToIndexada(TestSwitchingImport):
                 "active",
                 "state",
                 "modcontractual_ant",
-                "autoconsumo",
+                "tipus_subseccio",
             ],
         )
         modcon_act.pop("id")
@@ -232,7 +232,7 @@ class TestChangeToIndexada(TestSwitchingImport):
                 "active": True,
                 "state": "pendent",
                 "modcontractual_ant": prev_modcontactual_id,
-                "autoconsumo": "41",
+                "tipus_subseccio": "41",
             },
         )
         IrModel = self.pool.get("ir.model.data")

--- a/som_indexada/tests/test_wizard_change_to_indexada.py
+++ b/som_indexada/tests/test_wizard_change_to_indexada.py
@@ -232,7 +232,7 @@ class TestChangeToIndexada(TestSwitchingImport):
                 "active": True,
                 "state": "pendent",
                 "modcontractual_ant": prev_modcontactual_id,
-                "tipus_subseccio": "41",
+                "tipus_subseccio": "21",
             },
         )
         IrModel = self.pool.get("ir.model.data")

--- a/som_indexada/tests/test_wizard_change_to_periodes.py
+++ b/som_indexada/tests/test_wizard_change_to_periodes.py
@@ -339,7 +339,7 @@ class TestChangeToPeriodes(TestSwitchingImport):
                 "active": True,
                 "state": "pendent",
                 "modcontractual_ant": prev_modcontactual_id,
-                "tipus_subseccio": "41",
+                "tipus_subseccio": "21",
             },
         )
         IrModel = self.pool.get("ir.model.data")

--- a/som_indexada/tests/test_wizard_change_to_periodes.py
+++ b/som_indexada/tests/test_wizard_change_to_periodes.py
@@ -321,7 +321,7 @@ class TestChangeToPeriodes(TestSwitchingImport):
                 "active",
                 "state",
                 "modcontractual_ant",
-                "autoconsumo",
+                "tipus_subseccio",
             ],
         )
         modcon_act.pop("id")
@@ -339,7 +339,7 @@ class TestChangeToPeriodes(TestSwitchingImport):
                 "active": True,
                 "state": "pendent",
                 "modcontractual_ant": prev_modcontactual_id,
-                "autoconsumo": "41",
+                "tipus_subseccio": "41",
             },
         )
         IrModel = self.pool.get("ir.model.data")

--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -345,8 +345,8 @@ class SomInfoenergiaEnviament(osv.osv):
             if not "polissa_id" in pol or not pol["polissa_id"]:  # noqa: E713
                 res[item] = False
             else:
-                auto_type = gp_obj.read(cursor, uid, pol["polissa_id"][0], ["autoconsumo"])[
-                    "autoconsumo"
+                auto_type = gp_obj.read(cursor, uid, pol["polissa_id"][0], ["tipus_autoconsum"])[
+                    "tipus_autoconsum"
                 ]
                 res[item] = auto_type != "00"
 

--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -345,8 +345,8 @@ class SomInfoenergiaEnviament(osv.osv):
             if not "polissa_id" in pol or not pol["polissa_id"]:  # noqa: E713
                 res[item] = False
             else:
-                auto_type = gp_obj.read(cursor, uid, pol["polissa_id"][0], ["tipus_autoconsum"])[
-                    "tipus_autoconsum"
+                auto_type = gp_obj.read(cursor, uid, pol["polissa_id"][0], ["autoconsumo"])[
+                    "autoconsumo"
                 ]
                 res[item] = auto_type != "00"
 

--- a/som_infoenergia/som_infoenergia_enviament.py
+++ b/som_infoenergia/som_infoenergia_enviament.py
@@ -345,8 +345,8 @@ class SomInfoenergiaEnviament(osv.osv):
             if not "polissa_id" in pol or not pol["polissa_id"]:  # noqa: E713
                 res[item] = False
             else:
-                auto_type = gp_obj.read(cursor, uid, pol["polissa_id"][0], ["autoconsumo"])[
-                    "autoconsumo"
+                auto_type = gp_obj.read(cursor, uid, pol["polissa_id"][0], ["tipus_subseccio"])[
+                    "tipus_subseccio"
                 ]
                 res[item] = auto_type != "00"
 

--- a/som_infoenergia/wizard/wizard_add_contracts_lot.py
+++ b/som_infoenergia/wizard/wizard_add_contracts_lot.py
@@ -30,7 +30,7 @@ class WizardAddContractsLot(osv.osv_memory):
             "end_date": [("data_alta", "<=", wiz.end_date)],
             "comer_fare": [("llista_preu", "ilike", "%{}%".format(wiz.comer_fare))],
             "access_fare": [("tarifa", "ilike", "%{}%".format(wiz.access_fare))],
-            "autoconsum": [("tipus_autoconsum", "!=", "00"), ("tipus_autoconsum", "!=", False)]
+            "autoconsum": [("autoconsumo", "!=", "00"), ("autoconsumo", "!=", False)]
             if wiz.autoconsum == "all"
             else [("autoconsumo", "=", wiz.autoconsum)],
             "tipo_medida": [("tipo_medida", "ilike", "%{}%".format(wiz.tipo_medida))],

--- a/som_infoenergia/wizard/wizard_add_contracts_lot.py
+++ b/som_infoenergia/wizard/wizard_add_contracts_lot.py
@@ -30,9 +30,9 @@ class WizardAddContractsLot(osv.osv_memory):
             "end_date": [("data_alta", "<=", wiz.end_date)],
             "comer_fare": [("llista_preu", "ilike", "%{}%".format(wiz.comer_fare))],
             "access_fare": [("tarifa", "ilike", "%{}%".format(wiz.access_fare))],
-            "autoconsum": [("autoconsumo", "!=", "00"), ("autoconsumo", "!=", False)]
+            "autoconsum": [("tipus_subseccio", "!=", "00"), ("tipus_subseccio", "!=", False)]
             if wiz.autoconsum == "all"
-            else [("autoconsumo", "=", wiz.autoconsum)],
+            else [("tipus_subseccio", "=", wiz.autoconsum)],
             "tipo_medida": [("tipo_medida", "ilike", "%{}%".format(wiz.tipo_medida))],
             "category": [
                 ("category_id", "!=", False),

--- a/som_infoenergia/wizard/wizard_add_contracts_lot.py
+++ b/som_infoenergia/wizard/wizard_add_contracts_lot.py
@@ -30,7 +30,7 @@ class WizardAddContractsLot(osv.osv_memory):
             "end_date": [("data_alta", "<=", wiz.end_date)],
             "comer_fare": [("llista_preu", "ilike", "%{}%".format(wiz.comer_fare))],
             "access_fare": [("tarifa", "ilike", "%{}%".format(wiz.access_fare))],
-            "autoconsum": [("autoconsumo", "!=", "00"), ("autoconsumo", "!=", False)]
+            "autoconsum": [("tipus_autoconsum", "!=", "00"), ("tipus_autoconsum", "!=", False)]
             if wiz.autoconsum == "all"
             else [("autoconsumo", "=", wiz.autoconsum)],
             "tipo_medida": [("tipo_medida", "ilike", "%{}%".format(wiz.tipo_medida))],

--- a/som_informe/report/components/C105/C105.py
+++ b/som_informe/report/components/C105/C105.py
@@ -10,7 +10,7 @@ class C105(ProcesC1.ProcesC1):
         result = ProcesC1.ProcesC1.get_data(self, wiz, cursor, uid, step)
         result["type"] = "C105"
         result["tipus_contracte"] = get_description(step.tipus_contracte, "TABLA_9")
-        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113")
+        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113_NEW")
         result["codi_contracte"] = step.contracte_atr
         result["potencies"] = [
             {"name": pot.name, "potencia": pot.potencia}

--- a/som_informe/report/components/C201/C201.py
+++ b/som_informe/report/components/C201/C201.py
@@ -23,7 +23,7 @@ class C201(ProcesC2.ProcesC2):
         else:
             result["codi_document"] = step.codi_document
         result["tipus_contracte"] = get_description(step.tipus_contracte, "TABLA_9")
-        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113")
+        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113_NEW")
         result["control_potencia"] = get_description(step.control_potencia, "TABLA_51", True)
         result["potencies"] = [
             {"name": pot.name, "potencia": pot.potencia}

--- a/som_informe/report/components/C205/C205.py
+++ b/som_informe/report/components/C205/C205.py
@@ -10,7 +10,7 @@ class C205(ProcesC2.ProcesC2):
         result = ProcesC2.ProcesC2.get_data(self, wiz, cursor, uid, step)
         result["type"] = "C205"
         result["tipus_contracte"] = get_description(step.tipus_contracte, "TABLA_9")
-        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113", True)
+        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113_NEW", True)
         result["codi_contracte"] = step.contracte_atr
         result["potencies"] = [
             {"name": pot.name, "potencia": pot.potencia}

--- a/som_informe/report/components/M101/M101.py
+++ b/som_informe/report/components/M101/M101.py
@@ -31,7 +31,7 @@ class M101(ProcesM1.ProcesM1):
             result["codi_document"] = step.codi_document[2:]
         else:
             result["codi_document"] = step.codi_document
-        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113")
+        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113_NEW")
         result["control_potencia"] = get_description(step.control_potencia, "TABLA_51", True)
         result["comentaris"] = step.comentaris
         if len(step.document_ids) == 0:

--- a/som_informe/report/components/M105/M105.py
+++ b/som_informe/report/components/M105/M105.py
@@ -9,7 +9,7 @@ class M105(ProcesM1.ProcesM1):
     def get_data(self, wiz, cursor, uid, step):
         result = ProcesM1.ProcesM1.get_data(self, wiz, cursor, uid, step)
         result["type"] = "M105"
-        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113")
+        result["tipus_autoconsum"] = get_description(step.tipus_autoconsum, "TABLA_113_NEW")
         result["control_potencia"] = get_description(step.control_potencia, "TABLA_51", True)
         result["potencies"] = [
             {"name": pot.name, "potencia": pot.potencia}

--- a/som_polissa/giscedata_cups.py
+++ b/som_polissa/giscedata_cups.py
@@ -3,12 +3,8 @@ from osv import osv, fields
 from tools.translate import _
 
 
-TABLA_113_dict = {  # Table extracted from gestionatr.defs TABLA_113, not imported due translations issues # noqa: E501
-    '00': _(u"Sense Autoconsum"),
-    '01': _(u"Autoconsum Tipus 1"),
-    '2A': _(u"Autoconsum tipus 2 (segons l'Art. 13. 2. a) RD 900/2015)"),
-    '2B': _(u"Autoconsum tipus 2 (segons l'Art. 13. 2. b) RD 900/2015)"),
-    '2G': _(u"Serveis auxiliars de generació lligada a un autoconsum tipus 2"),
+TABLA_113_dict = {  # Table extracted from gestionatr.defs TABLA_113, not imported due translations issues  # noqa: E501
+    '00': _(u"Sense Autoconsum"),   # noqa: E501
     '31': _(u"Sense Excedents Individual - Consum"),
     '32': _(u"Sense Excedents Col·lectiu - Consum"),
     '33': _(u"Sense Excedents Col·lectiu amb acord de compensació – Consum"),
@@ -21,6 +17,8 @@ TABLA_113_dict = {  # Table extracted from gestionatr.defs TABLA_113, not import
     '54': _(u"Amb excedents sense compensació individual amb cte. de Serv. Aux. en Xarxa Interior - Serv. Aux."),  # noqa: E501
     '55': _(u"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Consum"),
     '56': _(u"Amb excedents sense compensació Col·lectiu / en Xarxa Interior - Serv. Aux."),
+    '57': _(u"Amb excedents sense compensació Col·lectiu sense cte de Serv. Aux. (menyspreable) en Xarxa Interior – Consum')"),  # noqa: E501
+    '58': _(u"Amb excedents sense compensació Col·lectiu sense cto de Serv. Aux. a través de xarxa - Consum')"),  # noqa: E501
     '61': _(u"Amb excedents sense compensació Individual amb cte. de Serv. Aux. a través de xarxa - Consum"),  # noqa: E501
     '62': _(u"Amb excedents sense compensació individual amb cte. de Serv. Aux. a través de xarxa - Serv. Aux."),  # noqa: E501
     '63': _(u"Amb excedents sense compensació Col·lectiu a través de xarxa - Consum"),

--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -28,7 +28,7 @@
                     <field name="info_gestio_endarrerida_curta" string="Gest. Endarrerida"/>
                     <field name="info_gestions_massives"/>
                     <field name="data_alta_autoconsum"/>
-                    <field name="autoconsumo"/>
+                    <field name="tipus_subseccio"/>
                     <field name="user_id"/>
                 </tree>
             </field>
@@ -189,7 +189,7 @@
                     <field name="autoconsum_id" string="CAU"/>
                     <field name="name"/>
                     <field name="cups"/>
-                    <field name="autoconsumo"/>
+                    <field name="tipus_subseccio"/>
                     <field name="is_autoconsum_collectiu"/>
                     <field name="tipus_installacio"/>
                     <field name="esquema_mesura"/>
@@ -286,7 +286,7 @@
             <field name="type">tree</field>
             <field name="arch" type="xml">
                 <field name="cups" position="after">
-                    <field name="autoconsumo"/>
+                    <field name="tipus_subseccio"/>
                 </field>
                 <field name="potencia_generacio" position="after">
                     <field name="bateria_activa"/>

--- a/som_polissa/giscedata_polissa_view.xml
+++ b/som_polissa/giscedata_polissa_view.xml
@@ -285,9 +285,6 @@
             <field name="inherit_id" ref="giscedata_polissa.view_polisses_tree" />
             <field name="type">tree</field>
             <field name="arch" type="xml">
-                <field name="cups" position="after">
-                    <field name="tipus_subseccio"/>
-                </field>
                 <field name="potencia_generacio" position="after">
                     <field name="bateria_activa"/>
                     <field name="data_activacio_bateria"/>

--- a/som_polissa/migrations/5.0.24.10.0/post-0001_ocultar_columna_autoconsum_i_mostrar_tipus_seccio.py
+++ b/som_polissa/migrations/5.0.24.10.0/post-0001_ocultar_columna_autoconsum_i_mostrar_tipus_seccio.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+
+    # UPDATAR UNA PART DE L'XML (POSAR LA ID)
+    logger.info("Updating XMLs")
+    list_of_records = ["view_giscedata_polissa_tree_inherit"]
+    load_data_records(
+        cursor, "som_polissa", "giscedata_polissa_view.xml", list_of_records, mode="update"
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa/migrations/5.0.24.10.0/post-0001_ocultar_columna_autoconsum_i_mostrar_tipus_seccio.py
+++ b/som_polissa/migrations/5.0.24.10.0/post-0001_ocultar_columna_autoconsum_i_mostrar_tipus_seccio.py
@@ -11,7 +11,11 @@ def up(cursor, installed_version):
 
     # UPDATAR UNA PART DE L'XML (POSAR LA ID)
     logger.info("Updating XMLs")
-    list_of_records = ["view_giscedata_polissa_tree_inherit"]
+    list_of_records = [
+        "view_giscedata_polissa_tree_inherit",
+        "view_giscedata_polissa_cau_tree",
+        "view_giscedata_polissa_endarrerida_tree",
+    ]
     load_data_records(
         cursor, "som_polissa", "giscedata_polissa_view.xml", list_of_records, mode="update"
     )

--- a/som_polissa/tests/som_polissa_demo.xml
+++ b/som_polissa/tests/som_polissa_demo.xml
@@ -34,6 +34,7 @@
             <field name="tipus_vivenda">habitual</field>
             <field name="tg">1</field>
             <field name="autoconsumo">00</field>
+            <field name="tipus_subseccio">00</field>
             <field name="llista_preu" ref="giscedata_facturacio.pricelist_tarifas_electricidad"/>
             <field name="bank" ref="res_partner_bank_som_iban"/>
             <field name="facturacio" eval="1"/>

--- a/som_polissa/tests/som_polissa_demo.xml
+++ b/som_polissa/tests/som_polissa_demo.xml
@@ -34,7 +34,6 @@
             <field name="tipus_vivenda">habitual</field>
             <field name="tg">1</field>
             <field name="autoconsumo">00</field>
-            <field name="tipus_autoconsum">00</field>
             <field name="llista_preu" ref="giscedata_facturacio.pricelist_tarifas_electricidad"/>
             <field name="bank" ref="res_partner_bank_som_iban"/>
             <field name="facturacio" eval="1"/>

--- a/som_polissa/tests/som_polissa_demo.xml
+++ b/som_polissa/tests/som_polissa_demo.xml
@@ -34,6 +34,7 @@
             <field name="tipus_vivenda">habitual</field>
             <field name="tg">1</field>
             <field name="autoconsumo">00</field>
+            <field name="tipus_autoconsum">00</field>
             <field name="llista_preu" ref="giscedata_facturacio.pricelist_tarifas_electricidad"/>
             <field name="bank" ref="res_partner_bank_som_iban"/>
             <field name="facturacio" eval="1"/>

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -123,7 +123,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         else:
             es_canvi_tecnic = False
         pots = pas.pot_ids if es_canvi_tecnic else pol.potencies_periode
-        res['autoconsum'] = pas.tipus_autoconsum if es_canvi_tecnic else pol.autoconsumo
+        res['autoconsum'] = pas.tipus_autoconsum if es_canvi_tecnic else pol.tipus_autoconsum
         if res['autoconsum'] and res['autoconsum'] in TABLA_113_dict:
             res['autoconsum'] = TABLA_113_dict[res['autoconsum']]
         res['es_canvi_tecnic'] = es_canvi_tecnic
@@ -152,7 +152,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         res['name'] = pol.name
         res['state'] = pol.state
         res['lead'] = context.get('lead', False)
-        res['auto'] = pol.autoconsumo
+        res['auto'] = pol.tipus_autoconsum
         res['contract_type'] = CONTRACT_TYPES[pol.contract_type]
         res['tarifa'] = pol.tarifa_codi
         res['data_baixa'] = pol.data_baixa

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -123,7 +123,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         else:
             es_canvi_tecnic = False
         pots = pas.pot_ids if es_canvi_tecnic else pol.potencies_periode
-        res['autoconsum'] = pas.tipus_autoconsum if es_canvi_tecnic else pol.autoconsumo
+        res['autoconsum'] = pas.tipus_autoconsum if es_canvi_tecnic else pol.tipus_subseccio
         if res['autoconsum'] and res['autoconsum'] in TABLA_113_dict:
             res['autoconsum'] = TABLA_113_dict[res['autoconsum']]
         res['es_canvi_tecnic'] = es_canvi_tecnic
@@ -152,7 +152,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         res['name'] = pol.name
         res['state'] = pol.state
         res['lead'] = context.get('lead', False)
-        res['auto'] = pol.autoconsumo
+        res['auto'] = pol.tipus_subseccio
         res['contract_type'] = CONTRACT_TYPES[pol.contract_type]
         res['tarifa'] = pol.tarifa_codi
         res['data_baixa'] = pol.data_baixa

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -123,7 +123,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         else:
             es_canvi_tecnic = False
         pots = pas.pot_ids if es_canvi_tecnic else pol.potencies_periode
-        res['autoconsum'] = pas.tipus_autoconsum if es_canvi_tecnic else pol.tipus_autoconsum
+        res['autoconsum'] = pas.tipus_autoconsum if es_canvi_tecnic else pol.autoconsumo
         if res['autoconsum'] and res['autoconsum'] in TABLA_113_dict:
             res['autoconsum'] = TABLA_113_dict[res['autoconsum']]
         res['es_canvi_tecnic'] = es_canvi_tecnic
@@ -152,7 +152,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         res['name'] = pol.name
         res['state'] = pol.state
         res['lead'] = context.get('lead', False)
-        res['auto'] = pol.tipus_autoconsum
+        res['auto'] = pol.autoconsumo
         res['contract_type'] = CONTRACT_TYPES[pol.contract_type]
         res['tarifa'] = pol.tarifa_codi
         res['data_baixa'] = pol.data_baixa

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -369,7 +369,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
             ),
             'autoconsum': {
                 'es_autoconsum': env.polissa_id.es_autoconsum,
-                'compensacio': env.polissa_id.autoconsum_id.tipus_autoconsum in ['41', '42', '43']
+                'compensacio': env.polissa_id.tipus_subseccio in ['21']
             },
         }
 

--- a/som_switching/giscedata_polissa.py
+++ b/som_switching/giscedata_polissa.py
@@ -48,7 +48,7 @@ class GiscedataPolissaModcontractual(osv.osv):
             cursor, uid, mod_id, polissa_id
         )
 
-        fields_to_read = ["autoconsumo", "data_inici", "modcontractual_ant", "polissa_id"]
+        fields_to_read = ["tipus_subseccio", "data_inici", "modcontractual_ant", "polissa_id"]
 
         modcon_info = self.read(cursor, uid, mod_id, fields_to_read)
         auto_vals = {}
@@ -57,17 +57,17 @@ class GiscedataPolissaModcontractual(osv.osv):
                 cursor, uid, modcon_info["modcontractual_ant"][0], fields_to_read
             )
             if (
-                modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
-                and modcon_ant_info["autoconsumo"] == "00"
+                modcon_ant_info.get("tipus_subseccio") != modcon_info["tipus_subseccio"]
+                and modcon_ant_info["tipus_subseccio"] == "00"
             ):
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
             elif (
-                modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
-                and modcon_info["autoconsumo"] == "00"
+                modcon_ant_info.get("tipus_subseccio") != modcon_info["tipus_subseccio"]
+                and modcon_info["tipus_subseccio"] == "00"
             ):
                 auto_vals.update({"data_baixa_autoconsum": modcon_info["data_inici"]})
         else:
-            if modcon_info["autoconsumo"] != "00":
+            if modcon_info["tipus_subseccio"] != "00":
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
 
         if auto_vals:

--- a/som_switching/giscedata_polissa.py
+++ b/som_switching/giscedata_polissa.py
@@ -44,12 +44,11 @@ class GiscedataPolissaModcontractual(osv.osv):
     _inherit = "giscedata.polissa.modcontractual"
 
     def aplicar_modificacio(self, cursor, uid, mod_id, polissa_id=None):
-
         super(GiscedataPolissaModcontractual, self).aplicar_modificacio(
             cursor, uid, mod_id, polissa_id
         )
 
-        fields_to_read = ["tipus_autoconsum", "data_inici", "modcontractual_ant", "polissa_id"]
+        fields_to_read = ["autoconsumo", "data_inici", "modcontractual_ant", "polissa_id"]
 
         modcon_info = self.read(cursor, uid, mod_id, fields_to_read)
         auto_vals = {}
@@ -58,17 +57,17 @@ class GiscedataPolissaModcontractual(osv.osv):
                 cursor, uid, modcon_info["modcontractual_ant"][0], fields_to_read
             )
             if (
-                modcon_ant_info.get("tipus_autoconsum") != modcon_info["tipus_autoconsum"]
-                and modcon_ant_info["tipus_autoconsum"] == "00"
+                modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
+                and modcon_ant_info["autoconsumo"] == "00"
             ):
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
             elif (
-                modcon_ant_info.get("tipus_autoconsum") != modcon_info["tipus_autoconsum"]
-                and modcon_info["tipus_autoconsum"] == "00"
+                modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
+                and modcon_info["autoconsumo"] == "00"
             ):
                 auto_vals.update({"data_baixa_autoconsum": modcon_info["data_inici"]})
         else:
-            if modcon_info["tipus_autoconsum"] != "00":
+            if modcon_info["autoconsumo"] != "00":
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
 
         if auto_vals:

--- a/som_switching/giscedata_polissa.py
+++ b/som_switching/giscedata_polissa.py
@@ -49,7 +49,7 @@ class GiscedataPolissaModcontractual(osv.osv):
             cursor, uid, mod_id, polissa_id
         )
 
-        fields_to_read = ["autoconsumo", "data_inici", "modcontractual_ant", "polissa_id"]
+        fields_to_read = ["tipus_autoconsum", "data_inici", "modcontractual_ant", "polissa_id"]
 
         modcon_info = self.read(cursor, uid, mod_id, fields_to_read)
         auto_vals = {}
@@ -58,17 +58,17 @@ class GiscedataPolissaModcontractual(osv.osv):
                 cursor, uid, modcon_info["modcontractual_ant"][0], fields_to_read
             )
             if (
-                modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
-                and modcon_ant_info["autoconsumo"] == "00"
+                modcon_ant_info.get("tipus_autoconsum") != modcon_info["tipus_autoconsum"]
+                and modcon_ant_info["tipus_autoconsum"] == "00"
             ):
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
             elif (
-                modcon_ant_info.get("autoconsumo") != modcon_info["autoconsumo"]
-                and modcon_info["autoconsumo"] == "00"
+                modcon_ant_info.get("tipus_autoconsum") != modcon_info["tipus_autoconsum"]
+                and modcon_info["tipus_autoconsum"] == "00"
             ):
                 auto_vals.update({"data_baixa_autoconsum": modcon_info["data_inici"]})
         else:
-            if modcon_info["autoconsumo"] != "00":
+            if modcon_info["tipus_autoconsum"] != "00":
                 auto_vals.update({"data_alta_autoconsum": modcon_info["data_inici"]})
 
         if auto_vals:

--- a/som_switching/giscedata_polissa_view.xml
+++ b/som_switching/giscedata_polissa_view.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
-        <record model="ir.ui.view" id="view_polissa_autoconsum_form">
-            <field name="name">view.polissa.autoconsum.form.som</field>
-            <field name="model">giscedata.polissa</field>
-            <field name="type">form</field>
-            <field name="inherit_id" ref="giscedata_polissa.view_polissa_autoconsum_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//page[@string='Autoconsum']/field[@name='is_autoconsum_collectiu']" position="after">
-                    <field name="data_alta_autoconsum" readonly="1" select="2"/>
-                    <field name="data_baixa_autoconsum" readonly="1" select="2"/>
-                </xpath>
-            </field>
-        </record>
         <record model="ir.ui.view" id="giscedata_polissa_auto_tree">
             <field name="name">giscedata.polissa.auto.tree</field>
             <field name="model">giscedata.polissa</field>

--- a/som_switching/migrations/5.0.24.10/post-0001_update_validate_d101_wizard.py
+++ b/som_switching/migrations/5.0.24.10/post-0001_update_validate_d101_wizard.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Creating new fields on wizard validate d101")
+    pool.get("wizard.validate.d101")._auto_init(
+        cursor, context={'module': 'som_switching'}
+    )
+    logger.info("Fields created successfully")
+
+    # UPDATAR UN XML SENCER#
+    logger.info("Updating XML wizard_validate_d101.xml")
+    load_data(
+        cursor,
+        "som_switching",
+        "wizard/wizard_validate_d101.xml",
+        idref=None,
+        mode="update",
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_switching/migrations/5.0.24.10/post-0001_update_validate_d101_wizard.py
+++ b/som_switching/migrations/5.0.24.10/post-0001_update_validate_d101_wizard.py
@@ -22,7 +22,7 @@ def up(cursor, installed_version):
     load_data(
         cursor,
         "som_switching",
-        "wizard/wizard_validate_d101.xml",
+        "wizard/wizard_validate_d101_view.xml",
         idref=None,
         mode="update",
     )

--- a/som_switching/tests/tests_activacions_b1.py
+++ b/som_switching/tests/tests_activacions_b1.py
@@ -34,7 +34,7 @@ class TestActivacioB1(TestSwitchingImport):
         # create step 01
         self.change_polissa_comer(txn)
         self.update_polissa_distri(txn)
-        self.activar_polissa_CUPS(txn, context)
+        self.activar_polissa_CUPS(txn, context=context)
         step_id = self.create_case_and_step(cursor, uid, contract_id, "B1", "01")
 
         sw_id = self.B101.read(cursor, uid, step_id, ["sw_id"])["sw_id"][0]

--- a/som_switching/tests/tests_activacions_b2.py
+++ b/som_switching/tests/tests_activacions_b2.py
@@ -34,7 +34,7 @@ class TestActivacioB2(TestSwitchingImport):
         # create step 05
         self.change_polissa_comer(txn)
         self.update_polissa_distri(txn)
-        self.activar_polissa_CUPS(txn, context)
+        self.activar_polissa_CUPS(txn, context=context)
         step_id = self.create_case_and_step(
             cursor, uid, contract_id, "B2", "05", {"whereiam": "distri"}
         )

--- a/som_switching/tests/tests_activacions_cn.py
+++ b/som_switching/tests/tests_activacions_cn.py
@@ -34,7 +34,7 @@ class TestActivacioCn(TestSwitchingImport):
         }
         # create step 06
         self.update_polissa_distri(txn)
-        self.activar_polissa_CUPS(txn, context)
+        self.activar_polissa_CUPS(txn, context=context)
         self.change_polissa_comer(txn)
         step_id = self.create_case_and_step(
             cursor, uid, contract_id, tipus, "06", {"whereiam": "distri"}

--- a/som_switching/tests/tests_activacions_m1.py
+++ b/som_switching/tests/tests_activacions_m1.py
@@ -31,7 +31,7 @@ class TestActivacioM1(TestSwitchingImport):
         # create step 01
         self.change_polissa_comer(txn)
         self.update_polissa_distri(txn)
-        self.activar_polissa_CUPS(txn, context)
+        self.activar_polissa_CUPS(txn, context=context)
         step_id = self.create_case_and_step(cursor, uid, contract_id, "M1", "01")
 
         pt_obj = self.openerp.pool.get("payment.type")

--- a/som_switching/tests/tests_wizard_validate_d101.py
+++ b/som_switching/tests/tests_wizard_validate_d101.py
@@ -42,10 +42,11 @@ class TestWizardValidateD101(TestSwitchingImport):
         autoconsum_id = self.crear_autoconsum(txn)
 
         polissa_obj = self.openerp.pool.get("giscedata.polissa")
-        cups_obj = self.openerp.pool.get("giscedata.cups.ps")
+        # cups_obj = self.openerp.pool.get("giscedata.cups.ps")
 
         cups_id = polissa_obj.read(cursor, uid, contract_id, ["cups"])["cups"]
-        cups_obj.write(cursor, uid, cups_id[0], {"autoconsum_id": autoconsum_id})
+        self.activar_autoconsum_a_cups(txn, autoconsum_id, cups_id[0])
+        # cups_obj.write(cursor, uid, cups_id[0], {"autoconsum_id": autoconsum_id})
 
         # Button create case
         context.update({"autoconsum_id": autoconsum_id})

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -38,7 +38,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
                 pas_obj = self.pool.get(swsi_obj).browse(cursor, uid, eval(pas_id))
                 if pas_obj.motiu_canvi != "04":
                     continue
-                if not sw.cups_polissa_id.active or sw.cups_polissa_id.tipus_autoconsum != "00":
+                if not sw.cups_polissa_id.active or sw.cups_polissa_id.autoconsumo != "00":
                     case_ids.append(sw.case_id.id)
 
         ctx = context.copy()

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -38,7 +38,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
                 pas_obj = self.pool.get(swsi_obj).browse(cursor, uid, eval(pas_id))
                 if pas_obj.motiu_canvi != "04":
                     continue
-                if not sw.cups_polissa_id.active or sw.cups_polissa_id.autoconsumo != "00":
+                if not sw.cups_polissa_id.active or sw.cups_polissa_id.tipus_autoconsum != "00":
                     case_ids.append(sw.case_id.id)
 
         ctx = context.copy()

--- a/som_switching/wizard/wizard_close_obsolete_cases.py
+++ b/som_switching/wizard/wizard_close_obsolete_cases.py
@@ -38,7 +38,7 @@ class WizardCloseObsoleteCases(osv.osv_memory):
                 pas_obj = self.pool.get(swsi_obj).browse(cursor, uid, eval(pas_id))
                 if pas_obj.motiu_canvi != "04":
                     continue
-                if not sw.cups_polissa_id.active or sw.cups_polissa_id.autoconsumo != "00":
+                if not sw.cups_polissa_id.active or sw.cups_polissa_id.tipus_subseccio != "00":
                     case_ids.append(sw.case_id.id)
 
         ctx = context.copy()

--- a/som_switching/wizard/wizard_validate_d101.py
+++ b/som_switching/wizard/wizard_validate_d101.py
@@ -242,6 +242,12 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
 
         # validate tarpot changes
         self_vals = self.read(cursor, uid, ids)[0]
+        if not self_vals['autoconsum_id']:
+            raise osv.except_osv(
+                "Error",
+                _(u"No s'ha pogut crear el cas M1 per la pòlissa {}"
+                  "al no haver-hi un autoconsum".format(pol_id))
+            )
         wiz_obj_vals = wiz_obj.read(cursor, uid, wiz_id)[0]
         wiz_modcon_args = {
             "tariff": self_vals["tariff"]
@@ -346,7 +352,7 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
         }
 
     _columns = {
-        'autoconsum_id': fields.many2one('giscedata.autoconsum', 'Autoconsums', size=64),
+        'autoconsum_id': fields.many2one('giscedata.autoconsum', 'Autoconsum', size=64),
         "is_rejected": fields.boolean(
             "Rebutjar", help="Si s'activa es generarà un D1-02 serà de rebuig"
         ),

--- a/som_switching/wizard/wizard_validate_d101.py
+++ b/som_switching/wizard/wizard_validate_d101.py
@@ -34,7 +34,7 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
         """
         Method prepared to add default values
         """
-        res = {"tipus_mod_autoconsum": 'alta'}
+        res = {"tipus_mod_cau": 'alta'}
 
         isAutoconsum = self.isAutoconsum(cursor, uid)
 
@@ -84,10 +84,13 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
             )
             self.write(cursor, uid, [ids], {"generated_d102": d102_id})
 
-        cups_name = sw_obj.read(cursor, uid, sw_id, ["cups_id"])["cups_id"][1]
+        cups_id, cups_name = sw_obj.read(cursor, uid, sw_id, ["cups_id"])["cups_id"]
+        # cups_id = sw_obj.read(cursor, uid, sw_id, ["cups_id"])["cups_id"][0]
 
         if not is_rejected:
-            pol_id = sw_obj.read(cursor, uid, sw_id, ["polissa_ref_id"])["polissa_ref_id"][0]
+            pol_obj = self.pool.get("giscedata.polissa")
+            pol_id = pol_obj.search(cursor, uid, [('cups', '=', cups_id)])[0]
+            # pol_id = sw_obj.read(cursor, uid, sw_id, ["polissa_ref_id"])["polissa_ref_id"][0]
 
             try:
                 m1_id = self._create_case_m1_01_autoconsum(cursor, uid, ids, pol_id, context)
@@ -100,7 +103,7 @@ class GiscedataSwitchingWizardValidateD101(osv.osv_memory):
                 raise osv.except_osv(
                     "Error",
                     _(
-                        u"No s'ha pogut crear el cas M1 pel contracte {}: {}".format(
+                        u"No s'ha pogut crear el cas M1 pel contracte amb id {}: {}".format(
                             pol_id, e.message
                         )
                     ),

--- a/som_switching/wizard/wizard_validate_d101_view.xml
+++ b/som_switching/wizard/wizard_validate_d101_view.xml
@@ -11,6 +11,7 @@
                     <group attrs="{'invisible': [('state', '!=', 'init')]}">
                         <group colspan="4">
                             <field name="sw_id"/>
+                            <field name="autoconsum_id"/>
                             <field name="is_rejected"/>
                         </group>
                         <group colspan="4" attrs="{'invisible': [('is_rejected', '!=', True)]}">

--- a/www_som/tests/tests_polissa.py
+++ b/www_som/tests/tests_polissa.py
@@ -222,7 +222,7 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
         today_plus_10_days = (datetime.today() + timedelta(days=10)).strftime("%Y-%m-%d")
         today_plus_100_days = (datetime.today() + timedelta(days=10)).strftime("%Y-%m-%d")
 
-        values = {"autoconsumo": "41"}
+        values = {"tipus_subseccio": "41"}
 
         self.pol_obj.crear_modcon(
             self.cursor,

--- a/www_som/tests/tests_polissa.py
+++ b/www_som/tests/tests_polissa.py
@@ -222,7 +222,7 @@ class TestPolissaWwwAutolectura(testing.OOTestCase):
         today_plus_10_days = (datetime.today() + timedelta(days=10)).strftime("%Y-%m-%d")
         today_plus_100_days = (datetime.today() + timedelta(days=10)).strftime("%Y-%m-%d")
 
-        values = {"tipus_subseccio": "41"}
+        values = {"tipus_subseccio": "21"}
 
         self.pol_obj.crear_modcon(
             self.cursor,


### PR DESCRIPTION
## Objectiu
PR per adaptar-nos als canvis del ATR 3.0 del repo de GISCE
(PR anterior descartada https://github.com/Som-Energia/openerp_som_addons/pull/272)

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/682
https://somenergia.openproject.com/wp/703


## Comportament antic
Funcionalitats no adaptades als nous models ATR 3.0

## Comportament nou
Funcionalitats adapatades als nous models ATR 3.0

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
giscedata_facturacio_comer_som
- [x] Script de migració
som_atc
som_polissa
som_switching
- [x] Modifica traduccions
