### PR TITLE
✨ Automatitzar ATR M105 (S)[R] Mod. Acord repartiment/fitxer coeficients 

### DIFF
--- a/som_gurb/__terp__.py
+++ b/som_gurb/__terp__.py
@@ -16,6 +16,7 @@
         "giscedata_polissa_representante",
         "som_poweremail_common_templates",
         "giscedata_signatura_documents_signaturit",
+        "som_switching",
         "som_polissa_condicions_generals"
     ],
     "demo_xml": [

--- a/som_gurb/models/giscedata_switching.py
+++ b/som_gurb/models/giscedata_switching.py
@@ -385,6 +385,7 @@ class GiscedataSwitchingHelpers(osv.osv):
             context = {}
 
         gurb_obj = self.pool.get("som.gurb")
+        sw_step_header_obj = self.pool.get("giscedata.switching.step.header")
         sw_obj = self.pool.get("giscedata.switching")
 
         res = super(GiscedataSwitchingHelpers, self).activar_polissa_from_m1(
@@ -398,14 +399,53 @@ class GiscedataSwitchingHelpers(osv.osv):
             and _contract_has_gurb_category(cursor, uid, self.pool, sw.cups_polissa_id.id)
         ):
             step_obj = self.pool.get("giscedata.switching.m1.05")
-            pas_id = int(sw.step_ids[-1].pas_id.split(",")[1])
+            step_id = int(sw.step_ids[-1].pas_id.split(",")[1])
 
             data_activacio = step_obj.read(
-                cursor, uid, pas_id, ["data_activacio"])["data_activacio"]
+                cursor, uid, step_id, ["data_activacio"])["data_activacio"]
 
             gurb_obj.activate_gurb_from_m1_05(
                 cursor, uid, sw_id, data_activacio, context=context
             )
+            sw_step_header_id = self.read(cursor, uid, step_id, ['header_id'])['header_id'][0]
+            sw_step_header_obj.write(
+                cursor, uid, sw_step_header_id, {'notificacio_pendent': False}
+            )
+
+        return res
+
+    def m105_acord_repartiment_autoconsum(self, cursor, uid, sw_id, context=None):
+        if context is None:
+            context = {}
+
+        sw_obj = self.pool.get('giscedata.switching')
+        sw_step_header_obj = self.pool.get("giscedata.switching.step.header")
+        gurb_obj = self.pool.get("som.gurb")
+
+        res = super(GiscedataSwitchingHelpers, self).m105_acord_repartiment_autoconsum(
+            cursor, uid, sw_id, context=context
+        )
+
+        sw = sw_obj.browse(cursor, uid, sw_id, context=context)
+        if (
+            sw.proces_id.name == "M1"
+            and sw.step_id.name == "05"
+            and _contract_has_gurb_category(cursor, uid, self.pool, sw.cups_polissa_id.id)
+        ):
+            step_obj = self.pool.get("giscedata.switching.m1.05")
+            step_id = int(sw.step_ids[-1].pas_id.split(",")[1])
+
+            data_activacio = step_obj.read(
+                cursor, uid, step_id, ["data_activacio"])["data_activacio"]
+
+            gurb_obj.activate_gurb_from_m1_05(
+                cursor, uid, sw_id, data_activacio, context=context
+            )
+            sw_step_header_id = self.read(cursor, uid, step_id, ['header_id'])['header_id'][0]
+            sw_step_header_obj.write(
+                cursor, uid, sw_step_header_id, {'notificacio_pendent': False}
+            )
+
         return res
 
 

--- a/som_switching/giscedata_switching_activation_data.xml
+++ b/som_switching/giscedata_switching_activation_data.xml
@@ -37,12 +37,27 @@
             <field name="comerdist">comer</field>
             <field name="sequence">999</field>
         </record>
+        <record model="giscedata.switching.activation.config" id="som_sw_act_m105_ct_traspas">
+            <field name="proces_id" ref="giscedata_switching.sw_proces_m1"/>
+            <field name="step_id" ref="giscedata_switching.sw_step_m1_05"/>
+            <field name="description">Nomes quan es tracte de un canvi de titular sense altres canvis.
+
+Si es tracte de una subrogació i en la variable de configuració 'sw_m1_owner_change_subrogacio_new_contract' s'indica que no es vol nou contracte per subrogacions (valor 0):
+Es fa una modificació contractual en la data indicada per la distribuidora cambiant el titular i les altres dades administratives.
+
+Si es tracte de un traspàs o una subrogació amb contracte nou (variable 'sw_m1_owner_change_subrogacio_new_contract' a 1):
+Es dona de baixa l'antic contracte en la data de canvi sol.licitada en el pas 01 o en data de última lectura facturada (la més recent).
+Les lectures, comptadors, linies extra, F1 i factures de proveidor posteriors a la data de baixa s'assignen al nou contracte, que es dona d'alta el dia despres de la baixa de l'antic.</field>
+            <field name="method">activar_polissa_from_m1</field>
+            <field name="conditions">[('01', 'sollicitudadm', '==', 'S'), ('01', 'canvi_titular', '!=', 'R')]</field>
+            <field name="comerdist">comer</field>
+        </record>
         <record model="giscedata.switching.activation.config" id="sw_act_m105_acord_repartiment_autoconsum">
             <field name="proces_id" ref="giscedata_switching.sw_proces_m1"/>
             <field name="step_id" ref="giscedata_switching.sw_step_m1_05"/>
             <field name="description">Tanca el cas quan es tracta d'un M1 05 Mod. Acord repartiment/fitxer coeficients.</field>
             <field name="method">m105_acord_repartiment_autoconsum</field>
-            <field name="conditions">[('02', 'rebuig', '!=', False), ('01', 'sollicitudadm', '==', 'S'), ('01', 'canvi_titular', '==', 'R')]</field>
+            <field name="conditions">[('01', 'sollicitudadm', '==', 'S'), ('01', 'canvi_titular', '==', 'R')]</field>
             <field name="comerdist">comer</field>
             <field name="sequence">114</field>
         </record>

--- a/som_switching/giscedata_switching_activation_data.xml
+++ b/som_switching/giscedata_switching_activation_data.xml
@@ -51,6 +51,7 @@ Les lectures, comptadors, linies extra, F1 i factures de proveidor posteriors a 
             <field name="method">activar_polissa_from_m1</field>
             <field name="conditions">[('01', 'sollicitudadm', '==', 'S'), ('01', 'canvi_titular', '!=', 'R')]</field>
             <field name="comerdist">comer</field>
+            <field name="sequence">115</field>
         </record>
         <record model="giscedata.switching.activation.config" id="sw_act_m105_acord_repartiment_autoconsum">
             <field name="proces_id" ref="giscedata_switching.sw_proces_m1"/>
@@ -59,7 +60,7 @@ Les lectures, comptadors, linies extra, F1 i factures de proveidor posteriors a 
             <field name="method">m105_acord_repartiment_autoconsum</field>
             <field name="conditions">[('01', 'sollicitudadm', '==', 'S'), ('01', 'canvi_titular', '==', 'R')]</field>
             <field name="comerdist">comer</field>
-            <field name="sequence">114</field>
+            <field name="sequence">115</field>
         </record>
         <!--Cn-->
         <record model="giscedata.switching.activation.config" id="sw_act_c106_baixa_mailchimp">

--- a/som_switching/giscedata_switching_activation_data.xml
+++ b/som_switching/giscedata_switching_activation_data.xml
@@ -37,6 +37,15 @@
             <field name="comerdist">comer</field>
             <field name="sequence">999</field>
         </record>
+        <record model="giscedata.switching.activation.config" id="sw_act_m105_acord_repartiment_autoconsum">
+            <field name="proces_id" ref="giscedata_switching.sw_proces_m1"/>
+            <field name="step_id" ref="giscedata_switching.sw_step_m1_05"/>
+            <field name="description">Tanca el cas quan es tracta d'un M1 05 Mod. Acord repartiment/fitxer coeficients.</field>
+            <field name="method">m105_acord_repartiment_autoconsum</field>
+            <field name="conditions">[('02', 'rebuig', '!=', False), ('01', 'sollicitudadm', '==', 'S'), ('01', 'canvi_titular', '==', 'R')]</field>
+            <field name="comerdist">comer</field>
+            <field name="sequence">114</field>
+        </record>
         <!--Cn-->
         <record model="giscedata.switching.activation.config" id="sw_act_c106_baixa_mailchimp">
             <field name="proces_id" ref="giscedata_switching.sw_proces_c1"/>

--- a/som_switching/migrations/5.0.25.6.0/post-0001_m105_SR_new_activation.py
+++ b/som_switching/migrations/5.0.25.6.0/post-0001_m105_SR_new_activation.py
@@ -11,6 +11,7 @@ def up(cursor, installed_version):
 
     logger.info("Updating XMLs")
     list_of_records = [
+        "som_sw_act_m105_ct_traspas",
         "sw_act_m105_acord_repartiment_autoconsum",
     ]
     load_data_records(

--- a/som_switching/migrations/5.0.25.6.0/post-0001_m105_SR_new_activation.py
+++ b/som_switching/migrations/5.0.25.6.0/post-0001_m105_SR_new_activation.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XMLs")
+    list_of_records = [
+        "sw_act_m105_acord_repartiment_autoconsum",
+    ]
+    load_data_records(
+        cursor,
+        'som_switching',
+        'giscedata_switching_activation_data.xml',
+        list_of_records,
+        mode='update',
+    )
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_switching/models/giscedata_switching_helpers.py
+++ b/som_switching/models/giscedata_switching_helpers.py
@@ -261,32 +261,6 @@ class GiscedataSwitchingHelpers(osv.osv):
             cac.case_close(context)
         return res
 
-    # def activar_polissa_from_m1(self, cursor, uid, sw_id, context=None):
-    #     if context is None:
-    #         context = {}
-
-    #     m101_obj = self.pool.get('giscedata.switching.m1.01')
-    #     sw_obj = self.pool.get('giscedata.switching')
-
-    #     res = False
-
-    #     sw = sw_obj.browse(cursor, uid, sw_id, context=context)
-    #     pas01 = m101_obj.browse(
-    #         cursor, uid,
-    #         m101_obj.search(cursor, uid, [('sw_id', '=', sw.id)])[0]
-    #     )
-
-    #     if pas01.sollicitudadm in ['S'] and pas01.canvi_titular in ['R']:
-    #         ATR M105 (S)[R] Mod. Acord repartiment/fitxer coeficients
-    #         res = self.m105_acord_repartiment_autoconsum(
-    #             cursor, uid, sw_id, context=context
-    #         )
-    #     else:
-    #         res = super(GiscedataSwitchingHelpers, self).activar_polissa_from_m1(
-    #             cursor, uid, sw_id, context=context
-    #         )
-    #     return res
-
     def m105_acord_repartiment_autoconsum(self, cursor, uid, sw_id, context=None):
         sw_obj = self.pool.get('giscedata.switching')
         polissa_obj = self.pool.get('giscedata.polissa')

--- a/som_switching/models/giscedata_switching_helpers.py
+++ b/som_switching/models/giscedata_switching_helpers.py
@@ -3,7 +3,7 @@ from osv import osv
 from datetime import datetime, timedelta
 from tools.translate import _
 
-from som_gurb.models.giscedata_switching import _contract_has_gurb_category
+# from som_gurb.models.giscedata_switching import _contract_has_gurb_category
 
 
 class GiscedataSwitchingHelpers(osv.osv):
@@ -297,9 +297,7 @@ class GiscedataSwitchingHelpers(osv.osv):
             cursor, uid, sw.cups_polissa_id.id, context={'prefetch': False}
         )
 
-        has_gurb = _contract_has_gurb_category(
-            cursor, uid, self.pool, sw.cups_polissa_id.id, context=context
-        )
+        has_gurb = False  # TODO: Use imported '_contract_has_gurb_category' to check GURB category?
 
         if has_gurb:
             info += _(

--- a/som_switching/models/giscedata_switching_helpers.py
+++ b/som_switching/models/giscedata_switching_helpers.py
@@ -297,23 +297,14 @@ class GiscedataSwitchingHelpers(osv.osv):
             cursor, uid, sw.cups_polissa_id.id, context={'prefetch': False}
         )
 
-        has_gurb = False  # TODO: Use imported '_contract_has_gurb_category' to check GURB category?
-
-        if has_gurb:
+        # tanquem el cas
+        if not sw.case_close():
             info += _(
-                u"Per la pólissa '%s' no podem tancar el cas %s "
-                u"perquè té una categoria GURB."
-            ) % (polissa.name, sw.name)
+                u"Per la pólissa '%s' no hem pogut tancar el cas %s") % (polissa.name, sw.name)
             return _(u'ERROR'), info
         else:
-            # tanquem el cas
-            if not sw.case_close():
-                info += _(
-                    u"Per la pólissa '%s' no hem pogut tancar el cas %s") % (polissa.name, sw.name)
-                return _(u'ERROR'), info
-            else:
-                info += _(u"  * S'ha tancat correctament.")
-                return 'OK', info
+            info += _(u"  * S'ha tancat correctament.")
+            return 'OK', info
 
 
 GiscedataSwitchingHelpers()

--- a/som_switching/models/giscedata_switching_helpers.py
+++ b/som_switching/models/giscedata_switching_helpers.py
@@ -259,5 +259,49 @@ class GiscedataSwitchingHelpers(osv.osv):
             cac.case_close(context)
         return res
 
+    # def activar_polissa_from_m1(self, cursor, uid, sw_id, context=None):
+    #     if context is None:
+    #         context = {}
+
+    #     m101_obj = self.pool.get('giscedata.switching.m1.01')
+    #     sw_obj = self.pool.get('giscedata.switching')
+
+    #     res = False
+
+    #     sw = sw_obj.browse(cursor, uid, sw_id, context=context)
+    #     pas01 = m101_obj.browse(
+    #         cursor, uid,
+    #         m101_obj.search(cursor, uid, [('sw_id', '=', sw.id)])[0]
+    #     )
+
+    #     if pas01.sollicitudadm in ['S'] and pas01.canvi_titular in ['R']:
+    #         ATR M105 (S)[R] Mod. Acord repartiment/fitxer coeficients
+    #         res = self.m105_acord_repartiment_autoconsum(
+    #             cursor, uid, sw_id, context=context
+    #         )
+    #     else:
+    #         res = super(GiscedataSwitchingHelpers, self).activar_polissa_from_m1(
+    #             cursor, uid, sw_id, context=context
+    #         )
+    #     return res
+
+    def m105_acord_repartiment_autoconsum(self, cursor, uid, sw_id, context=None):
+        sw_obj = self.pool.get('giscedata.switching')
+        polissa_obj = self.pool.get('giscedata.polissa')
+        info = ''
+
+        sw = sw_obj.browse(cursor, uid, sw_id, context=context)
+        polissa = polissa_obj.browse(
+            cursor, uid, sw.cups_polissa_id.id, context={'prefetch': False}
+        )
+        # tanquem el cas
+        if not sw.case_close():
+            info += _(
+                u"Per la pólissa '%s' no hem pogut tancar el cas %s") % (polissa.name, sw.name)
+            return _(u'ERROR'), info
+        else:
+            info += _(u"  * S'ha tancat correctament.")
+            return 'OK', info
+
 
 GiscedataSwitchingHelpers()

--- a/som_switching/tests/tests_activacions_m1.py
+++ b/som_switching/tests/tests_activacions_m1.py
@@ -172,9 +172,16 @@ class TestActivacioM1(TestSwitchingImport):
             cursor = txn.cursor
             uid = txn.user
 
+            # deactivate old ATR activation config that has been replaced
+            act_sw_act_m105_ct_traspas_old_id = self.IrModelData.get_object_reference(
+                cursor, uid, "giscedata_switching", "sw_act_m105_ct_traspas"
+            )[1]
+            act_o = self.openerp.pool.get("giscedata.switching.activation.config")
+            act_o.write(cursor, uid, act_sw_act_m105_ct_traspas_old_id, {"active": False})
+
             mock_lectures.return_value = []
             contract_id = self.get_contract_id(txn)
-            # remove all other contracts
+
             old_partner_id = self.Polissa.read(cursor, uid, contract_id, ["titular"])["titular"][0]
             pol_ids = self.Polissa.search(
                 cursor, uid, [("id", "!=", contract_id), ("titular", "=", old_partner_id)]
@@ -204,6 +211,13 @@ class TestActivacioM1(TestSwitchingImport):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
+
+            # deactivate old ATR activation config that has been replaced
+            act_sw_act_m105_ct_traspas_old_id = self.IrModelData.get_object_reference(
+                cursor, uid, "giscedata_switching", "sw_act_m105_ct_traspas"
+            )[1]
+            act_o = self.openerp.pool.get("giscedata.switching.activation.config")
+            act_o.write(cursor, uid, act_sw_act_m105_ct_traspas_old_id, {"active": False})
 
             mock_lectures.return_value = []
             contract_id = self.get_contract_id(txn, "polissa_tarifa_018")

--- a/som_switching/tests/tests_activacions_m1.py
+++ b/som_switching/tests/tests_activacions_m1.py
@@ -597,7 +597,7 @@ class TestActivacioM1(TestSwitchingImport):
             self.assertTrue(d1.collectiu_atr)
 
     @mock.patch(
-        "som_switching.giscedata_switching_helpers.GiscedataSwitchingHelpers.activar_polissa_from_m1"  # noqa: E501
+        "giscedata_switching.giscedata_switching_helpers.GiscedataSwitchingHelpers.activar_polissa_from_m1"  # noqa: E501
     )
     def test_sw_act_m105_acord_repartiment_autoconsum_SR(
         self, mock_activar_polissa_from_m1

--- a/som_switching/tests/tests_activacions_m1.py
+++ b/som_switching/tests/tests_activacions_m1.py
@@ -103,6 +103,20 @@ class TestActivacioM1(TestSwitchingImport):
 
         return m1
 
+    def get_m1_05_SR(self, txn, contract_id, context=None):
+        if not context:
+            context = {}
+        uid = txn.user
+        cursor = txn.cursor
+        m1 = self.get_m1_02_ct(txn, contract_id, "R")
+        self.ResConfig.set(cursor, uid, "sw_m1_owner_change_auto", "1")
+        self.create_step(cursor, uid, m1, "M1", "05", context=None)
+        m1 = self.Switching.browse(cursor, uid, m1.id, {"browse_reference": True})
+        m105 = m1.step_ids[-1].pas_id
+        m105.write({"data_activacio": context.get("data_activacio", "2021-08-05")})
+
+        return m1
+
     @mock.patch("som_polissa_soci.res_partner.ResPartner.arxiva_client_mailchimp_async")
     def test_ct_subrogacio_baixa_mailchimp_ok(self, mock_function):
         with Transaction().start(self.database) as txn:
@@ -581,3 +595,69 @@ class TestActivacioM1(TestSwitchingImport):
             # Comprovem que és Col·lectiu
             d1 = sw_obj.browse(cursor, uid, sw_id)
             self.assertTrue(d1.collectiu_atr)
+
+    @mock.patch(
+        "som_switching.giscedata_switching_helpers.GiscedataSwitchingHelpers.activar_polissa_from_m1"  # noqa: E501
+    )
+    def test_sw_act_m105_acord_repartiment_autoconsum_SR(
+        self, mock_activar_polissa_from_m1
+    ):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            # deactivate old ATR activation config that has been replaced
+            act_sw_act_m105_ct_traspas_old_id = self.IrModelData.get_object_reference(
+                cursor, uid, "giscedata_switching", "sw_act_m105_ct_traspas"
+            )[1]
+            act_o = self.openerp.pool.get("giscedata.switching.activation.config")
+            act_o.write(cursor, uid, act_sw_act_m105_ct_traspas_old_id, {"active": False})
+
+            mock_activar_polissa_from_m1.return_value = []
+            contract_id = self.get_contract_id(txn, "polissa_tarifa_018")
+
+            m1 = self.get_m1_05_SR(txn, contract_id, {"polissa_xml_id": "polissa_tarifa_018"})
+
+            with PatchNewCursors():
+                self.Switching.activa_cas_atr(cursor, uid, m1)
+
+            self.assertTrue(not mock_activar_polissa_from_m1.called)
+
+            expected_result = (
+                u"OK:   * S'ha tancat correctament."
+            )
+            history_line_desc = [line["description"] for line in m1.history_line]
+            self.assertTrue(any([expected_result in desc for desc in history_line_desc]))
+
+    @mock.patch(
+        "som_switching.giscedata_switching_helpers.GiscedataSwitchingHelpers.m105_acord_repartiment_autoconsum"  # noqa: E501
+    )
+    def test_sw_act_m105_acord_repartiment_autoconsum_not_SR(
+        self, mock_m105_acord_repartiment_autoconsum
+    ):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            # deactivate old ATR activation config that has been replaced
+            act_sw_act_m105_ct_traspas_old_id = self.IrModelData.get_object_reference(
+                cursor, uid, "giscedata_switching", "sw_act_m105_ct_traspas"
+            )[1]
+            act_o = self.openerp.pool.get("giscedata.switching.activation.config")
+            act_o.write(cursor, uid, act_sw_act_m105_ct_traspas_old_id, {"active": False})
+
+            mock_m105_acord_repartiment_autoconsum.return_value = []
+            contract_id = self.get_contract_id(txn, "polissa_tarifa_018")
+
+            m1 = self.get_m1_05_traspas(txn, contract_id, {"polissa_xml_id": "polissa_tarifa_018"})
+
+            with PatchNewCursors():
+                self.Switching.activa_cas_atr(cursor, uid, m1)
+
+            self.assertTrue(not mock_m105_acord_repartiment_autoconsum.called)
+
+            not_expected_result = (
+                u"OK:   * S'ha tancat correctament."
+            )
+            history_line_desc = [line["description"] for line in m1.history_line]
+            self.assertFalse(any([not_expected_result in desc for desc in history_line_desc]))


### PR DESCRIPTION
## Objectiu
Necessitem que quan arriben casos M105 SR (canvi de l'acord de repartiment), el cas ATR es tanque automàticament i envie un nou correu segons el que s'especifica a la targeta.

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/814

PR plantilla nou correu:
https://github.com/Som-Energia/somenergia-oomakotest/pull/188

## Comportament antic
A dia de hui apareix aquest error al casos ATR M105 (S)[R] Mod. Acord repartiment/fitxer coeficients:

> Resultado Activación:
> ERROR: No se trata de un cambio de titular (S / A) con tipo de cambio "sin subrogación" (T) o "con subrogación" (S), caso Procés M1 pel CUPS: XXXX

## Comportament nou
En cas de ser M105 SR, es tanca al cas i s'envia un mail nou.
🚧 _Casuística de GURB_

## Comprovacions

- [x] Desactivar l'activació ja existent: **sw_act_m105_ct_traspas** (id 26)
- [x] Marcar 'Activació automàtica' les 2 noves activacions creades
- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions
