### PR TITLE
Canvia el tipus del error d'importació 3043 de avís a crític

### DIFF
--- a/som_facturacio_switching/giscedata_facturacio_switching_error_data.xml
+++ b/som_facturacio_switching/giscedata_facturacio_switching_error_data.xml
@@ -16,7 +16,7 @@
         </record>
     </data>
     <data>
-        <record model="giscedata.facturacio.switching.error.template" id="error_phase_3_code_043" forcecreate="1">
+        <record model="giscedata.facturacio.switching.error.template" id="giscedata_facturacio_switching.error_phase_3_code_043" forcecreate="1">
             <field name="level">critical</field>
         </record>
     </data>

--- a/som_facturacio_switching/giscedata_facturacio_switching_error_data.xml
+++ b/som_facturacio_switching/giscedata_facturacio_switching_error_data.xml
@@ -15,4 +15,9 @@
             <field name="level">warning</field>
         </record>
     </data>
+    <data>
+        <record model="giscedata.facturacio.switching.error.template" id="error_phase_3_code_043" forcecreate="1">
+            <field name="level">critical</field>
+        </record>
+    </data>
 </openerp>

--- a/som_facturacio_switching/migrations/5.0.25.3.0/post-0001_reaload_switching_errors.py
+++ b/som_facturacio_switching/migrations/5.0.25.3.0/post-0001_reaload_switching_errors.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import logging
+from tools import config
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating giscedata_facturacio_switching_data.xml")
+    load_data_records(
+        cursor,
+        'som_facturacio_switching',
+        'giscedata_facturacio_switching_data.xml',
+        ['error_phase_3_code_043'],
+        mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+    # Run the script: manual_migration.py
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_facturacio_switching/migrations/5.0.25.3.0/post-0001_reaload_switching_errors.py
+++ b/som_facturacio_switching/migrations/5.0.25.3.0/post-0001_reaload_switching_errors.py
@@ -10,12 +10,12 @@ def up(cursor, installed_version):
 
     logger = logging.getLogger('openerp.migration')
 
-    logger.info("Updating giscedata_facturacio_switching_data.xml")
+    logger.info("Updating giscedata_facturacio_switching_error_data.xml")
     load_data_records(
         cursor,
         'som_facturacio_switching',
-        'giscedata_facturacio_switching_data.xml',
-        ['error_phase_3_code_043'],
+        'giscedata_facturacio_switching_error_data.xml',
+        ['giscedata_facturacio_switching.error_phase_3_code_043'],
         mode='update'
     )
     logger.info("XMLs succesfully updated.")


### PR DESCRIPTION
## Objectiu

Cal modificar el tipus del error d'importació 3043 d'avís a crític per tal de que pari i no permeti continuar, però només per som

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/618/activity

## Comportament antic

era warning i permetia continuar facturant

## Comportament nou

es crític i para el pipeline de facturació del contracte

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
        som_facturacio_switching
- [ ] Script de migració
- [ ] Modifica traduccions
