### PR TITLE
🐛 Fix report liquidacions unificat

### DIFF
--- a/som_inversions/report/report_liquidacions_unificat.py
+++ b/som_inversions/report/report_liquidacions_unificat.py
@@ -44,12 +44,16 @@ class ResPartner(osv.osv):
 
             data["invoices"][invoice.origin]["to_pay_total"] = invoice.amount_total
             data["invoices"][invoice.origin]["partner_iban"] = invoice.partner_bank.printable_iban
-
+            pos_date_ini = 3
+            pos_date_end = 6
             for line in invoice.invoice_line:
+                if line.name.split(" ")[0] == "Intereses":
+                    pos_date_ini = 2
+                    pos_date_end = 4
                 data["invoices"][invoice.origin]["lines"].append(
                     ns(
-                        date_ini=line.name.split(" ")[3],
-                        date_end=line.name.split(" ")[6],
+                        date_ini=line.name.split(" ")[pos_date_ini],
+                        date_end=line.name.split(" ")[pos_date_end],
                         quantity=float(
                             line.note.split("investmentInitialAmount: ")[1].split("\n")[0]
                         ),


### PR DESCRIPTION
## Objectiu
Corregir quan mostra de forma incorrecta les dates en el report de LIQUIDACIÓ INTERESSOS en aportacions voluntàries

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/666

## Comportament antic
En el cas que la descripció en la línea de la factura en castellà,  la posició on estan les dates varia.

## Comportament nou
Ara extrau les dates correctament en els 2 casos.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
