### PR TITLE
🐛 Arreglar path de giscedata_cups.TABLA_113

### DIFF
--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -8,7 +8,7 @@ from giscedata_facturacio.report.utils import get_atr_price, get_comming_atr_pri
 from som_extend_facturacio_comer.utils import get_gkwh_atr_price
 from tools.translate import _
 from giscedata_polissa.report.utils import localize_period
-from som_polissa.giscedata_cups import TABLA_113_dict
+from som_polissa.models.giscedata_cups import TABLA_113_dict
 
 CONTRACT_TYPES = dict(TABLA_9)
 


### PR DESCRIPTION
## Objectiu
Arreglar paths, ja que a la PR https://github.com/Som-Energia/openerp_som_addons/pull/1006 s'han modificat els paths del mòdul som_polissa

## Targeta on es demana o Incidència
Tests del diumenge

## Comportament antic
giscedata_cups estava a l'arrel del mòdul

## Comportament nou
giscedata_cups esta dins la carpeta modules del mòdul

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
