### PR TITLE
🩹✅ (gurb) Corregir incidències i testos de som_grub

### DIFF
--- a/som_gurb/models/som_gurb_cau.py
+++ b/som_gurb/models/som_gurb_cau.py
@@ -215,7 +215,7 @@ class SomGurbCau(osv.osv):
             res[gurb_cau_id] = {
                 "gift_betas_percentage": gift_betas_percentage,
                 "assigned_betas_kw": assigned_betas_kw,
-                "available_betas_kw": gen_power - assigned_betas_kw,
+                "available_betas_kw": gen_power - assigned_betas_kw - gift_betas_kw,
                 "assigned_betas_percentage": assigned_betas_percentage,
                 "assigned_gift_betas_percentage": assigned_gift_betas_percentage,
                 "extra_betas_kw": extra_betas_kw,

--- a/som_gurb/tests/tests_gurb_switching.py
+++ b/som_gurb/tests/tests_gurb_switching.py
@@ -232,7 +232,7 @@ class TestsGurbSwitching(TestsGurbBase):
         imd_obj = self.openerp.pool.get('ir.model.data')
         generador_obj = self.openerp.pool.get('giscedata.autoconsum.generador')
         partner_address_obj = self.openerp.pool.get('res.partner.address')
-        dades_cau_obj = self.pool.get('giscedata.switching.datos.cau')
+        dades_cau_obj = self.openerp.pool.get('giscedata.switching.datos.cau')
         autoconsum_obj = self.openerp.pool.get('giscedata.autoconsum')
 
         partner_id = imd_obj.get_object_reference(

--- a/som_gurb/tests/tests_gurb_wizard_create_coef_file.py
+++ b/som_gurb/tests/tests_gurb_wizard_create_coef_file.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64
 from datetime import datetime
 from tests_gurb_base import TestsGurbBase
@@ -57,3 +58,78 @@ class TestsGurbWizardCreateCoefFile(TestsGurbBase):
         self.assertEqual(
             decoded_file, "ES1234000000000001JN0F;0,350000\r\nES0021126262693495FV;0,050000"
         )
+
+    def test_coef_file_sum_precision(self):
+        """3 CUPS with equal betas (1/3 of generation power each) should sum to 1.000000"""
+        imd_obj = self.openerp.pool.get("ir.model.data")
+        gurb_cau_obj = self.openerp.pool.get("som.gurb.cau")
+        gurb_cups_obj = self.openerp.pool.get("som.gurb.cups")
+        gurb_cups_beta_obj = self.openerp.pool.get("som.gurb.cups.beta")
+        cups_ps_obj = self.openerp.pool.get("giscedata.cups.ps")
+        wiz_obj = self.openerp.pool.get("wizard.create.coeficients.file")
+
+        refs = self.get_references()
+        gurb_cau_id = refs["gurb_cau_id"]
+        cups_0001_id = refs["owner_gurb_cups_id"]
+        cups_0002_id = refs["gurb_cups_id"]
+
+        # generation_power=9, beta=3 per CUPS → coef = 3/9 = 0.333333... (repeating)
+        # 3 CUPS × 0.333333 = 0.999999 (float precision bug)
+        gurb_cau_obj.write(
+            self.cursor, self.uid, gurb_cau_id, {"generation_power": 9.0}
+        )
+
+        # Activate cups_0001 and cups_0002 via workflow
+        gurb_cups_obj.send_signal(
+            self.cursor, self.uid, [cups_0001_id, cups_0002_id], "button_create_cups"
+        )
+        gurb_cups_obj.send_signal(
+            self.cursor, self.uid, [cups_0001_id, cups_0002_id], "button_activate_cups"
+        )
+
+        # Create a 3rd CUPS PS and gurb_cups
+        id_municipi = imd_obj.get_object_reference(
+            self.cursor, self.uid, "base_extended", "ine_01001"
+        )[1]
+        config_obj = self.openerp.pool.get("res.config")
+        config_obj.set(self.cursor, self.uid, 'check_cups', 0)
+        cups_ps_03_id = cups_ps_obj.create(self.cursor, self.uid, {
+            "name": "ES9999999999999901XX",
+            "id_municipi": id_municipi,
+        })
+        config_obj.set(self.cursor, self.uid, 'check_cups', 1)
+        cups_0003_id = gurb_cups_obj.create(self.cursor, self.uid, {
+            "inscription_date": "2016-01-01",
+            "start_date": "2016-01-01",
+            "gurb_cau_id": gurb_cau_id,
+            "cups_id": cups_ps_03_id,
+            "active": True,
+        })
+        gurb_cups_obj.send_signal(
+            self.cursor, self.uid, [cups_0003_id], "button_create_cups"
+        )
+        gurb_cups_obj.send_signal(
+            self.cursor, self.uid, [cups_0003_id], "button_activate_cups"
+        )
+
+        # Set future beta = 3.0 kW for all 3 CUPS
+        # _ff_get_future_beta_percentage picks these up → 3*100/9 = 33.333...%
+        today = datetime.today().strftime('%Y-%m-%d')
+        for cups_id in [cups_0001_id, cups_0002_id, cups_0003_id]:
+            gurb_cups_beta_obj.create(self.cursor, self.uid, {
+                "active": True,
+                "start_date": today,
+                "future_beta": True,
+                "beta_kw": 3.0,
+                "extra_beta_kw": 0.0,
+                "gift_beta_kw": 0.0,
+                "gurb_cups_id": cups_id,
+            })
+
+        ctx = {"active_id": gurb_cau_id}
+        items = wiz_obj.get_items(self.cursor, self.uid, today, context=ctx)
+
+        self.assertEqual(len(items), 3)
+        coefs = [float(item["coef"].replace(",", ".")) for item in items]
+        total = sum(coefs)
+        self.assertEqual("{:1,.6f}".format(total), "1.000000")

--- a/som_gurb/tests/tests_gurb_www.py
+++ b/som_gurb/tests/tests_gurb_www.py
@@ -186,7 +186,7 @@ class TestsGurbWww(TestsGurbBase):
             "access_tariff": "2.0TD",
             "cups": "ES0021126262693495FV",
             "beta": 2.0,
-            "vat": "37692879L"
+            "vat": "B55129415"
         }
         self._eliminar_GURB_CUPS()
         result = gurb_www_obj.create_new_gurb_cups(
@@ -367,7 +367,7 @@ class TestsGurbWww(TestsGurbBase):
             "access_tariff": "2.0TD",
             "cups": "ES0021126262693495FV",
             "beta": 2.0,
-            "vat": "37692879L"
+            "vat": "B55129415"
         }
 
         ctx = {

--- a/som_gurb/wizard/wizard_create_coef_file.py
+++ b/som_gurb/wizard/wizard_create_coef_file.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+from decimal import Decimal, ROUND_HALF_UP
 from osv import osv, fields
 from datetime import datetime
 
@@ -29,6 +30,7 @@ class WizardCreateCoeficicientsFile(osv.osv_memory):
 
         items = gurb_cups_o.read(cursor, uid, gurb_cups_ids, ['cups_id'], context=context)
 
+        coefs = []
         for item in items:
             if item.get("cups_id"):
                 item["cups"] = item["cups_id"][1]
@@ -42,7 +44,19 @@ class WizardCreateCoeficicientsFile(osv.osv_memory):
                 cursor, uid, item["id"], context=context
             )[item["id"]] / 100
 
-            item["coef"] = "{:1,.6f}".format(beta).replace(".", ",")
+            coefs.append(
+                Decimal(str(beta)).quantize(Decimal('0.000001'), rounding=ROUND_HALF_UP)
+            )
+
+        # Adjust last coef to ensure the sum is exactly 1 (avoids float rounding errors)
+        if coefs:
+            diff = Decimal('1') - sum(coefs)
+            max_rounding_error = Decimal('0.0000005') * len(coefs)
+            if abs(diff) <= max_rounding_error:
+                coefs[-1] += diff
+
+        for item, coef in zip(items, coefs):
+            item["coef"] = str(coef).replace(".", ",")
 
         return items
 


### PR DESCRIPTION
## Objectiu

Corregir tests del mòdul `som_gurb` que fallaven per canvis en les dades de demo upstream (GISCE), i corregir un bug de precisió en el fitxer de coeficients de repartiment.

## Targeta on es demana o Incidència

Incidències detectades en l'execució de tests: 10 tests fallant (8 errors + 2 failures). A més, bug de precisió en punt flotant que provocava que la suma dels coeficients de repartiment donés valors com `1.000022` en lloc de `1.000000`.

https://freescout.somenergia.coop/conversation/8093249?folder_id=307

## Comportament antic

- `tests_gurb_switching.py`: 8 tests fallaven amb `AttributeError: 'TestsGurbSwitching' object has no attribute 'pool'` — s'usava `self.pool` en lloc de `self.openerp.pool`.
- `tests_gurb_www.py`: 2 tests fallaven perquè el VAT del titular de la pòlissa de test havia canviat a la DB (de `37692879L` a `B55129415`), fent que la validació `_validate_titular_cups` retornés `False`.
- `wizard_create_coef_file.py`: el mètode `get_items` calculava els coeficients amb aritmètica de punt flotant (`float`), cosa que podia provocar que la suma total dels coeficients no donés exactament `1.000000` (p. ex. `1.000022` o `0.999999`) per errors d'arrodoniment en CAUs amb 3 o més CUPS actius.

## Comportament nou

Els tests utilitzen les referències correctes:
- `self.openerp.pool.get(...)` al helper `_config_m101_autoconsum`
- VAT actualitzat a `B55129415` als tests `test_create_new_gurb_cups_on_active_contract` i `test_activate_gurb_cups_lead`

El càlcul de coeficients ara utilitza `Decimal` per garantir precisió exacta a 6 decimals, i aplica un ajust final al darrer coeficient per corregir l'error d'arrodoniment acumulat, sempre que la discrepància estigui dins del marge esperat (`0.0000005 × N CUPS`). Nou test `test_coef_file_sum_precision` verifica aquest comportament amb 3 CUPS que reparteixen 1/3 cadascun.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions