### PR TITLE
Fix invoice copy_data to dont copy mail info

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_factura.py
@@ -15,6 +15,20 @@ class GiscedataFacturacioFactura(osv.osv):
     _name = 'giscedata.facturacio.factura'
     _inherit = 'giscedata.facturacio.factura'
 
+    def copy_data(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        res, x = super(GiscedataFacturacioFactura, self).copy_data(
+            cr, uid, id, default, context
+        )
+        res.update({
+            'enviat_mail_id': False,
+            'enviat': False,
+            'enviat_data': False,
+            'enviat_carpeta': False,
+        })
+        return res, x
+
     # Poweremails hooks
     def poweremail_write_callback(self, cursor, uid, ids, vals, context=None):
         res = True


### PR DESCRIPTION
## Objectiu

https://freescout.somenergia.coop/conversation/7976387?folder_id=87

S'estava copiant tota la info del mail i ens molestava en les abonadores, que quedaven linkades al mail de la factura original i per tant al imprimir el PDF agafava també l'original.


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
