### PR TITLE
🐛 Fix 'ct_baixa_mailchimp'

### DIFF
--- a/som_switching/giscedata_switching_helpers.py
+++ b/som_switching/giscedata_switching_helpers.py
@@ -146,9 +146,11 @@ class GiscedataSwitchingHelpers(osv.osv):
         elif pas01_info["canvi_titular"] == "S" and not use_new_contract:
             # si es subrogació sense nou contracte, mirem que el titular abans i
             # després de la data d'activació són diferents
-            m102_obj = self.pool.get("giscedata.switching.m1.02")
+            model_name = sw.get_pas_model_name()
+            # 'giscedata.switching.m1.02' or 'giscedata.switching.m1.05' expected
+            m10X_obj = self.pool.get(model_name)
 
-            data_activacio = m102_obj.read(cursor, uid, pas_actual.id, ["data_activacio"])[
+            data_activacio = m10X_obj.read(cursor, uid, pas_actual.id, ["data_activacio"])[
                 "data_activacio"
             ]
             data_activacio = datetime.strptime(data_activacio, "%Y-%m-%d")


### PR DESCRIPTION
## Objectiu
Cobrir casuística no contemplada per als M105

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8009539?folder_id=185

## Comportament antic
S'assumia que els M1s de canvi de titular per subrogació sempre eren M102

## Comportament nou
Ara contemplem també els M105

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
