### PR TITLE
🐛 Mostrar per defecte 00 - Sin Autoconsumo al llistat de fitxers F1 si no TipoSubseccion al F1

### DIFF
--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -86,6 +86,8 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
         tipus_subseccio = re.findall("<TipoSubseccion>(.*)</TipoSubseccion>", xml_data)
         if tipus_subseccio:
             vals["tipus_subseccio"] = tipus_subseccio[0]
+        else:
+            vals["tipus_subseccio"] = '00'
 
         is_autoconsum_collectiu = re.findall("<Colectivo>(.*)</Colectivo>", xml_data)
         if is_autoconsum_collectiu:


### PR DESCRIPTION
## Objectiu

Mostrar per defecte 00 - Sin Autoconsumo al llistat de fitxers F1 importats quan el node TipoSubseccion no esta al F1 (o sigui sense autoconsum)

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/729/activity

## Comportament antic

mostrava en blanc

## Comportament nou

es mostra 00

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
