### PR TITLE
🐛(lead) Millor guardar el e-mail en minúscula 

### DIFF
--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -121,7 +121,7 @@ class SomLeadWww(osv.osv_memory):
             "titular_pu": member["address"].get("door"),
             "titular_bq": member["address"].get("block"),
             "titular_id_municipi": member["address"].get("city_id"),
-            "titular_email": member.get("email"),
+            "titular_email": member.get("email").lower(),
             "titular_phone": member.get("phone"),
             "titular_mobile": member.get("phone2"),
             "use_cont_address": False,


### PR DESCRIPTION
## Objectiu
Guardar el e-mail en minúscula al lead

## Targeta on es demana o Incidència
@PauBoix i @pedropote 

## Comportament antic
Es guardava com arribava

## Comportament nou
Ho guardem en minúscula SEMPRE

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
