### PR TITLE
🐛(lead) El Lang no s'estava passant si el partner ja existia

### DIFF
--- a/som_leads_polissa/giscedata_crm_lead.py
+++ b/som_leads_polissa/giscedata_crm_lead.py
@@ -151,7 +151,8 @@ class GiscedataCrmLead(osv.OsvInherits):
                 cursor, uid, lead.partner_id.id, {"representante_id": rep_id}, context=context)
 
         # We set again the lang because if it existed before, the base code dont write it
-        partner_o.write(cursor, uid, lead.partner_id.id, {"lang": lead.lang}, context=context)
+        if lead.lang:
+            partner_o.write(cursor, uid, lead.partner_id.id, {"lang": lead.lang}, context=context)
 
         if lead.create_new_member:
             # become_member will keep the member number we set here

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -81,7 +81,6 @@ class SomLeadWww(osv.osv_memory):
         values = {
             "state": "open",
             "name": "{} / {}".format(member["vat"].upper(), contract_info["cups"]),
-            "lang": member.get("lang"),
             "cups": contract_info["cups"],
             "codigoEmpresaDistribuidora": distri_ref,
             "cups_ref_catastral": contract_info.get("cups_cadastral_reference"),
@@ -150,6 +149,9 @@ class SomLeadWww(osv.osv_memory):
 
         for i, power in enumerate(contract_info["powers"]):
             values["potenciasContratadasEnKWP%s" % str(i + 1)] = float(power) / 1000
+
+        if www_vals.get("lang"):
+            values["lang"] = member["lang"]
 
         if www_vals.get("self_consumption"):
             values["seccio_registre"] = self._127_WITH_SURPLUSES


### PR DESCRIPTION
## Objectiu
Quan el partner ja existia estavem sobreescrivint el lang

## Targeta on es demana o Incidència
poweremail_sender

## Comportament antic
Sobreescriviem l'idioma i l'eliminavem amb un false

## Comportament nou
Ara ja no ho hauriem de fer

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
