### PR TITLE
Descarregar repo OMIE perquè ja no està a pypi.org

### DIFF
--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -92,6 +92,7 @@ jobs:
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/Som-Energia/erp.git -b ${{ inputs.erpbranch }} $ROOT_DIR_SRC/erp
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/Som-Energia/libFacturacioATR.git $ROOT_DIR_SRC/libFacturacioATR
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/Som-Energia/omie-modules.git $ROOT_DIR_SRC/omie-modules
+          git clone --depth 1 https://$GITHUB_TOKEN@github.com/Som-Energia/OMIE.git $ROOT_DIR_SRC/OMIE
           if [ ! -d "$ROOT_DIR_SRC/openerp_som_addons" ]; then
             git clone --depth 1 https://github.com/Som-Energia/openerp_som_addons.git $ROOT_DIR_SRC/openerp_som_addons
           fi
@@ -122,6 +123,9 @@ jobs:
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
           pip install -e .
           cd $ROOT_DIR_SRC/ooop
+          git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+          pip install -e .
+          cd $ROOT_DIR_SRC/OMIE
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
           pip install -e .
           cd $ROOT_DIR_SRC/somenergia-generationkwh


### PR DESCRIPTION
## Objectiu
Descarregar repo OMIE perquè ja no està a pypi.org

## Targeta on es demana o Incidència
Checks

## Comportament antic
GISCE tenia el repositori https://github.com/gisce/omie en obert i publicava els paquests a Pypi.org

## Comportament nou
GISCE ha tancat el repositori i deixa de publicar versions al pypi.org i ha canviat els requirements.txt dels mòduls que el necessiten, per a que vaig a buscar el repositori privat en comptes de a pypi.org.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
