### PR TITLE
No pujar coverage a Coveralls.io

### DIFF
--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -203,11 +203,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: ${{ inputs.all_modules == 'true' }}
 
-      - name: Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN_GA }}
-        uses: coverallsapp/github-action@v2
-        with:
-          format: cobertura
-          fail-on-error: false
-          flag-name: ${{ inputs.module }}


### PR DESCRIPTION
## Objectiu
No fem servir ja Coveralls.io, fem servir el Codecov

## Targeta on es demana o Incidència
Tests setmanals

## Comportament antic
Pujàvem als dos serveis (Coveralls i Codecov) i vam fer aquesta PR https://github.com/Som-Energia/openerp_som_addons/pull/866 perquè a vegades fallava al Coveralls, però sembla que aquest flag no funciona quan s'executa amb multithreat, per tant millor ho traiem.

## Comportament nou
Puja el coverage només al Codecov, que respecta històric de referència de coverage per mòdul.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
