### PR TITLE
Canvi de comportament per la F001 & F017

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_validation.py
+++ b/som_facturacio_comer/giscedata_facturacio_validation.py
@@ -204,6 +204,21 @@ class GiscedataFacturacioValidationValidator(osv.osv):
         if pcat_ids and pcat_ids[0] in [x.id for x in fact.polissa_id.category_id]:
             return None
 
+        tarifa_acces = fact.tarifa_acces_id.name
+        tarifa_comer = fact.polissa_id.llista_preu.name
+        autoconsum = fact.polissa_id.autoconsumo
+        limit_kWh = parameters.get("som_skip_if_20TD_00_and_less_than_kWh", None)
+        try:
+            limit_kWh = int(limit_kWh)
+        except (ValueError, TypeError):
+            limit_kWh = None
+        if (limit_kWh is not None
+            and fact.energia_kwh <= limit_kWh
+            and tarifa_acces == '2.0TD'
+            and tarifa_comer == '2.0TD_SOM'
+                and autoconsum == '00'):
+            return None
+
         return super(GiscedataFacturacioValidationValidator, self).check_consume_by_percentage(
             cursor, uid, fact, parameters
         )
@@ -290,6 +305,38 @@ class GiscedataFacturacioValidationValidator(osv.osv):
             GiscedataFacturacioValidationValidator,
             self
         ).check_exceding_days(cursor, uid, fact, parameters)
+
+    def check_invoice_from_delayed_contract(self, cursor, uid, fact, parameters):
+        tarifa_acces = fact.tarifa_acces_id.name
+        tarifa_comer = fact.polissa_id.llista_preu.name
+        autoconsum = fact.polissa_id.autoconsumo
+        last_origens = set(
+            [lect.origen_id.codi for lect in fact.lectures_energia_ids if lect.magnitud == 'AE'])
+        reals = set([
+            '10',  # telemesura
+            '20',  # TPL
+            '30',  # visual
+            '60',  # telegestio
+        ])
+        last_is_real = last_origens <= reals and len(last_origens) > 0
+
+        limit_days = parameters.get("som_skip_if_20TD_00_and_less_than_days", None)
+        try:
+            limit_days = int(limit_days)
+        except (ValueError, TypeError):
+            limit_days = None
+        if (limit_days is not None
+            and fact.dies <= limit_days
+            and tarifa_acces == '2.0TD'
+            and tarifa_comer == '2.0TD_SOM'
+            and last_is_real
+                and autoconsum == '00'):
+            return None
+
+        return super(
+            GiscedataFacturacioValidationValidator,
+            self
+        ).check_invoice_from_delayed_contract(cursor, uid, fact, parameters)
 
 
 GiscedataFacturacioValidationValidator()

--- a/som_facturacio_comer/tests/tests_facturacio_warnings.py
+++ b/som_facturacio_comer/tests/tests_facturacio_warnings.py
@@ -596,3 +596,99 @@ class TestsFacturesValidation(testing.OOTestCase):
         fact.polissa_id.autoconsumo = u'41'  # <-- té autoconsum!
         result = self.vali_obj.check_consume_by_amount(self.txn.cursor, self.txn.user, fact, params)
         self.assertIsNotNone(result)
+
+    def test_check_invoice_from_delayed_contract_overwrite__No(self):
+        pol_id = self.get_fixture("giscedata_polissa", "polissa_0001")
+        self.prepare_contract(pol_id, "2017-01-01", "2017-02-18")
+        inv_id = self.get_fixture("giscedata_facturacio", "factura_0001")
+        self.modify_invoice(inv_id, pol_id, "2017-02-18", "2017-03-17")
+        params = {
+            "max_delayed_days": 70,
+            "today": "2017-05-20",
+        }
+        fact = self.fact_obj.browse(self.txn.cursor, self.txn.user, inv_id)
+        result = self.vali_obj.check_invoice_from_delayed_contract(
+            self.txn.cursor, self.txn.user, fact, params)
+        self.assertEqual(result, None)
+
+    def test_check_invoice_from_delayed_contract_overwrite__Yes(self):
+        pol_id = self.get_fixture("giscedata_polissa", "polissa_0001")
+        self.prepare_contract(pol_id, "2017-01-01", "2017-02-18")
+        inv_id = self.get_fixture("giscedata_facturacio", "factura_0001")
+        self.modify_invoice(inv_id, pol_id, "2017-02-18", "2017-03-17")
+        params = {
+            "max_delayed_days": 70,
+            "today": "2017-05-30",
+        }
+        fact = self.fact_obj.browse(self.txn.cursor, self.txn.user, inv_id)
+        result = self.vali_obj.check_invoice_from_delayed_contract(
+            self.txn.cursor, self.txn.user, fact, params)
+        self.assertIsNotNone(result)
+
+    def test_check_invoice_from_delayed_contract_overwrite__Yes_but_jumped(self):
+        pol_id = self.get_fixture("giscedata_polissa", "polissa_0001")
+        self.prepare_contract(pol_id, "2017-01-01", "2017-02-18")
+        inv_id = self.get_fixture("giscedata_facturacio", "factura_0001")
+        self.modify_invoice(inv_id, pol_id, "2017-02-18", "2017-03-17")
+        params = {
+            "max_delayed_days": 70,
+            "today": "2017-05-30",
+            "som_skip_if_20TD_00_and_less_than_days": 90,
+        }
+        fact = self.fact_obj.browse(self.txn.cursor, self.txn.user, inv_id)
+        fact.tarifa_acces_id.name = u'2.0TD'
+        fact.polissa_id.llista_preu.name = u'2.0TD_SOM'
+        fact.polissa_id.autoconsumo = u'00'
+        result = self.vali_obj.check_invoice_from_delayed_contract(
+            self.txn.cursor, self.txn.user, fact, params)
+        self.assertEqual(result, None)
+
+    def test_check_invoice_from_delayed_contract_overwrite__Yes_but_not_jumped(self):
+        pol_id = self.get_fixture("giscedata_polissa", "polissa_0001")
+        self.prepare_contract(pol_id, "2017-01-01", "2017-02-18")
+        inv_id = self.get_fixture("giscedata_facturacio", "factura_0001")
+        self.modify_invoice(inv_id, pol_id, "2017-02-18", "2017-03-17")
+        params = {
+            "max_delayed_days": 70,
+            "today": "2017-05-30",
+            "som_skip_if_20TD_00_and_less_than_days": 70,
+        }
+        fact = self.fact_obj.browse(self.txn.cursor, self.txn.user, inv_id)
+        fact.tarifa_acces_id.name = u'2.0TD'
+        fact.polissa_id.llista_preu.name = u'2.0TD_SOM'
+        fact.polissa_id.autoconsumo = u'00'
+        result = self.vali_obj.check_invoice_from_delayed_contract(
+            self.txn.cursor, self.txn.user, fact, params)
+        self.assertIsNotNone(result)
+
+    def test_check_consume_by_percentage_overwrite__No(self):
+        pol_id = self.get_fixture("giscedata_polissa", "polissa_0001")
+        self.prepare_contract(pol_id, "2017-01-01", "2017-02-18")
+        inv_id = self.get_fixture("giscedata_facturacio", "factura_0001")
+        self.modify_invoice(inv_id, pol_id, "2017-02-18", "2017-03-17")
+        params = {
+            "min_amount": 0.0,
+            "min_periods": 24,
+            "n_months": 24,
+            "overuse_percentage": 65.0
+        }
+        fact = self.fact_obj.browse(self.txn.cursor, self.txn.user, inv_id)
+        result = self.vali_obj.check_consume_by_percentage(
+            self.txn.cursor, self.txn.user, fact, params)
+        self.assertEqual(result, None)
+
+    def test_check_consume_by_percentage_overwrite__Yes(self):
+        pol_id = self.get_fixture("giscedata_polissa", "polissa_0001")
+        self.prepare_contract(pol_id, "2017-01-01", "2017-02-18")
+        inv_id = self.get_fixture("giscedata_facturacio", "factura_0001")
+        self.modify_invoice(inv_id, pol_id, "2017-02-18", "2017-03-17")
+        params = {
+            "min_amount": 0.0,
+            "min_periods": 24,
+            "n_months": 24,
+            "overuse_percentage": 65.0
+        }
+        fact = self.fact_obj.browse(self.txn.cursor, self.txn.user, inv_id)
+        result = self.vali_obj.check_consume_by_percentage(
+            self.txn.cursor, self.txn.user, fact, params)
+        self.assertIsNotNone(result)


### PR DESCRIPTION
## Objectiu

Modificar el comportament de les F001 i F017 segons el demanat per l'equip de factura

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/1315/activity
https://somenergia.openproject.com/projects/som-energia/work_packages/1317/activity

## Comportament antic

Marcava amb error de validació F001 les factures amb certes característiques (sense autoconsum, menys de 69 dies, 2.0TD)
Marcava amb error de validació F017 les factures amb certes característiques (sense autoconsum, menys de 1000 kWh, 2.0TD)


## Comportament nou

No marca amb error de validació F001 les factures amb certes característiques (sense autoconsum, menys de 69 dies, 2.0TD)
No marca amb error de validació F017 les factures amb certes característiques (sense autoconsum, menys de 1000 kWh, 2.0TD)



## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
