### PR TITLE
Desmarcar check de evitar factures negatives a les linies de flux solar

### DIFF
--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -161,9 +161,9 @@ class GiscedataFacturacioFacturador(osv.osv):
 
     def get_avoid_negative_invoice_bv(self, cursor, uid, metode_descompte, context=None):
         """
-            Com que el total a descomptar ja està prèviament calculat tenint en compte l'import final de la factura,
-            desmarquem el check de evitar factures negatives perque sinó fa que s'apliqui menys de l'import calculat,
-            i per tant no queda a 0 la factura
+            Com que el total a descomptar ja està prèviament calculat tenint en compte l'import
+            final de la factura, desmarquem el check de evitar factures negatives perque sinó fa
+            que s'apliqui menys de l'import calculat, i per tant no queda a 0 la factura
         """
         return False
 

--- a/som_facturacio_flux_solar/giscedata_facturacio.py
+++ b/som_facturacio_flux_solar/giscedata_facturacio.py
@@ -159,5 +159,13 @@ class GiscedataFacturacioFacturador(osv.osv):
 
         return linies_utilitzades_ids, max_descompte
 
+    def get_avoid_negative_invoice_bv(self, cursor, uid, metode_descompte, context=None):
+        """
+            Com que el total a descomptar ja està prèviament calculat tenint en compte l'import final de la factura,
+            desmarquem el check de evitar factures negatives perque sinó fa que s'apliqui menys de l'import calculat,
+            i per tant no queda a 0 la factura
+        """
+        return False
+
 
 GiscedataFacturacioFacturador()


### PR DESCRIPTION
## Objectiu

- Crear les linies extres de descomptes de flux solar amb el check de evitar factures negatives desmarcat, per tal que la facturi quedi realment a 0.

## Targeta on es demana o Incidència

SAC GISCE -> `254516`
## Comportament antic

El mètode que calcula l'import del descompte tenia en compte el total de la factura, pero a l'hora d'aplicar la linia extra, quedava una quantitat pendent.

## Comportament nou

- Es creen sense el check ja que el total de la linia extra ja ha tingut en compte rigurosament totes les linies de la factura + impostos, i mai quedarà negativa.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
