### PR TITLE
🐛⚡ Lead fixes: member number, tests and write performance

### DIFF
--- a/som_leads_polissa/giscedata_crm_lead.py
+++ b/som_leads_polissa/giscedata_crm_lead.py
@@ -156,12 +156,12 @@ class GiscedataCrmLead(osv.OsvInherits):
 
         if lead.create_new_member:
             # become_member will keep the member number we set here
-            values["ref"] = lead.member_number
+            context["force_ref"] = lead.member_number
             values["date"] = datetime.today().strftime("%Y-%m-%d")
             partner_o.write(cursor, uid, lead.partner_id.id, values, context=context)
             partner_o.become_member(cursor, uid, lead.partner_id.id, context=context)
             partner_o.adopt_contracts_as_member(cursor, uid, lead.partner_id.id, context=context)
-        else:
+        elif values:
             partner_o.write(cursor, uid, lead.partner_id.id, values, context=context)
 
         return res
@@ -338,8 +338,8 @@ class GiscedataCrmLead(osv.OsvInherits):
             context = {}
         seq_o = self.pool.get("ir.sequence")
 
+        # We assing here the new numbers to show it in the contract to be signed
         if vals.get("create_new_member"):
-            # TODO: we have to keep the old number or not? By the moment, we assign a new one
             vals["member_number"] = seq_o.get_next(cursor, uid, "res.partner.soci")
         elif context.get("sponsored_titular"):
             vals["titular_number"] = seq_o.get_next(cursor, uid, "res.partner.titular")

--- a/som_leads_polissa/giscedata_crm_lead.py
+++ b/som_leads_polissa/giscedata_crm_lead.py
@@ -142,24 +142,26 @@ class GiscedataCrmLead(osv.OsvInherits):
         )
 
         lead = self.browse(cursor, uid, crml_id, context=context)
+        values = {}
 
         rep_id = self._create_or_get_representative(
             cursor, uid, lead.persona_firmant_vat, lead.persona_nom, context=context
         )
         if rep_id:
-            partner_o.write(
-                cursor, uid, lead.partner_id.id, {"representante_id": rep_id}, context=context)
+            values["representante_id"] = rep_id
 
         # We set again the lang because if it existed before, the base code dont write it
         if lead.lang:
-            partner_o.write(cursor, uid, lead.partner_id.id, {"lang": lead.lang}, context=context)
+            values["lang"] = lead.lang
 
         if lead.create_new_member:
             # become_member will keep the member number we set here
-            partner_o.write(
-                cursor, uid, lead.partner_id.id, {"ref": lead.member_number}, context=context)
+            values["ref"] = lead.member_number
+            partner_o.write(cursor, uid, lead.partner_id.id, values, context=context)
             partner_o.become_member(cursor, uid, lead.partner_id.id, context=context)
             partner_o.adopt_contracts_as_member(cursor, uid, lead.partner_id.id, context=context)
+        else:
+            partner_o.write(cursor, uid, lead.partner_id.id, values, context=context)
 
         return res
 

--- a/som_leads_polissa/giscedata_crm_lead.py
+++ b/som_leads_polissa/giscedata_crm_lead.py
@@ -157,6 +157,7 @@ class GiscedataCrmLead(osv.OsvInherits):
         if lead.create_new_member:
             # become_member will keep the member number we set here
             values["ref"] = lead.member_number
+            values["date"] = datetime.today().strftime("%Y-%m-%d")
             partner_o.write(cursor, uid, lead.partner_id.id, values, context=context)
             partner_o.become_member(cursor, uid, lead.partner_id.id, context=context)
             partner_o.adopt_contracts_as_member(cursor, uid, lead.partner_id.id, context=context)
@@ -176,7 +177,6 @@ class GiscedataCrmLead(osv.OsvInherits):
         create_vals["gender"] = lead.gender
         create_vals["birthdate"] = lead.birthdate
         create_vals["referral_source"] = lead.referral_source
-        create_vals["date"] = datetime.today().strftime("%Y-%m-%d")
 
         partner_id = super(GiscedataCrmLead, self).create_partner(
             cursor, uid, create_vals, crml_id, context=context)

--- a/som_partner_account/partner.py
+++ b/som_partner_account/partner.py
@@ -253,20 +253,22 @@ class ResPartner(osv.osv):
             return False
 
     def become_member(self, cursor, uid, id, context=None):
+        if not context:
+            context = {}
+
         imd_obj = self.pool.get("ir.model.data")
         soci_obj = self.pool.get("somenergia.soci")
         ir_seq = self.pool.get("ir.sequence")
         soci_cat = imd_obj._get_obj(cursor, uid, "som_partner_account", "res_partner_category_soci")
 
-        # Assign Member category
+        # Assign Member category and ref code
+        partner_vals = {}
         partner = self.read(cursor, uid, id, ["ref", "category_id"])
         if soci_cat.id not in partner["category_id"]:
-            self.write(cursor, uid, partner["id"], {"category_id": [(4, soci_cat.id)]})
+            partner_vals["category_id"] = [(4, soci_cat.id)]
 
-        # Assign Member ref code
-        if not partner["ref"] or partner["ref"][0] != "S":
-            codi = ir_seq.get(cursor, uid, "res.partner.soci")
-            self.write(cursor, uid, partner["id"], {"ref": codi})
+        partner_vals['ref'] = context.get('force_ref', ir_seq.get(cursor, uid, "res.partner.soci"))
+        self.write(cursor, uid, partner["id"], partner_vals)
 
         # Create Member instance
         soci_ids = soci_obj.search(

--- a/som_partner_account/tests/test_membership.py
+++ b/som_partner_account/tests/test_membership.py
@@ -90,7 +90,7 @@ class TestAccountAccountSom(testing.OOTestCase):
             "S[0-9]{6}",
         )
 
-    def test__become_member__withPreviousMemberRef_keepsIt(self):
+    def test__become_member__withPreviousMemberRef_renewsIt(self):
         Partner = self.openerp.pool.get("res.partner")
 
         Partner.write(
@@ -103,6 +103,29 @@ class TestAccountAccountSom(testing.OOTestCase):
         )
 
         Partner.become_member(self.cursor, self.uid, self.partner_id)
+
+        partner = Partner.read(self.cursor, self.uid, self.partner_id, ["ref"])
+
+        self.assertNotEqual(partner["ref"], "S666666")
+        self.assertRegexpMatches(
+            partner["ref"],
+            "S[0-9]{6}",
+        )
+
+    def test__become_member__withForcedMemberRef_usesIt(self):
+        Partner = self.openerp.pool.get("res.partner")
+
+        Partner.write(
+            self.cursor,
+            self.uid,
+            self.partner_id,
+            dict(
+                ref="",  # No ref
+            ),
+        )
+
+        Partner.become_member(
+            self.cursor, self.uid, self.partner_id, context={"force_ref": "S666666"})
 
         partner = Partner.read(self.cursor, self.uid, self.partner_id, ["ref"])
 


### PR DESCRIPTION
## Objectiu
La primera incidència ja estava resolta, aquest PR només arregla una mica els tests i simplifica els writes.

La segona és simplement canviar el comportament per sempre renovar el número de sòcia, i adaptar els leads perque tot segueixi funcionant com sempre :)

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8037651?folder_id=103
https://freescout.somenergia.coop/conversation/8035038?folder_id=103

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
