### PR TITLE
✨Mostrar els peatges i càrregs segregats quan hi ha un canvi (Block)

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3450,12 +3450,16 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                     lines_data[block][l.name]["price_subtotal"] + l.price_subtotal
                 )
             else:
+                t_tolls = self.get_tarifa_elect_atr(fact, "pricelist_tarifas_peajes_electricidad")
+                t_cargos = self.get_tarifa_elect_atr(fact, "pricelist_tarifas_cargos_electricidad")
                 lines_data[block][l.name] = {
                     "quantity": l.quantity,
                     "tolls": l.distribucion_price_subtotal + l.transporte_price_subtotal,
                     "atr_cargos": l.cargos_price_subtotal,
                     "tolls_price_unit": l.price_unit_distribucion + l.price_unit_transporte,
+                    "calculated_tolls": self.get_atr_price(fact, t_tolls, l),
                     "preu_cargos": l.price_unit_cargos,
+                    "calculated_cargos": self.get_atr_price(fact, t_cargos, l),
                     "price_subtotal": l.price_subtotal,
                     "price_unit_multi": l.price_unit_multi,
                     "price_unit": l.price_unit,

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3481,7 +3481,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         charges_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
         periods = self.get_matrix_show_periods(pol)
-        total_charges = sum([sum([round(charges[period]["preu_cargos"], 2) for period in periods]) for charges in charges_data])  # noqa: E501
+        total_charges = sum([sum([round(charges[period]["atr_cargos"], 2) for period in periods if period in charges]) for charges in charges_data])  # noqa: E501
         data = {
             "lines_data": charges_data,
             "total": total_charges,
@@ -3500,7 +3500,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         tolls_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
         periods = self.get_matrix_show_periods(pol)
-        total_tolls = sum([sum([round(tolls[period]["tolls"], 2) for period in periods]) for tolls in tolls_data])  # noqa: E501
+        total_tolls = sum([sum([round(tolls[period]["tolls"], 2) for period in periods if period in tolls]) for tolls in tolls_data])  # noqa: E501
         data = {
             "lines_data": tolls_data,
             "total": total_tolls,

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3117,11 +3117,13 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             }
 
         data = atr_linies_potencia
-        data["showing_periods"] = self.get_matrix_show_periods(pol)
+        periods = self.get_matrix_show_periods(pol)
+        data["showing_periods"] = periods
         data["dies"] = int(atr_linies_potencia["P1"]["days"]) if "P1" in atr_linies_potencia else 0
         data["dies_any"] = days_year
         data["iva_column"] = has_iva_column(fact)
         data["is_visible"] = len(self.get_dates_desde(fact.linies_potencia)) == 1
+        data["total"] = sum([round(atr_linies_potencia[period]["atr_peatge"], 2) for period in periods if period in atr_linies_potencia])  # noqa: E501
         return data
 
     def get_sub_component_invoice_details_td_power_charges_data(self, fact, pol, discount):
@@ -3183,7 +3185,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 "days": v["multi"],
             }
         data = charges_lines_potencia
-        data["showing_periods"] = self.get_matrix_show_periods(pol)
+        periods = self.get_matrix_show_periods(pol)
+        data["showing_periods"] = periods
         data["dies"] = (
             int(charges_lines_potencia["P1"]["days"]) if "P1" in charges_lines_potencia else 0
         )
@@ -3191,6 +3194,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data["header_multi"] = 4 if discount["is_visible"] else 2
         data["iva_column"] = has_iva_column(fact)
         data["is_visible"] = len(self.get_dates_desde(fact.linies_potencia)) == 1
+        data["total"] = sum([round(charges_lines_potencia[period]["preu_cargos"], 2) for period in periods if period in charges_lines_potencia])  # noqa: E501
         return data
 
     def get_component_invoice_details_info_td_data(self, fact, pol):
@@ -3489,10 +3493,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         charges_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
         periods = self.get_matrix_show_periods(pol)
-        total_charges = sum([sum([round(charges[period]["atr_cargos"], 2) for period in periods if period in charges]) for charges in charges_data])  # noqa: E501
+        total = sum([sum([round(charges[period]["atr_cargos"], 2) for period in periods if period in charges]) for charges in charges_data])  # noqa: E501
         data = {
             "lines_data": charges_data,
-            "total": total_charges,
+            "total": total,
             "header_multi": 2 * len(charges_data),
             "showing_periods": periods,
             "is_visible": is_visible,
@@ -3508,10 +3512,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         tolls_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
         periods = self.get_matrix_show_periods(pol)
-        total_tolls = sum([sum([round(tolls[period]["tolls"], 2) for period in periods if period in tolls]) for tolls in tolls_data])  # noqa: E501
+        total = sum([sum([round(tolls[period]["tolls"], 2) for period in periods if period in tolls]) for tolls in tolls_data])  # noqa: E501
         data = {
             "lines_data": tolls_data,
-            "total": total_tolls,
+            "total": total,
             "header_multi": 2 * len(tolls_data),
             "showing_periods": periods,
             "is_visible": is_visible,
@@ -3527,10 +3531,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         charges_data = self.get_sub_component_data_blocks(fact, pol, linies_potencia)
         periods = self.get_matrix_show_periods(pol)
-        total_charges = sum([sum([round(charges[period]["atr_cargos"], 2) for period in periods if period in charges]) for charges in charges_data])  # noqa: E501
+        total = sum([sum([round(charges[period]["atr_cargos"], 2) for period in periods if period in charges]) for charges in charges_data])  # noqa: E501
         data = {
             "lines_data": charges_data,
-            "total": total_charges,
+            "total": total,
             "header_multi": 2 * len(charges_data),
             "showing_periods": periods,
             "is_visible": is_visible,
@@ -3546,10 +3550,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         tolls_data = self.get_sub_component_data_blocks(fact, pol, linies_potencia)
         periods = self.get_matrix_show_periods(pol)
-        total_charges = sum([sum([round(tolls[period]["tolls"], 2) for period in periods if period in tolls]) for tolls in tolls_data])  # noqa: E501
+        total = sum([sum([round(tolls[period]["tolls"], 2) for period in periods if period in tolls]) for tolls in tolls_data])  # noqa: E501
         data = {
             "lines_data": tolls_data,
-            "total": total_charges,
+            "total": total,
             "header_multi": 2 * len(tolls_data),
             "showing_periods": periods,
             "is_visible": is_visible,
@@ -3984,9 +3988,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         # TODO remove this when fields return correct values
         all_tolls = 0.0
         p_tolls = self.get_sub_component_invoice_details_td_power_tolls_data(fact, pol)
-        for p_toll in p_tolls.keys():
-            if p_toll.startswith(u"P"):
-                all_tolls += round(p_tolls[p_toll]["atr_peatge"], 2)
+        if not p_tolls["is_visible"]:
+            p_tolls = self.get_sub_component_invoice_details_td_power_tolls_CT_data(fact, pol)
+        all_tolls += p_tolls["total"]
 
         e_tolls = self.get_sub_component_invoice_details_td_energy_tolls_data(fact, pol)
         if not e_tolls["is_visible"]:
@@ -4003,9 +4007,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         p_charges = self.get_sub_component_invoice_details_td_power_charges_data(
             fact, pol, discount_power
         )
-        for p_charge in p_charges.keys():
-            if p_charge.startswith(u"P"):
-                all_charges += round(p_charges[p_charge]["atr_cargos"], 2)
+        if not p_charges["is_visible"]:
+            p_charges = self.get_sub_component_invoice_details_td_power_charges_CT_data(fact, pol)
+        all_charges += p_charges["total"]
 
         e_charges = self.get_sub_component_invoice_details_td_energy_charges_data(
             fact, pol, discount_energy

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2806,6 +2806,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "power_charges_CT": self.get_sub_component_invoice_details_td_power_charges_CT_data(
                 fact, pol
             ),
+            "power_tolls_CT": self.get_sub_component_invoice_details_td_power_tolls_CT_data(
+                fact, pol
+            ),
             "energy": self.get_sub_component_invoice_details_td_energy_data(
                 fact, pol, energy_discount_BOE17_2021
             ),
@@ -3118,6 +3121,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data["dies"] = int(atr_linies_potencia["P1"]["days"]) if "P1" in atr_linies_potencia else 0
         data["dies_any"] = days_year
         data["iva_column"] = has_iva_column(fact)
+        data["is_visible"] = len(self.get_dates_desde(fact.linies_potencia)) == 1
         return data
 
     def get_sub_component_invoice_details_td_power_charges_data(self, fact, pol, discount):
@@ -3528,6 +3532,25 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "lines_data": charges_data,
             "total": total_charges,
             "header_multi": 2 * len(charges_data),
+            "showing_periods": periods,
+            "is_visible": is_visible,
+            "iva_column": has_iva_column(fact),
+        }
+        return data
+
+    def get_sub_component_invoice_details_td_power_tolls_CT_data(self, fact, pol):
+        linies_potencia = fact.linies_potencia
+        is_visible = len(self.get_dates_desde(linies_potencia)) > 1
+        if not is_visible:
+            return {"is_visible": is_visible}
+
+        tolls_data = self.get_sub_component_data_blocks(fact, pol, linies_potencia)
+        periods = self.get_matrix_show_periods(pol)
+        total_charges = sum([sum([round(tolls[period]["tolls"], 2) for period in periods if period in tolls]) for tolls in tolls_data])  # noqa: E501
+        data = {
+            "lines_data": tolls_data,
+            "total": total_charges,
+            "header_multi": 2 * len(tolls_data),
             "showing_periods": periods,
             "is_visible": is_visible,
             "iva_column": has_iva_column(fact),

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2813,6 +2813,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "energy_charges": self.get_sub_component_invoice_details_td_energy_charges_data(
                 fact, pol, energy_discount_BOE17_2021
             ),
+            "energy_charges_CT": self.get_sub_component_invoice_details_td_energy_charges_CT_data(
+                fact, pol
+            ),
             "other_concepts": self.get_sub_component_invoice_details_td_other_concepts_data(
                 fact, pol
             ),
@@ -3341,6 +3344,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         charges_lines_energy = {}
         tarifa_elect_atr = self.get_tarifa_elect_atr(fact, "pricelist_tarifas_cargos_electricidad")
         linies_energia = self.get_real_energy_lines(fact, pol)
+        is_visible = len(self.get_dates_desde(linies_energia)) == 1
+        if not is_visible:
+            return {"is_visible": is_visible}
+
         for l in linies_energia:  # noqa: E741
             if "price_unit_cargos" in l:
                 l_count = Counter(
@@ -3391,6 +3398,83 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data["showing_periods"] = self.get_matrix_show_periods(pol)
         data["header_multi"] = 4 if discount["is_visible"] else 2
         data["iva_column"] = has_iva_column(fact)
+        data["is_visible"] = is_visible
+        return data
+
+    def get_sub_component_data_blocks(self, fact, pol, linies):
+        lines_data = {}
+        block = 0
+        sorted_linies = sorted(linies, key=attrgetter("data_desde"))
+        data_desde = sorted_linies[0]["data_desde"] if len(sorted_linies) > 0 else None
+        for l in sorted_linies:  # noqa: E741
+            if data_desde != l["data_desde"]:
+                block += 1
+                data_desde = l["data_desde"]
+
+            if block not in lines_data:
+                lines_data[block] = {"total": 0, "multi": 0, "days_per_year": 0}
+
+            days_per_year = (
+                is_leap_year(datetime.strptime(l.data_desde, "%Y-%m-%d").year) and 366 or 365
+            )
+
+            if lines_data.has_key(block) and lines_data[block].has_key(l.name):  # noqa: W601
+                lines_data[block][l.name]["quantity"] = (
+                    lines_data[block][l.name]["quantity"] + l.quantity
+                )
+                lines_data[block][l.name]["price_subtotal"] = (
+                    lines_data[block][l.name]["price_subtotal"] + l.price_subtotal
+                )
+            else:
+                lines_data[block][l.name] = {
+                    "quantity": l.quantity,
+                    "tolls": l.distribucion_price_subtotal,
+                    "atr_cargos": l.cargos_price_subtotal,
+                    "tolls_price_unit": l.price_unit_distribucion,
+                    "preu_cargos": l.price_unit_cargos,
+                    "price_subtotal": l.price_subtotal,
+                    "price_unit_multi": l.price_unit_multi,
+                    "price_unit": l.price_unit,
+                    "extra": l.multi,
+                }
+            lines_data[block]["multi"] = l.multi
+            lines_data[block]["days_per_year"] = days_per_year
+            lines_data[block]["total"] += l.price_subtotal
+            lines_data[block]["data"] = data_desde
+            lines_data[block]["days"] = (
+                datetime.strptime(l.data_fins, "%Y-%m-%d")
+                - datetime.strptime(l.data_desde, "%Y-%m-%d")
+            ).days + 1
+            lines_data[block]["date_from"] = dateformat(l.data_desde)
+            lines_data[block]["date_to_d"] = (
+                val(l.data_fins)
+                if "date_to_d" not in lines_data[block]
+                or lines_data[block]["date_to_d"] > val(l.data_fins)
+                else lines_data[block]["date_to_d"]
+            )
+            lines_data[block]["date_to"] = dateformat(lines_data[block]["date_to_d"])
+            lines_data[block]["iva"] = get_iva_line(l)
+
+        lines_data = [lines_data[k] for k in sorted(lines_data.keys())]
+        return lines_data
+
+    def get_dates_desde(self, linies):
+        return sorted(list(set([linia.data_desde for linia in linies])))
+
+    def get_sub_component_invoice_details_td_energy_charges_CT_data(self, fact, pol):
+        linies_energia = self.get_real_energy_lines(fact, pol)
+        is_visible = len(self.get_dates_desde(linies_energia)) > 1
+        if not is_visible:
+            return {"is_visible": is_visible}
+
+        charges_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
+        data = {
+            "lines_data": charges_data,
+            "header_multi": 2 * len(charges_data),
+            "showing_periods": self.get_matrix_show_periods(pol),
+            "is_visible": is_visible,
+            "iva_column": has_iva_column(fact),
+        }
         return data
 
     def get_sub_component_invoice_details_td_other_concepts_data(self, fact, pol):

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3936,7 +3936,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         )
         if not e_charges["is_visible"]:
             e_charges = self.get_sub_component_invoice_details_td_energy_charges_CT_data(
-                fact, pol, discount_energy
+                fact, pol
             )
         all_charges += e_charges["total"]
 

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3395,10 +3395,12 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 - d,  # TODO switch back when lines comes well calculated
             }
         data = charges_lines_energy
-        data["showing_periods"] = self.get_matrix_show_periods(pol)
+        periods = self.get_matrix_show_periods(pol)
+        data["showing_periods"] = periods
         data["header_multi"] = 4 if discount["is_visible"] else 2
         data["iva_column"] = has_iva_column(fact)
         data["is_visible"] = is_visible
+        data["total"] = sum([charges_lines_energy[period]["atr_cargos"] for period in periods if period in charges_lines_energy])  # noqa: E501
         return data
 
     def get_sub_component_data_blocks(self, fact, pol, linies):
@@ -3468,10 +3470,13 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             return {"is_visible": is_visible}
 
         charges_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
+        periods = self.get_matrix_show_periods(pol)
+        total_charges = sum([sum([charges[period]["preu_cargos"] for period in periods]) for charges in charges_data])  # noqa: E501
         data = {
             "lines_data": charges_data,
+            "total": total_charges,
             "header_multi": 2 * len(charges_data),
-            "showing_periods": self.get_matrix_show_periods(pol),
+            "showing_periods": periods,
             "is_visible": is_visible,
             "iva_column": has_iva_column(fact),
         }

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3400,7 +3400,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data["header_multi"] = 4 if discount["is_visible"] else 2
         data["iva_column"] = has_iva_column(fact)
         data["is_visible"] = is_visible
-        data["total"] = sum([charges_lines_energy[period]["atr_cargos"] for period in periods if period in charges_lines_energy])  # noqa: E501
+        data["total"] = sum([round(charges_lines_energy[period]["atr_cargos"], 2) for period in periods if period in charges_lines_energy])  # noqa: E501
         return data
 
     def get_sub_component_data_blocks(self, fact, pol, linies):
@@ -3471,7 +3471,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         charges_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
         periods = self.get_matrix_show_periods(pol)
-        total_charges = sum([sum([charges[period]["preu_cargos"] for period in periods]) for charges in charges_data])  # noqa: E501
+        total_charges = sum([sum([round(charges[period]["preu_cargos"], 2) for period in periods]) for charges in charges_data])  # noqa: E501
         data = {
             "lines_data": charges_data,
             "total": total_charges,
@@ -3930,12 +3930,15 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         for p_charge in p_charges.keys():
             if p_charge.startswith(u"P"):
                 all_charges += round(p_charges[p_charge]["atr_cargos"], 2)
+
         e_charges = self.get_sub_component_invoice_details_td_energy_charges_data(
             fact, pol, discount_energy
         )
-        for e_charge in e_charges.keys():
-            if e_charge.startswith(u"P"):
-                all_charges += round(e_charges[e_charge]["atr_cargos"], 2)
+        if not e_charges["is_visible"]:
+            e_charges = self.get_sub_component_invoice_details_td_energy_charges_CT_data(
+                fact, pol, discount_energy
+            )
+        all_charges += e_charges["total"]
 
         other_data = self.get_sub_component_invoice_details_td_other_concepts_data(fact, pol)
         if 'compl_info' in other_data and 'energy_lines_data' in other_data['compl_info']:

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2803,6 +2803,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "power_charges": self.get_sub_component_invoice_details_td_power_charges_data(
                 fact, pol, power_discount_BOE17_2021
             ),
+            "power_charges_CT": self.get_sub_component_invoice_details_td_power_charges_CT_data(
+                fact, pol
+            ),
             "energy": self.get_sub_component_invoice_details_td_energy_data(
                 fact, pol, energy_discount_BOE17_2021
             ),
@@ -3183,6 +3186,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data["dies_any"] = days_year
         data["header_multi"] = 4 if discount["is_visible"] else 2
         data["iva_column"] = has_iva_column(fact)
+        data["is_visible"] = len(self.get_dates_desde(fact.linies_potencia)) == 1
         return data
 
     def get_component_invoice_details_info_td_data(self, fact, pol):
@@ -3505,6 +3509,25 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "lines_data": tolls_data,
             "total": total_tolls,
             "header_multi": 2 * len(tolls_data),
+            "showing_periods": periods,
+            "is_visible": is_visible,
+            "iva_column": has_iva_column(fact),
+        }
+        return data
+
+    def get_sub_component_invoice_details_td_power_charges_CT_data(self, fact, pol):
+        linies_potencia = fact.linies_potencia
+        is_visible = len(self.get_dates_desde(linies_potencia)) > 1
+        if not is_visible:
+            return {"is_visible": is_visible}
+
+        charges_data = self.get_sub_component_data_blocks(fact, pol, linies_potencia)
+        periods = self.get_matrix_show_periods(pol)
+        total_charges = sum([sum([round(charges[period]["atr_cargos"], 2) for period in periods if period in charges]) for charges in charges_data])  # noqa: E501
+        data = {
+            "lines_data": charges_data,
+            "total": total_charges,
+            "header_multi": 2 * len(charges_data),
             "showing_periods": periods,
             "is_visible": is_visible,
             "iva_column": has_iva_column(fact),

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2813,6 +2813,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "energy_charges": self.get_sub_component_invoice_details_td_energy_charges_data(
                 fact, pol, energy_discount_BOE17_2021
             ),
+            "energy_tolls_CT": self.get_sub_component_invoice_details_td_energy_tolls_CT_data(
+                fact, pol
+            ),
             "energy_charges_CT": self.get_sub_component_invoice_details_td_energy_charges_CT_data(
                 fact, pol
             ),
@@ -3316,6 +3319,10 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         atr_linies_energia = {}  # ATR Peatges Energia dict
         tarifa_elect_atr = self.get_tarifa_elect_atr(fact, "pricelist_tarifas_peajes_electricidad")
         linies_energia = self.get_real_energy_lines(fact, pol)
+        is_visible = len(self.get_dates_desde(linies_energia)) == 1
+        if not is_visible:
+            return {"is_visible": is_visible}
+
         for l in sorted(  # noqa: E741
             sorted(linies_energia, key=attrgetter("data_desde")), key=attrgetter("name")
         ):
@@ -3336,8 +3343,11 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             }
 
         data = atr_linies_energia
-        data["showing_periods"] = self.get_matrix_show_periods(pol)
+        periods = self.get_matrix_show_periods(pol)
+        data["showing_periods"] = periods
         data["iva_column"] = has_iva_column(fact)
+        data["is_visible"] = is_visible
+        data["total"] = sum([round(atr_linies_energia[period]["atr_peatge"], 2) for period in periods if period in atr_linies_energia])  # noqa: E501
         return data
 
     def get_sub_component_invoice_details_td_energy_charges_data(self, fact, pol, discount):
@@ -3430,9 +3440,9 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             else:
                 lines_data[block][l.name] = {
                     "quantity": l.quantity,
-                    "tolls": l.distribucion_price_subtotal,
+                    "tolls": l.distribucion_price_subtotal + l.transporte_price_subtotal,
                     "atr_cargos": l.cargos_price_subtotal,
-                    "tolls_price_unit": l.price_unit_distribucion,
+                    "tolls_price_unit": l.price_unit_distribucion + l.price_unit_transporte,
                     "preu_cargos": l.price_unit_cargos,
                     "price_subtotal": l.price_subtotal,
                     "price_unit_multi": l.price_unit_multi,
@@ -3476,6 +3486,25 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "lines_data": charges_data,
             "total": total_charges,
             "header_multi": 2 * len(charges_data),
+            "showing_periods": periods,
+            "is_visible": is_visible,
+            "iva_column": has_iva_column(fact),
+        }
+        return data
+
+    def get_sub_component_invoice_details_td_energy_tolls_CT_data(self, fact, pol):
+        linies_energia = self.get_real_energy_lines(fact, pol)
+        is_visible = len(self.get_dates_desde(linies_energia)) > 1
+        if not is_visible:
+            return {"is_visible": is_visible}
+
+        tolls_data = self.get_sub_component_data_blocks(fact, pol, linies_energia)
+        periods = self.get_matrix_show_periods(pol)
+        total_tolls = sum([sum([round(tolls[period]["tolls"], 2) for period in periods]) for tolls in tolls_data])  # noqa: E501
+        data = {
+            "lines_data": tolls_data,
+            "total": total_tolls,
+            "header_multi": 2 * len(tolls_data),
             "showing_periods": periods,
             "is_visible": is_visible,
             "iva_column": has_iva_column(fact),
@@ -3912,10 +3941,11 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         for p_toll in p_tolls.keys():
             if p_toll.startswith(u"P"):
                 all_tolls += round(p_tolls[p_toll]["atr_peatge"], 2)
+
         e_tolls = self.get_sub_component_invoice_details_td_energy_tolls_data(fact, pol)
-        for e_toll in e_tolls.keys():
-            if e_toll.startswith(u"P"):
-                all_tolls += round(e_tolls[e_toll]["atr_peatge"], 2)
+        if not e_tolls["is_visible"]:
+            e_tolls = self.get_sub_component_invoice_details_td_energy_tolls_CT_data(fact, pol)
+        all_tolls += e_tolls["total"]
 
         discount_power = self.get_sub_component_invoice_details_td_power_discount_BOE17_2021_data(
             fact, pol

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2026-04-17 17:36+0000\n"
-"PO-Revision-Date: 2026-04-17 15:38+0000\n"
+"POT-Creation-Date: 2026-04-29 11:27+0000\n"
+"PO-Revision-Date: 2026-04-29 09:30+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4087
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4263
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -45,7 +45,7 @@ msgid "Reimprimir Pdf (no caché)"
 msgstr "Reimprimir Pdf (no caché)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3513
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3685
 msgid "Factura amb linies complementaries de tipus desconegut {}"
 msgstr "Factura con líneas complementarias de tipo desconocido {}"
 
@@ -55,8 +55,8 @@ msgid "Reimprimir factura en pdf"
 msgstr "Reimprimir factura en pdf"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2853
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2857
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2865
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2869
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
@@ -94,14 +94,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4117
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4293
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2897
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2909
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -130,14 +130,14 @@ msgstr "Salir"
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:229
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2849
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2861
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4213
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4243
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4389
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4419
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
 msgid "Autoconsum compartit (kWh)"
 msgstr "Autoconsumo compartido (kWh)"
@@ -148,18 +148,18 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Invalid XML for View Architecture!"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3987
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4163
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2847
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2859
 msgid "estimada"
 msgstr "estimada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3456
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3628
 msgid ""
 "No s'han trobats F1's d'expedient de anomalia/frau al generar pdf per {}"
 msgstr "No se han encontrado F1's de expediente de anomalía/fraude al generar pdf por {}"
@@ -182,7 +182,7 @@ msgid "estimada distribuïdora"
 msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4019
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4195
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
@@ -208,7 +208,7 @@ msgid "State"
 msgstr "State"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4056
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4232
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
@@ -362,8 +362,10 @@ msgstr "A los importes indicados en el diagrama debe añadirse, en su caso, el a
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:121
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:9
 msgid "Càrrecs"
 msgstr "Cargos"
 
@@ -1050,12 +1052,14 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_auvi/invoice_details_td_energy_auvi.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_auvi/invoice_details_td_energy_auvi.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:9
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:33
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:51
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:9
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:43
@@ -1098,6 +1102,9 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:22
@@ -1105,6 +1112,9 @@ msgstr "Valle"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:85
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:89
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:99
@@ -1468,7 +1478,7 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:48
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:52
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:48
@@ -1478,11 +1488,13 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:150
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:164
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:44
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:49
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:95
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:98
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:104
@@ -1515,6 +1527,9 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:52
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:58
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:39
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:51
@@ -1522,6 +1537,9 @@ msgstr "%s kWh x %s €/kWh"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:52
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:58
 #, python-format
 msgid "%s €"
 msgstr "%s €"
@@ -1795,7 +1813,7 @@ msgstr "IGIC"
 msgid "IVA"
 msgstr "IVA"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:47
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:51
 msgid "TOTAL FACTURA"
 msgstr "TOTAL FACTURA"
 
@@ -1888,6 +1906,7 @@ msgid "Serveis d'Ajust segons preu REE pel periode facturat"
 msgstr "Servicios de Ajuste según precio REE por el período facturado"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:12
 msgid "Preu càrrecs per electricitat utilitzades [€/kWh]"
 msgstr "Precio cargos por electricidad utilizada [€/kWh]"
 
@@ -1896,6 +1915,12 @@ msgstr "Precio cargos por electricidad utilizada [€/kWh]"
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:20
 msgid "kWh x €/kWh"
 msgstr "kWh x €/kWh"
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:26
+#, python-format
+msgid "kWh x €/kWh x (%s/%s) dies (del %s al %s)"
+msgstr "kWh x €/kWh x (%s/%s) días (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kWh]"
@@ -1911,12 +1936,15 @@ msgid "Preu GenerationkWh [€/kWh]"
 msgstr "Precio GenerationkWh [€/kWh]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:92
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:9
 msgid "Peatges"
 msgstr "Peajes"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:12
 msgid "Preu peatges per electricitat utilitzada [€/kWh]"
 msgstr "Precio peajes por electricidad utilizada [€/kWh]"
 
@@ -2217,6 +2245,7 @@ msgid "kW x €/kW x (%.f/%d) dies (del %s al %s)"
 msgstr "kW x €/kW x (%.f/%d) días (del %s al %s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:12
 msgid "Preu càrrecs per potència contractada [€/kW i any]"
 msgstr "Precio cargos por potencia contratada [€/kW y año]"
 
@@ -2227,11 +2256,18 @@ msgstr "Precio cargos por potencia contratada [€/kW y año]"
 msgid "kW x €/kW x (%s/%s) dies"
 msgstr "kW x €/kW x (%s/%s) días"
 
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:41
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:41
+#, python-format
+msgid "kW x €/kW x (%s/%s) dies (del %s al %s)"
+msgstr "kW x €/kW x (%s/%s) días (del %s al %s)"
+
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kW i any]"
 msgstr "Descuento sobre los cargos (RDL 17/2021) [€/kW y año]"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:12
 msgid "Preu peatges per potència contractada [€/kW i any]"
 msgstr "Precio peajes por potencia contratada [€/kW y año]"
 

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2026-04-17 17:36+0000\n"
-"PO-Revision-Date: 2026-04-17 17:36+0000\n"
+"POT-Creation-Date: 2026-04-29 11:27+0000\n"
+"PO-Revision-Date: 2026-04-29 11:27+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4087
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4263
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -38,7 +38,7 @@ msgid "Reimprimir Pdf (no caché)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3513
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3685
 msgid "Factura amb linies complementaries de tipus desconegut {}"
 msgstr ""
 
@@ -48,8 +48,8 @@ msgid "Reimprimir factura en pdf"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2853
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2857
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2865
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2869
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
@@ -86,14 +86,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4117
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4293
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2897
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2909
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -122,14 +122,14 @@ msgstr ""
 
 #. module: giscedata_facturacio_comer_som
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:229
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2849
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2861
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4213
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4243
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4389
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4419
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
 msgid "Autoconsum compartit (kWh)"
 msgstr ""
@@ -140,18 +140,18 @@ msgid "Invalid XML for View Architecture!"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3987
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4163
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2847
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2859
 msgid "estimada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3456
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3628
 msgid "No s'han trobats F1's d'expedient de anomalia/frau al generar pdf per {}"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "estimada distribuïdora"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4019
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4195
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
@@ -199,7 +199,7 @@ msgid "State"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4056
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4232
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
@@ -353,8 +353,10 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/amount_destination_td/amount_destination_td.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:121
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:9
 msgid "Càrrecs"
 msgstr ""
 
@@ -1036,12 +1038,14 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_auvi/invoice_details_td_energy_auvi.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_auvi/invoice_details_td_energy_auvi.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:9
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:33
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:51
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:9
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:15
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:43
@@ -1084,6 +1088,9 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:10
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:22
@@ -1091,6 +1098,9 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:11
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:17
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:20
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:85
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:89
 #: rml:giscedata_facturacio_comer_som/report/components/simplified_enviromental_impact/simplified_enviromental_impact.mako:99
@@ -1453,7 +1463,7 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_power/invoice_details_power.mako:32
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:13
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_reactive/invoice_details_reactive.mako:21
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:48
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:52
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako:14
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_capacitive/invoice_details_td_capacitive.mako:48
@@ -1463,11 +1473,13 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:150
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:164
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:22
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:44
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako:49
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:23
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:29
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:95
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:98
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako:104
@@ -1500,6 +1512,9 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:52
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:58
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:39
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:42
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:51
@@ -1507,6 +1522,9 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:40
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:52
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:46
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:49
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:58
 #, python-format
 msgid "%s €"
 msgstr ""
@@ -1782,7 +1800,7 @@ msgstr ""
 msgid "IVA"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:47
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako:51
 msgid "TOTAL FACTURA"
 msgstr ""
 
@@ -1875,6 +1893,7 @@ msgid "Serveis d'Ajust segons preu REE pel periode facturat"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:12
 msgid "Preu càrrecs per electricitat utilitzades [€/kWh]"
 msgstr ""
 
@@ -1882,6 +1901,12 @@ msgstr ""
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:19
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:20
 msgid "kWh x €/kWh"
+msgstr ""
+
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako:26
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:26
+#, python-format
+msgid "kWh x €/kWh x (%s/%s) dies (del %s al %s)"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako:5
@@ -1898,12 +1923,15 @@ msgid "Preu GenerationkWh [€/kWh]"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:9
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:92
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:5
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:9
 msgid "Peatges"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako:12
 msgid "Preu peatges per electricitat utilitzada [€/kWh]"
 msgstr ""
 
@@ -2204,6 +2232,7 @@ msgid "kW x €/kW x (%.f/%d) dies (del %s al %s)"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:12
 msgid "Preu càrrecs per potència contractada [€/kW i any]"
 msgstr ""
 
@@ -2214,11 +2243,18 @@ msgstr ""
 msgid "kW x €/kW x (%s/%s) dies"
 msgstr ""
 
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako:41
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:41
+#, python-format
+msgid "kW x €/kW x (%s/%s) dies (del %s al %s)"
+msgstr ""
+
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako:5
 msgid "Descompte sobre els càrrecs (RDL 17/2021) [€/kW i any]"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako:6
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako:12
 msgid "Preu peatges per potència contractada [€/kW i any]"
 msgstr ""
 

--- a/giscedata_facturacio_comer_som/migrations/5.0.25.5.0/post-0004_NEW_invoice_pdf_separated_charges_and_tolls_when_tariff_change_migrate_fields_translations.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.25.5.0/post-0004_NEW_invoice_pdf_separated_charges_and_tolls_when_tariff_change_migrate_fields_translations.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import logging
+from tools.translate import trans_load
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Updating translations")
+    trans_load(cursor, "{}/{}/i18n/es_ES.po".format(config['addons_path'], "giscedata_facturacio_comer_som"), 'es_ES')  # noqa: E501
+    logger.info("Translations succesfully updated.")
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
@@ -49,7 +49,7 @@
             % endfor
             <td class="periods_td">
             % if meter.adjust_reason != False:
-                <sup>(1)</sup>
+                <sup>(2)</sup>
             % endif
             </td>
         </tr>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
@@ -38,7 +38,7 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako" args="id=id.energy" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako" args="id=id.energy_tolls" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako" args="id=id.energy_charges" />
-    ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako" args="id=id.energy_tolls_CT" />
+    <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako" args="id=id.energy_tolls_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako" args="id=id.energy_charges_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako" args="id=id.energy_discount_BOE17_2021" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako" args="bs=id.bo_social_2023" />

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
@@ -29,7 +29,7 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako" args="id=id.power_tolls" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako" args="id=id.power_charges" />
     ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako" args="id=id.power_tolls_CT" />
-    ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako" args="id=id.power_charges_CT" />
+    <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako" args="id=id.power_charges_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako" args="id=id.power_discount_BOE17_2021" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako" args="id=id.excess_power_maximeter" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako" args="id=id.excess_power_quarterhours" />

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
@@ -28,6 +28,8 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako" args="id=id.power" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako" args="id=id.power_tolls" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako" args="id=id.power_charges" />
+    ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako" args="id=id.power_tolls_CT" />
+    ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako" args="id=id.power_charges_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako" args="id=id.power_discount_BOE17_2021" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako" args="id=id.excess_power_maximeter" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_quarterhours/invoice_details_td_excess_power_quarterhours.mako" args="id=id.excess_power_quarterhours" />
@@ -36,6 +38,8 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_generationkwh/invoice_details_td_energy_generationkwh.mako" args="id=id.energy" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako" args="id=id.energy_tolls" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako" args="id=id.energy_charges" />
+    ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako" args="id=id.energy_tolls_CT" />
+    <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako" args="id=id.energy_charges_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_discount_BOE17_2021/invoice_details_td_energy_discount_BOE17_2021.mako" args="id=id.energy_discount_BOE17_2021" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_bo_social_2023/invoice_details_td_bo_social_2023.mako" args="bs=id.bo_social_2023" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_generation/invoice_details_td_generation.mako" args="id=id.generation" />

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td/invoice_details_td.mako
@@ -28,7 +28,7 @@
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako" args="id=id.power" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako" args="id=id.power_tolls" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako" args="id=id.power_charges" />
-    ##<%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako" args="id=id.power_tolls_CT" />
+    <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako" args="id=id.power_tolls_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako" args="id=id.power_charges_CT" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_discount_BOE17_2021/invoice_details_td_power_discount_BOE17_2021.mako" args="id=id.power_discount_BOE17_2021" />
     <%include file="/giscedata_facturacio_comer_som/report/components/invoice_details_td_excess_power_maximeter/invoice_details_td_excess_power_maximeter.mako" args="id=id.excess_power_maximeter" />

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges/invoice_details_td_energy_charges.mako
@@ -1,6 +1,6 @@
 <%page args="id" />
 <%import locale%>
-% if 'P1' in id:
+% if 'P1' in id and id.is_visible:
 <tr>
     <td class="td_third concepte_td" rowspan=${id.header_multi}>${_(u"Càrrecs")}</td>
     <td class="td_bold detall_td">${_(u"Preu càrrecs per electricitat utilitzades [€/kWh]")}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako
@@ -12,7 +12,7 @@ first_pass = True
         <td class="detall_td">${_(u"Preu càrrecs per electricitat utilitzades [€/kWh]")}</td>
         % for p in id.showing_periods:
             % if p in lines_data:
-                <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"], digits=6))))}</td>
+                <td>${_(u"%s") %(formatLang(lines_data[p]["preu_cargos"], digits=6))}</td>
             % else:
                 <td></td>
             % endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako
@@ -23,7 +23,7 @@ first_pass = True
         % endif
     </tr>
     <tr class="${'last_row' if id.lines_data[-1] == lines_data else ''}">
-        <td class="detall_td">${_(u"kWh x €/kWh x (%s/%s) díes (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
+        <td class="detall_td">${_(u"kWh x €/kWh x (%s/%s) dies (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
         % for p in id.showing_periods:
             % if p in lines_data:
                 <td>${_(u"%s €") %(formatLang(lines_data[p]["atr_cargos"]))}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_charges_CT/invoice_details_td_energy_charges_CT.mako
@@ -1,0 +1,40 @@
+<%page args="id" />
+<%import locale
+first_pass = True
+%>
+% if id.is_visible:
+% for lines_data in id.lines_data:
+    <tr>
+    % if first_pass:
+        <td class="td_third concepte_td" rowspan=${id.header_multi}>${_(u"Càrrecs")}</td>
+        <%first_pass = False%>
+    % endif
+        <td class="detall_td">${_(u"Preu càrrecs per electricitat utilitzades [€/kWh]")}</td>
+        % for p in id.showing_periods:
+            % if p in lines_data:
+                <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"], digits=6))))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+    <tr class="${'last_row' if id.lines_data[-1] == lines_data else ''}">
+        <td class="detall_td">${_(u"kWh x €/kWh x (%s/%s) díes (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
+        % for p in id.showing_periods:
+            % if p in lines_data:
+                <td>${_(u"%s €") %(formatLang(lines_data[p]["atr_cargos"]))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+% endfor
+% endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls/invoice_details_td_energy_tolls.mako
@@ -1,6 +1,6 @@
 <%page args="id" />
 <%import locale%>
-% if 'P1' in id:
+% if 'P1' in id and id.is_visible:
 <tr>
     <td class="td_second concepte_td" rowspan="2">${_(u"Peatges")}</td>
     <td class="td_bold detall_td">${_(u"Preu peatges per electricitat utilitzada [€/kWh]")}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako
@@ -12,7 +12,7 @@ first_pass = True
         <td class="detall_td">${_(u"Preu peatges per electricitat utilitzada [€/kWh]")}</td>
         % for p in id.showing_periods:
             % if p in lines_data:
-                <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"], digits=6))))}</td>
+                <td>${_(u"%s") %(formatLang(lines_data[p]["tolls_price_unit"], digits=6))}</td>
             % else:
                 <td></td>
             % endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako
@@ -1,0 +1,40 @@
+<%page args="id" />
+<%import locale
+first_pass = True
+%>
+% if id.is_visible:
+% for lines_data in id.lines_data:
+    <tr>
+    % if first_pass:
+        <td class="td_second concepte_td" rowspan=${id.header_multi}>${_(u"Peatges")}</td>
+        <%first_pass = False%>
+    % endif
+        <td class="detall_td">${_(u"Preu peatges per electricitat utilitzada [€/kWh]")}</td>
+        % for p in id.showing_periods:
+            % if p in lines_data:
+                <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"], digits=6))))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+    <tr>
+        <td class="detall_td">${_(u"kWh x €/kWh x (%s/%s) díes (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
+        % for p in id.showing_periods:
+            % if p in lines_data:
+                <td>${_(u"%s €") %(formatLang(lines_data[p]["tolls"]))}</td>
+            % else:
+                <td></td>
+            % endif
+        % endfor
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+% endfor
+% endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_energy_tolls_CT/invoice_details_td_energy_tolls_CT.mako
@@ -23,7 +23,7 @@ first_pass = True
         % endif
     </tr>
     <tr>
-        <td class="detall_td">${_(u"kWh x €/kWh x (%s/%s) díes (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
+        <td class="detall_td">${_(u"kWh x €/kWh x (%s/%s) dies (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
         % for p in id.showing_periods:
             % if p in lines_data:
                 <td>${_(u"%s €") %(formatLang(lines_data[p]["tolls"]))}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges/invoice_details_td_power_charges.mako
@@ -1,6 +1,6 @@
 <%page args="id" />
 <%import locale %>
-% if 'P1' in id:
+% if 'P1' in id and id.is_visible:
 <tr>
     <td class="td_third concepte_td" rowspan=${id.header_multi}>${_(u"Càrrecs")}</td>
     <td class="td_bold detall_td">${_(u"Preu càrrecs per potència contractada [€/kW i any]")}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako
@@ -12,12 +12,12 @@ first_pass = True
         <td class="detall_td">${_(u"Preu càrrecs per potència contractada [€/kW i any]")}</td>
         % if len(id.showing_periods) == 3:
             % for p in id.showing_periods[:-1]:
-                % if p in lines_data and "preu_cargos" in lines_data[p]:
+                % if p in lines_data and "calculated_cargos" in lines_data[p]:
                     % if p == 'P1':
-                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"] * lines_data["days_per_year"], digits=6))))}</td>
+                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["calculated_cargos"], digits=6))))}</td>
                         <td></td>
                     % else:
-                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"] * lines_data["days_per_year"], digits=6))))}</td>
+                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["calculated_cargos"], digits=6))))}</td>
                     % endif
                 % else:
                     <td></td>
@@ -25,8 +25,8 @@ first_pass = True
             % endfor
         % else:
             % for p in id.showing_periods:
-                % if p in lines_data and "preu_cargos" in lines_data[p]:
-                    <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"] * lines_data["days_per_year"], digits=6))))}</td>
+                % if p in lines_data and "calculated_cargos" in lines_data[p]:
+                    <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["calculated_cargos"], digits=6))))}</td>
                 % else:
                     <td></td>
                 % endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_charges_CT/invoice_details_td_power_charges_CT.mako
@@ -1,0 +1,70 @@
+<%page args="id" />
+<%import locale
+first_pass = True
+%>
+% if id.is_visible:
+% for lines_data in id.lines_data:
+    <tr>
+    % if first_pass:
+        <td class="td_third concepte_td" rowspan=${id.header_multi}>${_(u"Càrrecs")}</td>
+        <%first_pass = False%>
+    % endif
+        <td class="detall_td">${_(u"Preu càrrecs per potència contractada [€/kW i any]")}</td>
+        % if len(id.showing_periods) == 3:
+            % for p in id.showing_periods[:-1]:
+                % if p in lines_data and "preu_cargos" in lines_data[p]:
+                    % if p == 'P1':
+                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"] * lines_data["days_per_year"], digits=6))))}</td>
+                        <td></td>
+                    % else:
+                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"] * lines_data["days_per_year"], digits=6))))}</td>
+                    % endif
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % else:
+            % for p in id.showing_periods:
+                % if p in lines_data and "preu_cargos" in lines_data[p]:
+                    <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["preu_cargos"] * lines_data["days_per_year"], digits=6))))}</td>
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % endif
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+    <tr class="${'last_row' if id.lines_data[-1] == lines_data else ''}">
+        <td class="detall_td">${_(u"kW x €/kW x (%s/%s) dies (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
+        % if len(id.showing_periods) == 3:
+            % for p in id.showing_periods[:-1]:
+                % if p in lines_data and "atr_cargos" in lines_data[p]:
+                    % if p == 'P1':
+                        <td>${_(u"%s €") %(formatLang(lines_data[p]["atr_cargos"]))}</td>
+                        <td></td>
+                    % else:
+                        <td>${_(u"%s €") %(formatLang(lines_data[p]["atr_cargos"]))}</td>
+                    % endif
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % else:
+            % for p in id.showing_periods:
+                % if p in lines_data and "atr_cargos" in lines_data[p]:
+                    <td>${_(u"%s €") %(formatLang(lines_data[p]["atr_cargos"]))}</td>
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % endif
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+% endfor
+% endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls/invoice_details_td_power_tolls.mako
@@ -1,6 +1,6 @@
 <%page args="id" />
 <%import locale %>
-% if 'P1' in id:
+% if 'P1' in id and id.is_visible:
 <tr>
     <td class="td_second concepte_td" rowspan="2">${_(u"Peatges")}</td>
     <td class="td_bold detall_td">${_(u"Preu peatges per potència contractada [€/kW i any]")}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako
@@ -12,12 +12,12 @@ first_pass = True
         <td class="detall_td">${_(u"Preu peatges per potència contractada [€/kW i any]")}</td>
         % if len(id.showing_periods) == 3:
             % for p in id.showing_periods[:-1]:
-                % if p in lines_data and lines_data[p]["tolls_price_unit"]:
+                % if p in lines_data and lines_data[p]["calculated_tolls"]:
                     % if p == 'P1':
-                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"] * lines_data["days_per_year"], digits=6))))}</td>
+                        <td>${_(u"%s") %(formatLang(lines_data[p]["calculated_tolls"], digits=5))}</td>
                         <td></td>
                     % else:
-                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"] * lines_data["days_per_year"], digits=6))))}</td>
+                        <td>${_(u"%s") %(formatLang(lines_data[p]["calculated_tolls"], digits=6))}</td>
                     % endif
                 % else:
                     <td></td>
@@ -25,8 +25,8 @@ first_pass = True
             % endfor
         % else:
             % for p in id.showing_periods:
-                % if p in lines_data and lines_data[p]["tolls_price_unit"]:
-                    <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"] * lines_data["days_per_year"], digits=6))))}</td>
+                % if p in lines_data and lines_data[p]["calculated_tolls"]:
+                    <td>${_(u"%s") %(formatLang(lines_data[p]["calculated_tolls"], digits=6))}</td>
                 % else:
                     <td></td>
                 % endif

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako
@@ -11,7 +11,6 @@ first_pass = True
     % endif
         <td class="detall_td">${_(u"Preu peatges per potència contractada [€/kW i any]")}</td>
         % if len(id.showing_periods) == 3:
-            kk
             % for p in id.showing_periods[:-1]:
                 % if p in lines_data and lines_data[p]["tolls_price_unit"]:
                     % if p == 'P1':

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_power_tolls_CT/invoice_details_td_power_tolls_CT.mako
@@ -1,0 +1,71 @@
+<%page args="id" />
+<%import locale
+first_pass = True
+%>
+% if id.is_visible:
+% for lines_data in id.lines_data:
+    <tr>
+    % if first_pass:
+        <td class="td_second concepte_td" rowspan=${id.header_multi}>${_(u"Peatges")}</td>
+        <%first_pass = False%>
+    % endif
+        <td class="detall_td">${_(u"Preu peatges per potència contractada [€/kW i any]")}</td>
+        % if len(id.showing_periods) == 3:
+            kk
+            % for p in id.showing_periods[:-1]:
+                % if p in lines_data and lines_data[p]["tolls_price_unit"]:
+                    % if p == 'P1':
+                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"] * lines_data["days_per_year"], digits=6))))}</td>
+                        <td></td>
+                    % else:
+                        <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"] * lines_data["days_per_year"], digits=6))))}</td>
+                    % endif
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % else:
+            % for p in id.showing_periods:
+                % if p in lines_data and lines_data[p]["tolls_price_unit"]:
+                    <td>${_(u"%s") %(locale.str(locale.atof(formatLang(lines_data[p]["tolls_price_unit"] * lines_data["days_per_year"], digits=6))))}</td>
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % endif
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+    <tr>
+        <td class="detall_td">${_(u"kW x €/kW x (%s/%s) dies (del %s al %s)") % (lines_data.days, lines_data.days_per_year, lines_data.date_from, lines_data.date_to)}</td>
+        % if len(id.showing_periods) == 3:
+            % for p in id.showing_periods[:-1]:
+                % if p in lines_data and lines_data[p]["tolls"]:
+                    % if p == 'P1':
+                        <td>${_(u"%s €") %(formatLang(lines_data[p]["tolls"]))}</td>
+                        <td></td>
+                    % else:
+                        <td>${_(u"%s €") %(formatLang(lines_data[p]["tolls"]))}</td>
+                    % endif
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % else:
+            % for p in id.showing_periods:
+                % if p in lines_data and lines_data[p]["tolls"]:
+                    <td>${_(u"%s €") %(formatLang(lines_data[p]["tolls"]))}</td>
+                % else:
+                    <td></td>
+                % endif
+            % endfor
+        % endif
+        <td></td>
+        % if id.iva_column:
+            <td></td>
+        % endif
+    </tr>
+% endfor
+% endif

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -2259,6 +2259,8 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                 "dies_any": 0,
                 "dies": 0,
                 "iva_column": False,
+                "total": 0,
+                "is_visible": False,
             },
         )
 
@@ -2285,6 +2287,8 @@ class Tests_FacturacioFacturaReport_invoice_details_td(Tests_FacturacioFacturaRe
                 "dies": 0,
                 "header_multi": 2,
                 "iva_column": False,
+                "total": 0,
+                "is_visible": False,
             },
         )
 


### PR DESCRIPTION
## Objectiu

Mostrar els peatges i càrrecs de la factura tant de potència com d'energia segregats en cas que sigui necessari per canvi (canvi tarifa o any)

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/610/activity

## Comportament antic

Es mostraven els peatges o càrrecs acumulats i en cas de canvi la informació podia no ser detallada

## Comportament nou

Es mostra peatges i càrrecs detallats per dies

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [x] Modifica traduccions
