### PR TITLE
🐛 (leads) KW en comptes de W al helper

### DIFF
--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -163,7 +163,9 @@ class SomLeadWww(osv.osv_memory):
             values["cau"] = www_vals["self_consumption"]["cau"]
             values["collectiu"] = www_vals["self_consumption"]["collective_installation"]
             values["tec_generador"] = www_vals["self_consumption"]["technology"]
-            values["pot_instalada_gen"] = www_vals["self_consumption"]["installation_power"] / 1000
+            values["pot_instalada_gen"] = float(
+                www_vals["self_consumption"]["installation_power"]
+            ) / 1000
             values["tipus_installacio"] = www_vals["self_consumption"]["installation_type"]
             values["ssaa"] = 'S' if www_vals["self_consumption"]['aux_services'] else 'N'
 


### PR DESCRIPTION
## Objectiu
Arreglar error de kW i W

Això és un hotfix, a la llarga hauríem de treballar només en kW

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8053936?folder_id=71

## Comportament antic
La potència arribava desproporcionada

## Comportament nou
Ara arriba bé.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
