### PR TITLE
Moure codi de flux solar al modul correcte

### DIFF
--- a/som_facturacio_comer/giscedata_polissa.py
+++ b/som_facturacio_comer/giscedata_polissa.py
@@ -11,36 +11,6 @@ class GiscedataPolissa(osv.osv):
     _name = "giscedata.polissa"
     _inherit = "giscedata.polissa"
 
-    def search_factura(self, cursor, uid, ids, data_inici, data_final, context=None):
-        if context is None:
-            context = {}
-        origen_obj = self.pool.get("giscedata.bateria.virtual.origen")
-        origen_data = (
-            origen_obj.q(cursor, uid)
-            .read(["data_inici_descomptes"])
-            .where([("origen_ref", "=", "giscedata.polissa,{}".format(str(ids[0])))])
-        )
-
-        if len(origen_data):
-            data_inici_origen = origen_data[0].get("data_inici_descomptes")
-        else:
-            data_inici_origen = data_inici
-
-        factura_obj = self.pool.get("giscedata.facturacio.factura")
-        factura_ids = factura_obj.search(
-            cursor,
-            uid,
-            [
-                ("polissa_id", "=", ids[0]),
-                ("data_inici", ">=", data_inici_origen),
-                ("data_inici", "<=", data_final),
-                ("state", "in", ("paid", "open")),
-                ("type", "in", ("out_invoice", "out_refund")),
-            ],
-            context=context,
-        )
-        return factura_ids
-
     def _ff_observations_first_line(self, cursor, uid, ids, args, fields, context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
## Objectiu
 
Tindre tot el codi referent a les personalitzacions de flux solar en el modul `som_facturacio_flux_solar` per evitar que la gent de gisce es torni boja intentant saber què té el flux solar diferent en els mòduls de som.

Origen del codi que es mou: https://github.com/Som-Energia/openerp_som_addons/pull/413