### PR TITLE
Millorar script de creació de scripts de migració

### DIFF
--- a/som_switching/migrations/5.0.24.5.0/post-0004_ADD_M1_02_notification_config_update_views_and_fields.py
+++ b/som_switching/migrations/5.0.24.5.0/post-0004_ADD_M1_02_notification_config_update_views_and_fields.py
@@ -13,12 +13,12 @@ def up(cursor, installed_version):
     data_files = [
         'giscedata_switching_notification_data.xml',
     ]
-
     for data_file in data_files:
         load_data(
             cursor, 'som_switching', data_file,
             idref=None, mode='update'
         )
+
     logger.info("Migration completed successfully.")
 
 

--- a/som_switching/migrations/5.0.24.5.0/post-0004_ADD_M1_02_notification_config_update_views_and_fields.py
+++ b/som_switching/migrations/5.0.24.5.0/post-0004_ADD_M1_02_notification_config_update_views_and_fields.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'giscedata_switching_notification_data.xml',
+    ]
+
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_switching', data_file,
+            idref=None, mode='update'
+        )
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu
Millorar script de creació de scripts de migració

## Targeta on es demana o Incidència
No

## Comportament antic
- Afegia la variabla pooler quan no la necessitava i t'obligava a acceptar els canvis del pre-commit
- Barrejava data.xml i security.csv fent que si es carregava primer el csv, petava l'script.

## Comportament nou
- Només afegeix pooler quan el fa servir
-  Ara carrega primer els xml i després els csv.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
