### PR TITLE
Disabled failed CI when update coveralls fail

### DIFF
--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -194,4 +194,5 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           format: cobertura
+          fail-on-error: false
           flag-name: ${{ inputs.module }}


### PR DESCRIPTION
## Objectiu
Disabled failed CI when update coveralls fail

## Targeta on es demana o Incidència
Ens falla de tant en tant la pujada a coveralls i ens fa petar el CI
https://github.com/Som-Energia/openerp_som_addons/actions/runs/14702131835/attempts/1

## Comportament antic
Si falla el servidor de coveralls, peta tot el pipeline.

## Comportament nou
Si falla el servidor de coveralls, no peta tot el pipeline.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
