### PR TITLE
Eliminar vistes duplicades per haver-se afegit a ERP

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_factura_view.xml
+++ b/som_facturacio_comer/giscedata_facturacio_factura_view.xml
@@ -13,27 +13,5 @@
                 </field>
             </field>
         </record>
-        <record model="ir.ui.view" id="view_giscedata_facturacio_factura_generacio_som_form">
-            <field name="name">giscedata.facturacio.factura.generacio.som.form</field>
-            <field name="model">giscedata.facturacio.factura</field>
-            <field name="inherit_id" ref="giscedata_facturacio.view_factura_tree" />
-            <field name="type">tree</field>
-            <field name="arch" type="xml">
-                <field name="energia_kwh" position="after">
-                    <field name="generacio_kwh" select="2"/>
-                </field>
-            </field>
-        </record>
-        <record model="ir.ui.view" id="view_giscedata_facturacio_factura_generacio_grouped_som_form">
-            <field name="name">giscedata.facturacio.factura.grouped.generacio.som.form</field>
-            <field name="model">giscedata.facturacio.factura</field>
-            <field name="inherit_id" ref="giscedata_facturacio.view_factura_grouped_tree" />
-            <field name="type">tree</field>
-            <field name="arch" type="xml">
-                <field name="energia_kwh" position="after">
-                    <field name="generacio_kwh" select="2"/>
-                </field>
-            </field>
-        </record>
     </data>
 </openerp>

--- a/som_facturacio_comer/migrations/5.0.25.9.0/pre-0001_remove_unnecessary_tree_views.py
+++ b/som_facturacio_comer/migrations/5.0.25.9.0/pre-0001_remove_unnecessary_tree_views.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import delete_record
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Removing tree view records")
+
+    list_of_records = ["view_giscedata_facturacio_factura_generacio_som_form",
+                       "view_giscedata_facturacio_factura_generacio_grouped_som_form"]
+    delete_record(
+        cursor,
+        'som_facturacio_comer',
+        list_of_records,
+    )
+    logger.info("Tree records successfully removed.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Eliminar vistes duplicades per haver-se afegit a ERP

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/941

## Comportament antic

Mostrar camp a llistats de factures

## Comportament nou

Degut a PR https://github.com/gisce/erp/pull/24693 ja no son necessaris i de fet son redundants ja que es mostren per duplicat els camps de generacio_kwh

## Comprovacions

- [x] Reiniciar serveis
- [x] Actualitzar mòdul - som_facturacio_comer
- [x] Script de migració - som_facturacio_comer/migrations/5.0.25.9.0/pre-0001_remove_unnecessary_tree_views.py
