### PR TITLE
🐛 Mostrar les dades d'autoconsum col·lectiu quan hi ha un F1 tipus R pel mig

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3897,16 +3897,17 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 ('linia_id', 'in', f1_cups_ids),
                 ('data_inici', '=', fact.data_inici),
                 ('data_final', '=', fact.data_final),
+                ('type', '=', 'in_invoice'),
             ]
-        )
-        f1_lf = f1_lf_obj.browse(
-            self.cursor,
-            self.uid,
-            f1_lf_ids[-1] if f1_lf_ids else []
         )
 
         linies = []
-        if f1_lf:
+        if f1_lf_ids:
+            f1_lf = f1_lf_obj.browse(
+                self.cursor,
+                self.uid,
+                f1_lf_ids[-1]
+            )
             linies = [
                 linia for linia in f1_lf.factura_id.linia_ids if linia.tipus in [
                     'generacio_neta', 'generacio', 'autoconsum',


### PR DESCRIPTION
## Objectiu

Mostrar les dades d'autoconsum col·lectiu quan hi ha un F1 tipus R pel mig

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/8034909?folder_id=87

## Comportament antic

no es mostra o es motren les dades d'un altre F1 del mateix contracte

## Comportament nou

es mostren les dades correctes

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
