### PR TITLE
🐛 corregir notació científica en els peatges d'energia si números molt petits

### DIFF
--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako
@@ -5,7 +5,7 @@
     <td class="td_bold detall_td">${_(u"Preu peatges per electricitat utilitzada [€/kWh]")}</td>
     % for p in id.showing_periods:
         % if p in id:
-            <td>${_(u"%s") %(locale.str(locale.atof(formatLang(id[p]["preu_peatge"], digits=6))))}</td>
+            <td>${_(u"%s") %(formatLang(id[p]["preu_peatge"], digits=6))}</td>
         % else:
             <td></td>
         % endif


### PR DESCRIPTION
## Objectiu

corregir notació científica en els peatges d'energia si números molt petits

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/7972661?folder_id=259

## Comportament antic

es mostrava en notació científica de l'estil 2.8e-6

## Comportament nou

es mostra correctament

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
