### PR TITLE
🐛 Fix proces name in polissa observations

### DIFF
--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -261,6 +261,10 @@ class SomLeadWww(osv.osv_memory):
             # Remove the attachment base64 data from the log
             attachment.pop("datas", None)
 
+        # giscedata_switching/giscedata_polissa.crear_cas_atr reads the contract observations
+        # and looks for the key 'proces: XX' :O
+        www_vals['contract_info']['proces'] = www_vals['contract_info']['process']
+
         data = yaml.safe_dump(www_vals, indent=2)
         msg = "{header}\n{data}".format(header=WWW_DATA_FORM_HEADER, data=data)
         lead.historize_msg(msg, context=context)


### PR DESCRIPTION
## Objectiu
Sembla ser que GISCE llegeix desde crear_cas_atr les observacions de la polissa i busca el camp proces amb aquest nom concret.
Amb aquest PR ens assegurem que el codi de GISCE funcionarà (fa una copia del camp al guardar-lo)

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8035520?folder_id=69

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
