### PR TITLE
🐛 (lead) Afegir error descriptiu quan un lead falla pq el número de sòcia està mal escrit

### DIFF
--- a/som_leads_polissa/giscedata_crm_lead.py
+++ b/som_leads_polissa/giscedata_crm_lead.py
@@ -89,7 +89,17 @@ class GiscedataCrmLead(osv.OsvInherits):
         polissa_id = lead.polissa_id.id
         member_number = lead.member_number
 
-        values["soci"] = partner_o.search(cursor, uid, [("ref", "=", member_number)], limit=1)[0]
+        member_id = partner_o.search(
+            cursor, uid, [("ref", "=", member_number)], limit=1
+        )
+
+        if not member_id:
+            raise osv.except_osv(
+                "Error - Sòcia no trobada",
+                "Prova de posar el número {} amb la lletra i els zeros".format(member_number),
+            )
+
+        values["soci"] = member_id[0]
         values["donatiu"] = lead.donation
 
         for line in lead.history_line:

--- a/som_leads_polissa/tests/tests_som_lead_www.py
+++ b/som_leads_polissa/tests/tests_som_lead_www.py
@@ -1140,10 +1140,11 @@ class TestsSomLeadWww(testing.OOTestCase):
             self.cursor, self.uid, 'giscedata_tensions', 'tensio_3x230_400')[1]
         self.assertEqual(lead.polissa_id.tensio_normalitzada.id, tensio_trifasica)
 
-    def test_member_number_error(self):
+    def test_manual_member_number_error(self):
         www_lead_o = self.get_model("som.lead.www")
         member_o = self.get_model("somenergia.soci")
         ir_model_o = self.get_model("ir.model.data")
+        lead_o = self.get_model("giscedata.crm.lead")
         partner_o = self.get_model("res.partner")
 
         member_id = ir_model_o.get_object_reference(
@@ -1155,12 +1156,17 @@ class TestsSomLeadWww(testing.OOTestCase):
         vat = member.partner_id.vat.replace("ES", "")
 
         values = self._basic_values
-        del values["new_member_info"]
-        values["linked_member"] = "already_member"
+        values["linked_member"] = "sponsored"
+        values["contract_owner"] = values.pop("new_member_info")
         values["linked_member_info"] = {
             "vat": vat,
-            "code": "WRONGCODE",
+            "code": member.partner_id.ref.replace("S", ""),
         }
 
+        lead_id = www_lead_o.create_lead(self.cursor, self.uid, values)["lead_id"]
+        lead_o.write(
+            self.cursor, self.uid, lead_id, {"member_number": "WRONGCODE", "titular_number": ""}
+        )
+
         with self.assertRaises(osv.except_osv):
-            www_lead_o.create_lead(self.cursor, self.uid, values)
+            lead_o.create_entities(self.cursor, self.uid, lead_id)

--- a/som_leads_polissa/tests/tests_som_lead_www.py
+++ b/som_leads_polissa/tests/tests_som_lead_www.py
@@ -1139,3 +1139,28 @@ class TestsSomLeadWww(testing.OOTestCase):
         tensio_trifasica = ir_model_o.get_object_reference(
             self.cursor, self.uid, 'giscedata_tensions', 'tensio_3x230_400')[1]
         self.assertEqual(lead.polissa_id.tensio_normalitzada.id, tensio_trifasica)
+
+    def test_member_number_error(self):
+        www_lead_o = self.get_model("som.lead.www")
+        member_o = self.get_model("somenergia.soci")
+        ir_model_o = self.get_model("ir.model.data")
+        partner_o = self.get_model("res.partner")
+
+        member_id = ir_model_o.get_object_reference(
+            self.cursor, self.uid, "som_polissa_soci", "soci_0001"
+        )[1]
+        member = member_o.browse(self.cursor, self.uid, member_id)
+        partner_o.write(self.cursor, self.uid, member.partner_id.id, {'lang': 'ca_ES'})
+
+        vat = member.partner_id.vat.replace("ES", "")
+
+        values = self._basic_values
+        del values["new_member_info"]
+        values["linked_member"] = "already_member"
+        values["linked_member_info"] = {
+            "vat": vat,
+            "code": "WRONGCODE",
+        }
+
+        with self.assertRaises(osv.except_osv):
+            www_lead_o.create_lead(self.cursor, self.uid, values)


### PR DESCRIPTION
## Objectiu
Afegir error descriptiu quan un lead falla pq el número de sòcia està mal escrit

## Targeta on es demana o Incidència
- XATS i incidències varies

## Comportament antic
Error "list intex out of range"

## Comportament nou
Error que diu el que està passant

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis ERP's de leads

