### PR TITLE
🏗️ Actualitzar versions terp a 24.5.0 + script per fer-ho

### DIFF
--- a/account_account_som/__terp__.py
+++ b/account_account_som/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Obligació que un compte comptable tingui pare
     """,
-    "version": "0.1",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/account_invoice_som/__terp__.py
+++ b/account_invoice_som/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Account invoice comer (SomEnergia)",
     "description": """Este módulo añade las siguientes funcionalidades:
     * Extiende account_invoice""",
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "GISCEMaster",
     "depends": [

--- a/base_extended_som/__terp__.py
+++ b/base_extended_som/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Base extension de Som Energia",
     "description": """Base models extensions""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "Som Energia",
     "category": "Generic Modules",
     "depends": [

--- a/dx_invoice_supplier_renumber/__terp__.py
+++ b/dx_invoice_supplier_renumber/__terp__.py
@@ -4,7 +4,7 @@
     "description": """
         *** Dx Invoice Supplier Renumber
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "Domatix",
     "category": "Account",
     "depends": [

--- a/giscedata_facturacio_comer_som/__terp__.py
+++ b/giscedata_facturacio_comer_som/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Reports Facturació SOM (Comercialitzadora)",
     "description": """Reports Facturació SOM (Comercialitzadora)""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "Extrareports",
     "depends": [

--- a/giscedata_facturacio_iva_10_som/__terp__.py
+++ b/giscedata_facturacio_iva_10_som/__terp__.py
@@ -6,7 +6,7 @@
   Este módulo introduce un modelo de datos para guardar en el ERP la media aritmética del precio medio de OMIE
   a nivel mensual, en barras de central.
   """,  # noqa: E501
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "GISCEMaster",
     "depends": ["base", "giscedata_facturacio_iva_10"],

--- a/giscedata_facturacio_som/__terp__.py
+++ b/giscedata_facturacio_som/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Giscedata Facturació Factura (SomEnergia)",
     "description": """Este módulo añade las siguientes funcionalidades:
     * Extiende giscedata_facturacio""",
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "GISCE extend",
     "depends": [

--- a/report_tester/__terp__.py
+++ b/report_tester/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * menus models u wizards per poder testejar reports de manera integrada dins del erp
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/scripts/update_terp_version.py
+++ b/scripts/update_terp_version.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" Script to update __terp__.py versions of the module
+
+This is a script copied from GISCE due execution path limitatons
+Original path script: erp/scripts/update_terp_version.py
+
+Som Energia example execution:
+    python scripts/update_terp_version.py . 24.5.0
+
+"""
+
+EXTRA_DIRECTORIES = [
+    'server/bin/addons/base',
+    'addons/gisce/',
+    'addons/extra/account_invoice_pending',
+    'addons/spain/l10n_es_extras/l10n_ES_aeat_sii',
+    'addons/spain/l10n_es_extras/l10n_ES_face',
+    'addons/official/account',
+    'addons/official/crm',
+    'addons/spain/l10n_es/l10n_chart_ES',
+]
+
+
+def confirm(ask_query="OK to push to continue [Y/N]?"):
+    """
+    Ask user to enter Y or N (case-insensitive).
+    :return: True if the answer is Y.
+    :rtype: bool
+    """
+    answer = ""
+    while answer not in ["y", "n"]:
+        answer = raw_input(ask_query + ' ').lower()
+    return answer == "y"
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    import re
+
+    directory = sys.argv[1]
+    version = sys.argv[2]
+
+    pattern = "2\.[0-9]+\.[0-9]+"  # noqa: W605
+    # Versions should be a 2, followed by a . and a number and another . and
+    # another number. A possible example is: "2.79.2"
+    if not re.match(pattern, version):
+        confirm_message = "Provided version does not match usual pattern, " \
+                          "do you wish to continue?"
+        if not confirm(confirm_message):
+            sys.exit(0)
+
+    print ("Updating to version {version}".format(**locals()))
+    version_regex = r'["\']version*["\'](.*)["\'],'
+    replace_str = r'"version": "{}",'.format(version)
+
+    modules = 0
+    updated = 0
+
+    directories_to_update = []
+    if directory != 'all':
+        directories_to_update.append(directory)
+    else:
+        directories_to_update.extend(EXTRA_DIRECTORIES)
+
+    for directory in directories_to_update:
+        for root, dirs, files in os.walk(directory):
+            if '.svn' in dirs:
+                dirs.remove('.svn')
+            if '.git' in dirs:
+                dirs.remove('.git')
+            if '__terp__.py' in files:
+                modules += 1
+                module = root.split(os.path.sep)[-1]
+                terp_file_path = os.path.join(root, '__terp__.py')
+                with open(terp_file_path, 'r') as f:
+                    terp = f.read()
+                    parsed_version_terp = re.sub(version_regex, replace_str,
+                                                 terp)
+                with open(terp_file_path, 'w') as f:
+                    f.write(parsed_version_terp)
+                if parsed_version_terp != terp:
+                    updated += 1
+                    print (
+                        "** MODULE: {module} **  => Upgraded to {version}".format(
+                            **locals()
+                        ))
+
+    print("Updated {updated}/{modules}".format(**locals()))

--- a/som_account_invoice_pending/__terp__.py
+++ b/som_account_invoice_pending/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Procediments d'impagats específics de Som Energia",
     "description": """Mòdul per a la gestió dels impagaments de contractes
         especifics de SomEngergia""",
-    "version": "0.1.2",
+    "version": "24.5.0",
     "author": "Som Energia SCCL",
     "category": "Master",
     "depends": [

--- a/som_assets/__terp__.py
+++ b/som_assets/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "som_assets",
     "description": "Assets per fer servir a les comunicacions amb les sòcies",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_atc/__terp__.py
+++ b/som_atc/__terp__.py
@@ -4,7 +4,7 @@
     "description": """Aquest mòdul afegeix les següents funcionalitats:
     * Funcionalitats sobre casos d'atencio al client
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "Master",
     "depends": [

--- a/som_autofactura/__terp__.py
+++ b/som_autofactura/__terp__.py
@@ -5,7 +5,7 @@
     Aquest mòdul fa:
         * Poder definir un workflow de tasques, activades o no, per automatitzar el procés de facturació.
     """,  # noqa: E501
-    "version": "0.dev",
+    "version": "24.5.0",
     "author": "SOM ENERGIA",
     "category": "SomEnergia",
     "depends": [

--- a/som_autoreclama/__terp__.py
+++ b/som_autoreclama/__terp__.py
@@ -7,7 +7,7 @@
         * Model d'historització
         * Vistes associades
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SOM ENERGIA",
     "category": "SomEnergia",
     "depends": [

--- a/som_auvidi/__terp__.py
+++ b/som_auvidi/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Customitzacions per AUVIDIs (Serveis de generació) per a SOM",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_control_reports/__terp__.py
+++ b/som_control_reports/__terp__.py
@@ -6,7 +6,7 @@
         * Report de control de l'estat y creixement de diferents àmbits, com
         socis, contractes, ATR, etc ...
     """,
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "SOM ENERGIA",
     "category": "SomEnergia",
     "depends": ["base", "som_polissa_soci", "giscedata_switching"],

--- a/som_crawlers/__terp__.py
+++ b/som_crawlers/__terp__.py
@@ -1,7 +1,7 @@
 {
     "name": "Mòdul per descarregar fitxers distribuidores electricitat",
     "description": """ """,
-    "version": "0.1",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "Master",
     "depends": [

--- a/som_custom_views/__terp__.py
+++ b/som_custom_views/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Vistes personalitzades de Som Energia",
     "description": """Vistes personalitzades de Som Energia""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "Som Energia",
     "category": "Generic Modules",
     "depends": [

--- a/som_documents_sensibles/__terp__.py
+++ b/som_documents_sensibles/__terp__.py
@@ -4,7 +4,7 @@
     "description": """Aquest mòdul afegeix les següents funcionalitats:
   * Afegeix el model de dades per a clients electrodependents
 """,
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "SOMEnergia",
     "category": "Master",
     "depends": [

--- a/som_empowering/__terp__.py
+++ b/som_empowering/__terp__.py
@@ -4,7 +4,7 @@
     "description": """Aquest mòdul afegeix les següents funcionalitats:
   * Add empowering features
 """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "Master",
     "depends": [

--- a/som_energetica/__terp__.py
+++ b/som_energetica/__terp__.py
@@ -4,7 +4,7 @@
     "description": """Aquest mòdul afegeix les següents funcionalitats:
   * Menú Energética
 """,
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "Master",
     "depends": [

--- a/som_estalvi/__terp__.py
+++ b/som_estalvi/__terp__.py
@@ -4,7 +4,7 @@
     "description": """
         Funcions i continguts per millorar l'estalvi dels contractes de SOM
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_extend_facturacio_comer/__terp__.py
+++ b/som_extend_facturacio_comer/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Som Energia billing extension",
     "description": """SomEnergia billing extension""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "Som Energia",
     "category": "Master",
     "depends": [

--- a/som_extend_facturacio_facturae/__terp__.py
+++ b/som_extend_facturacio_facturae/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Som Energia facturae extension",
     "description": """SomEnergia facturae extension""",
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "Som Energia",
     "category": "Master",
     "depends": ["base", "giscedata_facturacio", "giscedata_facturacio_facturae"],

--- a/som_facturacio_calculada/__terp__.py
+++ b/som_facturacio_calculada/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Mòdul per crear lectures calculades per a la facturació",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_facturacio_comer/__terp__.py
+++ b/som_facturacio_comer/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Validació propia a giscedata_facturacio_comer
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_facturacio_flux_solar/__terp__.py
+++ b/som_facturacio_flux_solar/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Validació propia a giscedata_facturacio_bateria_virtual
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_facturacio_switching/__terp__.py
+++ b/som_facturacio_switching/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Funció propia a pólissa (escull_llista_preus) per escollir tarifa a partir llistes de preus.  # noqa: E501
     """,
-    "version": "2.107.6",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_factures_paper/__terp__.py
+++ b/som_factures_paper/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Mòdul per crear un assitent per ajudar a la impresuió de factures en paper",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_gurb/__terp__.py
+++ b/som_gurb/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Generació urbana",
     "description": "Mòdul per gestionar els grups de generació urbana",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_indexada/__terp__.py
+++ b/som_indexada/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Mòdul per gestionar els canvis a facturació indexada",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_infoenergia/__terp__.py
+++ b/som_infoenergia/__terp__.py
@@ -7,7 +7,7 @@
         * Model lot enviament
         * Acció d'enviament
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_informe/__terp__.py
+++ b/som_informe/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Mòdul per crear informes per Consum",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_inversions/__terp__.py
+++ b/som_inversions/__terp__.py
@@ -9,7 +9,7 @@
           bancari on es cobraran els interessos de les inversions
         * Creació d'impost per representar el % de retorn d'inversió
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_l10n_ES_aeat_mod347/__terp__.py
+++ b/som_l10n_ES_aeat_mod347/__terp__.py
@@ -3,7 +3,7 @@
     "name": "Som AEAT 347",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "Som",
     "category": "Master",
     "depends": ["base_extended_som", "account", "l10n_ES_aeat_mod347", "poweremail"],

--- a/som_leads_polissa/__terp__.py
+++ b/som_leads_polissa/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Afegir o modificar funcionalitats dels leads base
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/som_municipal_taxes/__terp__.py
+++ b/som_municipal_taxes/__terp__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Som municipal taxes',
     'description': 'Mòdul per gestionar el pagament del impost municipal',
-    'version': '0.1',
+    "version": "24.5.0",
     'category': 'Som Energia module',
     'website': 'https://github.com/Som-Energia/openerp-som-addons',
     'author': 'Som Energia SCCL',

--- a/som_partner_account/__terp__.py
+++ b/som_partner_account/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Creació de comptes comptables per partner.
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_partner_seq/__terp__.py
+++ b/som_partner_seq/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * A sequence for partners SXXXXXX.
     """,
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": ["base"],

--- a/som_polissa/__terp__.py
+++ b/som_polissa/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Pestanya de logs de Gestió Endarrerida
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_polissa_administradora/__terp__.py
+++ b/som_polissa_administradora/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Camp d'administradora per relacionar un contracte amb una administradora.
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_polissa_condicions_generals/__terp__.py
+++ b/som_polissa_condicions_generals/__terp__.py
@@ -4,7 +4,7 @@
     "description": """Aquest mòdul afegeix les següents funcionalitats:
     * Condicions generals pòlisses Somenergia
     """,
-    "version": "2.107.5",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_polissa_soci/__terp__.py
+++ b/som_polissa_soci/__terp__.py
@@ -5,7 +5,7 @@
     This module provide :
         * Camp de soci per relacionar un contracte amb un soci.
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "SomEnergia",
     "depends": [

--- a/som_poweremail_common_templates/__terp__.py
+++ b/som_poweremail_common_templates/__terp__.py
@@ -6,7 +6,7 @@
         * Common templates to be used in the rest of poweremail templates,
     p.e. header with customer data, logo, footer, legal texts... etc.
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SOM ENERGIA",
     "category": "SomEnergia",
     "depends": [

--- a/som_remeses_base/__terp__.py
+++ b/som_remeses_base/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "GISCE Remeses Base Somenergia",
     "description": """Modificació de remeses per mostrar el texte especific de client""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE Enginyeria, SL",
     "category": "Facturació",
     "depends": [

--- a/som_stash/__terp__.py
+++ b/som_stash/__terp__.py
@@ -7,7 +7,7 @@
         * Vistes associades
         * Scripts recurrents
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SOM ENERGIA",
     "category": "SomEnergia",
     "depends": [

--- a/som_switching/__terp__.py
+++ b/som_switching/__terp__.py
@@ -4,7 +4,7 @@
     "description": """Aquest mòdul afegeix les següents funcionalitats:
   * Categories per les pòlisses per els casos de switching
 """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "Master",
     "depends": [

--- a/som_telemesura/__terp__.py
+++ b/som_telemesura/__terp__.py
@@ -3,7 +3,7 @@
     "name": "SOM Telemesura",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE-TI",
     "category": "",
     "depends": ["giscedata_telemesura"],

--- a/som_tg_comer_provider/__terp__.py
+++ b/som_tg_comer_provider/__terp__.py
@@ -3,7 +3,7 @@
     "name": "SOM Tg Comer Provider",
     "description": """
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "",
     "depends": [

--- a/som_webforms_helpers/__terp__.py
+++ b/som_webforms_helpers/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "Webforms Helpers for Som Energia",
     "description": """Aquest mòdul afegeix funcions per donar suport a l'API de Webforms""",
-    "version": "2.103.13",
+    "version": "24.5.0",
     "author": "SOMEnergia",
     "category": "Master",
     "depends": [

--- a/somre_giscere_facturacio/__terp__.py
+++ b/somre_giscere_facturacio/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "GISCE RE Facturacio Som Energia",
     "description": """Mòdul per Facturació de contractes de Representació a Som Energia""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "RE",
     "depends": [

--- a/somre_giscere_oferta/__terp__.py
+++ b/somre_giscere_oferta/__terp__.py
@@ -2,7 +2,7 @@
 {
     "name": "GISCE RE Oferta Som Energia",
     "description": """Mòdul de generació i publicació d'Ofertas de Generació""",
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE",
     "category": "RE",
     "depends": [

--- a/somre_ov_module/__terp__.py
+++ b/somre_ov_module/__terp__.py
@@ -3,7 +3,7 @@
 {
     'name': 'somre_ov_module',
     'description': 'Modul de som representa com a suport de la oficina virtual',
-    'version': '1.0',
+    "version": "24.5.0",
     'category': 'Som Energia module',
     'website': 'https://github.com/Som-Energia/openerp-som-addons',
     'author': 'Som Energia SCCL',

--- a/uiqmako_helpers/__terp__.py
+++ b/uiqmako_helpers/__terp__.py
@@ -7,7 +7,7 @@
         * Model lot enviament
         * Acció d'enviament
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [

--- a/www_som/__terp__.py
+++ b/www_som/__terp__.py
@@ -4,7 +4,7 @@
     "description": """
 Mòdul per la integració de l'oficina virtual
     """,
-    "version": "0-dev",
+    "version": "24.5.0",
     "author": "GISCE-TI, S.L.",
     "category": "www",
     "depends": [


### PR DESCRIPTION
## Objectiu
🏗️ Actualitzar versions terp a 24.5.0 + script per fer-ho

## Targeta on es demana o Incidència
https://somenergia.openproject.com/work_packages/497

## Comportament antic
Teníem un poti poti de 0-dev, versions random (0.1, 0.1.2, 1.0) i versions antigues (2.103.13, 2.107.5, 2.107.6)

## Comportament nou
Tots els terps estan a la versió que tenim a productiu i tenim un script per actualitzar-lo.
Exemple d'execució:
```bash
python scripts/update_terp_version.py . 24.5.0
```
