### PR TITLE
Update 6eis name in XMLs (formerly aseme)

### DIFF
--- a/som_crawlers/data/som_crawlers_config_data.xml
+++ b/som_crawlers/data/som_crawlers_config_data.xml
@@ -341,8 +341,8 @@
             <field name="port">22</field>
             <field name="user_ultima_modificacio" ref="base.user_admin"/>
         </record>
-        <record model="som.crawlers.config" id="aseme_ftp_conf">
-            <field name="name">aseme_ftp</field>
+        <record model="som.crawlers.config" id="aseme_ftp_conf">  <!-- now 6eis -->
+            <field name="name">6eis_ftp</field>
             <field name="crawler">Selenium</field>
             <field name="days_of_margin">5</field>
             <field name="pending_files_only" eval="False"/>

--- a/som_crawlers/data/som_crawlers_step_data.xml
+++ b/som_crawlers/data/som_crawlers_step_data.xml
@@ -955,9 +955,9 @@
             <field name="params">{}</field>
             <field name="task_id" ref="descarregar_chilla_ftp"/>
         </record>
-        <!-- aseme -->
+        <!-- 6eis (formerly aseme) -->
         <record model="som.crawlers.task.step" id="pas_descarregar_ftp_aseme">
-            <field name="name">Descarregar fitxers FTP aseme</field>
+            <field name="name">Descarregar fitxers FTP 6eis (abans aseme)</field>
             <field name="sequence">1</field>
             <field name="function">download_ftp_files</field>
             <field name="params">{"dir_list": ["Entrada"]}</field>

--- a/som_crawlers/data/som_crawlers_task_data.xml
+++ b/som_crawlers/data/som_crawlers_task_data.xml
@@ -355,9 +355,9 @@
             <field name="active">True</field>
             <field name="configuracio_id" ref="chilla_ftp_conf"/>
         </record>
-        <!-- aseme -->
+        <!-- 6eis (formerly aseme) -->
         <record model="som.crawlers.task" id="descarregar_aseme_ftp">
-            <field name="name">Descarregar FTP aseme</field>
+            <field name="name">Descarregar FTP 6eis (abans aseme)</field>
             <field name="active">True</field>
             <field name="configuracio_id" ref="aseme_ftp_conf"/>
         </record>


### PR DESCRIPTION
## Objectiu
Simplement actualitzar els noms per quan fem proves amb som_crawlers en local no liarnos, ja que a producció ja es diu 6eis. No cal ni instal·lar ni migrar ni res.

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/678

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
