### PR TITLE
Arreglar la funció search quan l'operador no és ilike

### DIFF
--- a/giscedata_facturacio_som/giscedata_facturacio.py
+++ b/giscedata_facturacio_som/giscedata_facturacio.py
@@ -34,14 +34,14 @@ class GiscedataFacturacio(osv.osv):
             for idx, arg in enumerate(args):
                 if len(arg) == 3:
                     field, operator, match = arg
-                    if exact_number and field == "number" and isinstance(match, (unicode, str)):  # noqa: E501, F821
-                        if "%" not in match:
-                            operator = "="
-                        args[idx] = (field, operator, match)
-                    if exact_origin and field == "origin" and isinstance(match, (unicode, str)):  # noqa: E501, F821
-                        if "%" not in match:
-                            operator = "="
-                        args[idx] = (field, operator, match)
+                    if (exact_number and field == "number" and operator == "ilike"
+                            and isinstance(match, (unicode, str) and "%" not in match):
+                            operator="="
+                            args[idx]=(field, operator, match)
+                    if (exact_origin and field == "origin" and operator == "ilike"
+                        and isinstance(match, (unicode, str)) and "%" not in match):
+                            operator="="
+                            args[idx]=(field, operator, match)
         return super(GiscedataFacturacio, self).search(
             cr, user, args, offset, limit, order, context, count
         )

--- a/giscedata_facturacio_som/giscedata_facturacio.py
+++ b/giscedata_facturacio_som/giscedata_facturacio.py
@@ -35,13 +35,13 @@ class GiscedataFacturacio(osv.osv):
                 if len(arg) == 3:
                     field, operator, match = arg
                     if (exact_number and field == "number" and operator == "ilike"
-                            and isinstance(match, (unicode, str) and "%" not in match):
-                            operator="="
-                            args[idx]=(field, operator, match)
+                            and isinstance(match, (unicode, str)) and "%" not in match):
+                        operator = "="
+                        args[idx] = (field, operator, match)
                     if (exact_origin and field == "origin" and operator == "ilike"
-                        and isinstance(match, (unicode, str)) and "%" not in match):
-                            operator="="
-                            args[idx]=(field, operator, match)
+                            and isinstance(match, (unicode, str)) and "%" not in match):
+                        operator = "="
+                        args[idx] = (field, operator, match)
         return super(GiscedataFacturacio, self).search(
             cr, user, args, offset, limit, order, context, count
         )

--- a/giscedata_facturacio_som/tests/tests_giscedata_facturacio_som.py
+++ b/giscedata_facturacio_som/tests/tests_giscedata_facturacio_som.py
@@ -112,3 +112,21 @@ class TestGiscedataFacturacioSom(testing.OOTestCaseWithCursor):
         gff_ids = self.gff_obj.search(self.cursor, self.uid, [("origin", "ilike", "sample_origin")])
 
         self.assertGreater(len(gff_ids), 1)
+
+    def test_search_nonequal_operator_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, "1")
+
+        gff_ids = self.gff_obj.search(
+            self.cursor, self.uid, [("origin", "!=", "sample_origin1")]
+        )
+
+        self.assertEqual(len(gff_ids), 3)
+
+    def test_search_equal_operator_active(self):
+        self.set_invoice_origin_cerca_exacte(self.cursor, self.uid, "1")
+
+        gff_ids = self.gff_obj.search(
+            self.cursor, self.uid, [("origin", "=", "sample_origin1")]
+        )
+
+        self.assertEqual(len(gff_ids), 1)


### PR DESCRIPTION
## Objectiu
Arreglar la funció search quan l'operador no és ilike

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/7981701?folder_id=87
https://somenergia.openproject.com/projects/som-energia/work_packages/618/activity

## Comportament antic
Si no apareix un "%" en el camp número de factura o origen de factura, substitueix l'operador que sigui per un "=". Això provocava que quan es feia una cerca per aquests camps amb un operador com per exemple "!=", el comportament dels resultats era contrari al buscat amb l'optimització.

## Comportament nou
Només substitueix l'operador per un "=" quan l'operador és un "ilike".

## Comprovacions

- [ ] Reiniciar serveis
