### PR TITLE
Copy/Paste ha sobreescrit el botó que portava a un wizard

### DIFF
--- a/som_gurb/migrations/5.0.24.5.0/post-0003_fix_gurb_wizard_copy_paste_migrate_data.py
+++ b/som_gurb/migrations/5.0.24.5.0/post-0003_fix_gurb_wizard_copy_paste_migrate_data.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'wizard/wizard_atr_gurb_model_view.xml',
+        'wizard/wizard_create_coef_file_view.xml',
+    ]
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_gurb', data_file,
+            idref=None, mode='update'
+        )
+
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_gurb/wizard/wizard_atr_gurb_model_view.xml
+++ b/som_gurb/wizard/wizard_atr_gurb_model_view.xml
@@ -19,7 +19,7 @@
             <field name="target">new</field>
             <field name="view_id" ref="view_wizard_atr_gurb_model_form" />
         </record>
-        <record id="values_wizard_create_gurb_coeficients_file_form" model="ir.values">
+        <record id="values_wizard_atr_gurb_model_form" model="ir.values">
             <field name="object" eval="1" />
             <field name="name">Tots els casos ATR del GURB</field>
             <field name="key2">client_action_multi</field>


### PR DESCRIPTION
## Objectiu
Tornar a crear botó que s'havia sobreescrit. Canviar nom incorrecte que sobreescrivia.

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8050356?folder_id=87

## Comportament antic
No apareixia botó d'un assistent

## Comportament nou
Ara torna a aparèixer

## Comprovacions

- [x] Reiniciar serveis --> ERP
- [x] Script de migració