### PR TITLE
Fix www_som tests

### DIFF
--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -12,7 +12,6 @@
         "l10n_ES_cobros_ventanilla",
         "powersms",
         "giscedata_facturacio_impagat_comer",
-        "www_som",
         "poweremail",
         "som_polissa",
         "custom_search",
@@ -21,6 +20,7 @@
         "giscedata_facturacio_comer_bono_social",
         "giscedata_atc",
         "giscedata_facturacio_comer_som",
+        "som_generationkwh",
     ],
     "init_xml": [
     ],

--- a/www_som/__terp__.py
+++ b/www_som/__terp__.py
@@ -18,6 +18,7 @@ Mòdul per la integració de l'oficina virtual
         "giscedata_lectures_pool",
         "giscedata_facturacio_impagat_comer",
         "giscedata_atc_switching",
+        "som_account_invoice_pending",
     ],
     "init_xml": [],
     "demo_xml": [

--- a/www_som/__terp__.py
+++ b/www_som/__terp__.py
@@ -19,6 +19,8 @@ Mòdul per la integració de l'oficina virtual
         "giscedata_lectures_pool",
         "giscedata_facturacio_impagat_comer",
         "giscedata_atc_switching",
+        "som_account_invoice_pending",
+        "l10n_ES_cobros_ventanilla",
     ],
     "init_xml": [],
     "demo_xml": [

--- a/www_som/__terp__.py
+++ b/www_som/__terp__.py
@@ -8,7 +8,6 @@ Mòdul per la integració de l'oficina virtual
     "author": "GISCE-TI, S.L.",
     "category": "www",
     "depends": [
-        "base_extended",
         "base_extended_som",
         "www_base",
         "som_polissa_soci",
@@ -19,8 +18,6 @@ Mòdul per la integració de l'oficina virtual
         "giscedata_lectures_pool",
         "giscedata_facturacio_impagat_comer",
         "giscedata_atc_switching",
-        "som_account_invoice_pending",
-        "l10n_ES_cobros_ventanilla",
     ],
     "init_xml": [],
     "demo_xml": [

--- a/www_som/requirements.txt
+++ b/www_som/requirements.txt
@@ -1,0 +1,1 @@
+retrofix

--- a/www_som/requirements.txt
+++ b/www_som/requirements.txt
@@ -1,1 +1,0 @@
-retrofix


### PR DESCRIPTION
## Objectiu
Fix www_som tests

## Targeta on es demana o Incidència
RedTestsBugster

## Canvis
Per alguna raó, el destral no instala el paquet retrofix d'aquest [aquest mòdul de GISCE](https://github.com/gisce/erp/blob/6b8f35dfbe2f576a00ffe239314e264d7a5f1a40/addons/spain/l10n_es_extras/l10n_ES_cobros_ventanilla/requirements.txt#L2) i l'hem de forçar aqui.
