### PR TITLE
🚧 (ov_representa) Only hourly forecast measurements are shown in ov_rep

### DIFF
--- a/somre_ov_module/sql/get_forecast_measures.sql
+++ b/somre_ov_module/sql/get_forecast_measures.sql
@@ -6,6 +6,7 @@ WITH filtered_data AS (
         giscere_previsio_publicada gp
     WHERE
         gp.publicada = TRUE
+        AND gp.type = 'p'
         AND gp.codi_previsio = %(forecast_code)s
         AND gp."timestamp" AT TIME ZONE 'UTC' BETWEEN %(first_timestamp_utc)s AND %(last_timestamp_utc)s
 ),


### PR DESCRIPTION
## Objectiu
Sols mostrar les previsions horàries a l'OV de Representa

💡 Donar-li una pensada si caldria afegir-ho com a paràmetre indicant si es volen: _totes, horàries o quathoràries_ al [entry_point measures ](https://github.com/Som-Energia/openerp_som_addons/blob/main/somre_ov_module/models/somre_ov_production_data.py#L21) i conseqüentment al mètode del backend i la query.

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8004516?folder_id=87

## Comportament antic
Mostrava totes, horàries i quarthoràries

## Comportament nou
Sols mostra les horàries

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
