### PR TITLE
Wizard de refacturació no carrega les lectures correctes quan hi ha canvi de comptador

### DIFF
--- a/som_facturacio_switching/tests/tests_wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_switching/tests/tests_wizard_refund_rectify_from_origin.py
@@ -261,7 +261,7 @@ class TestRefundRectifyFromOrigin(testing.OOTestCase):
         mock_lectures.assert_called_with(
             cursor,
             uid,
-            [wiz_id],
+            [],
             fact_info["polissa_id"][0],
             fact_info["data_inici"],
             fact_info["data_final"],
@@ -342,7 +342,7 @@ class TestRefundRectifyFromOrigin(testing.OOTestCase):
         mock_lectures.assert_called_with(
             cursor,
             uid,
-            [wiz_id],
+            [],
             fact_info["polissa_id"][0],
             fact_info["data_inici"],
             fact_info["data_final"],

--- a/som_facturacio_switching/tests/tests_wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_switching/tests/tests_wizard_refund_rectify_from_origin.py
@@ -357,6 +357,52 @@ class TestRefundRectifyFromOrigin(testing.OOTestCase):
             ),
         )
 
+    def test_recarregar_lectures_between_dates_filters_by_f1_meters(self):
+        cursor = self.cursor
+        uid = self.uid
+        wiz_obj = self.pool.get("wizard.refund.rectify.from.origin")
+
+        meter_obj = mock.Mock()
+        lect_pool_obj = mock.Mock()
+        copia_lect_wiz_o = mock.Mock()
+
+        meter_obj.search.return_value = [101]
+        lect_pool_obj.search.side_effect = [[201], [202]]
+        copia_lect_wiz_o.create.return_value = 301
+
+        def get_model(model_name):
+            if model_name == "giscedata.lectures.comptador":
+                return meter_obj
+            if model_name == "giscedata.lectures.lectura.pool":
+                return lect_pool_obj
+            if model_name == "wizard.copiar.lectura.pool.a.fact":
+                return copia_lect_wiz_o
+            raise AssertionError("Model inesperat: {}".format(model_name))
+
+        with mock.patch.object(wiz_obj.pool, "get", side_effect=get_model):
+            copied = wiz_obj.recarregar_lectures_between_dates(
+                cursor,
+                uid,
+                ["C-NEW"],
+                999,
+                "2024-01-01",
+                "2024-01-31",
+                context={},
+            )
+
+        self.assertEqual(copied, 2)
+        meter_obj.search.assert_called_with(
+            cursor,
+            uid,
+            [
+                ("polissa", "=", 999),
+                ("name", "in", ["C-NEW"]),
+            ],
+            context={"active_test": False},
+        )
+        self.assertEqual(lect_pool_obj.search.call_count, 2)
+        self.assertEqual(copia_lect_wiz_o.action_copia_lectura.call_count, 2)
+
     def test_get_factures_client_by_dates_toRefundOne(self):
         cursor = self.cursor
         uid = self.uid

--- a/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
@@ -85,7 +85,7 @@ class WizardRefundRectifyFromOrigin(osv.osv_memory):
             facts_cli_ids = list(set(facts_cli_ids) - set(f_cli_rectificar_draft))
         return facts_cli_ids, msg
 
-    def Import_readings_from_f1_to_pool(self, cursor, uid, f1_id, context):
+    def import_readings_from_f1_to_pool(self, cursor, uid, f1_id, context):
         wiz_pool_o = self.pool.get("wizard.load.lectures.pool.from.f1.multi")
         ctx = {
             'active_id': f1_id,
@@ -514,8 +514,8 @@ class WizardRefundRectifyFromOrigin(osv.osv_memory):
                     )
                     continue
 
-                if f1.import_phase != 40:
-                    self.Import_readings_from_f1_to_pool(cursor, uid, _id, context)
+                if f1.import_phase == 50:
+                    self.import_readings_from_f1_to_pool(cursor, uid, _id, context)
 
                 meters = []
                 for lect in f1.importacio_lectures_ids:

--- a/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
@@ -90,7 +90,7 @@ class WizardRefundRectifyFromOrigin(osv.osv_memory):
         ctx = {
             'active_id': f1_id,
         }
-        wiz_pool_id = wiz_pool_o.create({}, context=ctx)
+        wiz_pool_id = wiz_pool_o.create(cursor, uid, {}, context=ctx)
         wiz_pool_o.write(cursor, uid, [wiz_pool_id],
                          {
             'overwrite': True,
@@ -99,9 +99,9 @@ class WizardRefundRectifyFromOrigin(osv.osv_memory):
             'set_phase_5': False,
         }, context=ctx
         )
-        wiz_pool_o.import_pool_readings_from_f1([wiz_pool_id], context=ctx)
+        wiz_pool_o.import_pool_readings_from_f1(cursor, uid, [wiz_pool_id], context=ctx)
 
-        data = wiz_pool_o.read(cursor, uid, [wiz_pool_id], ['state', 'incorrect_ids'], context=ctx)
+        data = wiz_pool_o.read(cursor, uid, wiz_pool_id, ['state', 'incorrect_ids'], context=ctx)[0]
         if data['state'] != 'end':
             return False, data['incorrect_ids']
         return True, []

--- a/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
@@ -515,11 +515,17 @@ class WizardRefundRectifyFromOrigin(osv.osv_memory):
                     continue
 
                 if f1.import_phase == 50:
-                    self.import_readings_from_f1_to_pool(cursor, uid, _id, context)
+                    ok, l_ids = self.import_readings_from_f1_to_pool(cursor, uid, _id, context)
+                    if not ok:
+                        msg.append(
+                            "La pòlissa {}, que té l'F1 amb origen {} en fase 5, no s'han pogut importar les lectures associades a l'F1. Lectures amb error: {}, continuem...".format(  # noqa: E501
+                                pol_name, origen, l_ids
+                            )
+                        )
 
                 meters = []
                 for lect in f1.importacio_lectures_ids:
-                    meters.append(lect.comptador)
+                    meters.append(str(lect.comptador))
                 meters = list(set(meters))
 
                 n_lect_del = self.recarregar_lectures_between_dates(

--- a/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
+++ b/som_facturacio_switching/wizard/wizard_refund_rectify_from_origin.py
@@ -525,7 +525,7 @@ class WizardRefundRectifyFromOrigin(osv.osv_memory):
 
                 meters = []
                 for lect in f1.importacio_lectures_ids:
-                    meters.append(str(lect.comptador))
+                    meters.append(lect.comptador.name)
                 meters = list(set(meters))
 
                 n_lect_del = self.recarregar_lectures_between_dates(


### PR DESCRIPTION
## Objectiu

El wizard de re-facturació automàtica no carrega les lectures correctes quan coincideix un un canvi de comptador amb l'F1, ja que es dona que tenim lectura del mateix dia al comptador vell i nou. L'F1 aporta lectures amb ajustos diferents.

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/8114652?folder_id=259

## Comportament antic

Agafava les lectures per data de creació, normalment la del comptador nou.

## Comportament nou

Agafa les lectures per comptador indicat a l'F1.

##  Observacions

No passarà tests fins que gisce apliqui https://github.com/gisce/erp/pull/19969 o https://github.com/gisce/erp/pull/27040

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
