### PR TITLE
✨🌐  Add new auto subseccion translations and description methods

### DIFF
--- a/som_polissa/giscedata_cups.py
+++ b/som_polissa/giscedata_cups.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from osv import osv, fields
 from tools.translate import _
+from gestionatr.defs import TABLA_113_NEW, TABLA_133
 
 
 TABLA_113_dict = {  # Table extracted from gestionatr.defs TABLA_113, not imported due translations issues  # noqa: E501
@@ -28,6 +29,25 @@ TABLA_113_dict = {  # Table extracted from gestionatr.defs TABLA_113, not import
     '73': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - Consum"),  # noqa: E501
     '74': _(u"Amb excedents sense compensació Col·lectiu amb cte. de Serv. Aux. a través de xarxa i xarxa interior - SSAA"),  # noqa: E501
 }
+
+TABLA_113_NEW_CA_dict = {
+    '00': 'Sense Autoconsum',
+    '11': 'Sense excedents',
+    '12': 'Amb excedents',
+    '0C': 'Baixa com a memebre d\'autoconsum col·lectiu',
+}
+
+TABLA_133_CA_dict = {
+    '10': "Sense excedents No acollit a compensació",
+    '11': "Sense excedents acollit a compensació",
+    '20': "Amb excedents no acollits a compensació",
+    '21': "Amb excedents acollits a compensació",
+    '00': "Sense autoconsum",
+    '0C': "Baixa com a membre d'autoconsum col·lectiu",
+}
+
+TABLA_113_NEW_ES_dict = dict(TABLA_113_NEW)
+TABLA_133_ES_dict = dict(TABLA_133)
 
 
 class GiscedataCupsPs(osv.osv):
@@ -120,6 +140,20 @@ class GiscedataCupsPs(osv.osv):
         llista += vals
 
         return llista
+
+    def get_autoconsum_description(self, cursor, uid, auto_consum, lang):
+        """Get the description of the autoconsum"""
+        if lang == "ca_ES":
+            return auto_consum + " - " + TABLA_113_NEW_CA_dict[auto_consum]
+        else:
+            return auto_consum + " - " + TABLA_113_NEW_ES_dict[auto_consum]
+
+    def get_auto_tipus_subseccio_description(self, cursor, uid, tipus_subseccio, lang):
+        """Get the description of the auto tipus subseccio"""
+        if lang == "ca_ES":
+            return tipus_subseccio + " - " + TABLA_133_CA_dict[tipus_subseccio]
+        else:
+            return tipus_subseccio + " - " + TABLA_133_ES_dict[tipus_subseccio]
 
     _columns = {
         'importacio_cadastre_incidencies_origen': fields.char(

--- a/som_polissa/tests/__init__.py
+++ b/som_polissa/tests/__init__.py
@@ -2,3 +2,4 @@ from test_wizard_gestio_text_to_polissa import *
 from som_polissa_tests import *
 from som_polissa_webforms_helpers_tests import *
 from giscedata_polissa_tests import *
+from giscedata_cups_tests import *

--- a/som_polissa/tests/giscedata_cups_tests.py
+++ b/som_polissa/tests/giscedata_cups_tests.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+
+
+class TestGiscedataCups(testing.OOTestCase):
+    def model(self, model_name):
+        return self.openerp.pool.get(model_name)
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+        self.cups_obj = self.model("giscedata.cups.ps")
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test_get_autoconsum_description(self):
+        """
+        Test the get_autoconsum_description method of the polissa model.
+        """
+        autoconsum = self.cups_obj.get_autoconsum_description(self.cursor, self.uid, '00', "ca_ES")
+        self.assertEqual(autoconsum, u"00 - Sense Autoconsum")
+        autoconsum = self.cups_obj.get_autoconsum_description(self.cursor, self.uid, '12', "es_ES")
+        self.assertEqual(autoconsum, u"12 - Con excedentes")
+
+    def test_get_auto_tipus_subseccio_description(self):
+        """
+        Test the get_auto_tipus_subseccio_description method of the polissa model.
+        """
+        tipus_subseccio = self.cups_obj.get_auto_tipus_subseccio_description(
+            self.cursor, self.uid, "10", "ca_ES")
+        self.assertEqual(tipus_subseccio, u"10 - Sense excedents No acollit a compensació")
+        tipus_subseccio = self.cups_obj.get_auto_tipus_subseccio_description(
+            self.cursor, self.uid, "0C", "es_ES")
+        self.assertEqual(tipus_subseccio, u"0C - Baja como miembro de autoconsumo colectivo")


### PR DESCRIPTION
## Objectiu
✨🌐  Add new auto subseccion translations and description methods

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/7993509?folder_id=283

## Comportament antic
S'havien de traduïr aquests camps en cada report/email

## Comportament nou
Es poden cridar els mètodes de CUPS per obtenir la descripció d'aquests dos camps en l'idioma que es vulgui:
```python
cups_obj.get_autoconsum_description(cursor, uid, '00', 'ca_ES')
cups_obj.get_auto_tipus_subseccio_description(cursor, uid, '00', 'es_ES')
```

O importar directament la taula en format diccionari:
```python
from som_polissa.giscedata_cups import TABLA_113_dict
from som_polissa.giscedata_cups import TABLA_133_dict
```

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
