### PR TITLE
Corregir Plantillas de notificaciones de M2 05

### DIFF
--- a/som_switching/giscedata_switching_notification_data.xml
+++ b/som_switching/giscedata_switching_notification_data.xml
@@ -47,19 +47,19 @@
             <field name="proces_id" ref="giscedata_switching.sw_proces_m2"/>
             <field name="step_id" ref="giscedata_switching.sw_step_m2_05"/>
             <field name="description">Activa les notificacions per els pasos M2-05 on els motius siguin 01, 02, 03, 04, 05 i 08</field>
-            <field name="conditions">[('01', 'motiu', 'in', ['01', '02', '03', '04', '05', '08'])]</field>
+            <field name="conditions">[('05', 'motiu', 'in', ['01', '02', '03', '04', '05', '08'])]</field>
         </record>
         <record model="giscedata.switching.notificacio.config" id="sw_not_m2_05_motiu_06">
             <field name="proces_id" ref="giscedata_switching.sw_proces_m2"/>
             <field name="step_id" ref="giscedata_switching.sw_step_m2_05"/>
             <field name="description">Activa les notificacions per els pasos M2-05 motiu 06</field>
-            <field name="conditions">[('01', 'motiu', '==', '06')]</field>
+            <field name="conditions">[('05', 'motiu', '==', '06')]</field>
         </record>
         <record model="giscedata.switching.notificacio.config" id="sw_not_m2_05_motiu_07">
             <field name="proces_id" ref="giscedata_switching.sw_proces_m2"/>
             <field name="step_id" ref="giscedata_switching.sw_step_m2_05"/>
             <field name="description">Activa les notificacions per els pasos M2-05 motiu 07</field>
-            <field name="conditions">[('01', 'motiu', '==', '07')]</field>
+            <field name="conditions">[('05', 'motiu', '==', '07')]</field>
         </record>
     </data>
 </openerp>

--- a/som_switching/migrations/5.0.25.9.0/post-0001_fix_m2_sw_notifications.py
+++ b/som_switching/migrations/5.0.25.9.0/post-0001_fix_m2_sw_notifications.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XMLs")
+    list_of_records = [
+        "sw_not_m2_05_motius_nofiticar",
+        "sw_not_m2_05_motiu_06",
+        "sw_not_m2_05_motiu_07",
+    ]
+    load_data_records(
+        cursor,
+        'som_switching',
+        'giscedata_switching_notification_data.xml',
+        list_of_records,
+        mode='update',
+    )
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Corregir les plantilles de notificacio de casos ATR perque tinguin el pas correcte. El primer element del camp 'conditions' correspon al pas del procés. 

Com que estava posat el `01`, fallava perque no existia el model `giscedata.switching.m2.01`


## Targeta on es demana o Incidència

SAC GISCE -> `246968`

## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions
