### PR TITLE
:white_check_mark: Add 30 tests for component_utils to increase som_i…

### DIFF
--- a/som_informe/tests/__init__.py
+++ b/som_informe/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from .test_wizard_create_technical_report import *
+from .test_component_utils import *

--- a/som_informe/tests/test_component_utils.py
+++ b/som_informe/tests/test_component_utils.py
@@ -1,277 +1,204 @@
 # -*- coding: utf-8 -*-
 from destral import testing
-from destral.transaction import Transaction
+from som_informe.report.components.component_utils import (
+    get_unit_magnitude,
+    get_invoice_lines,
+    to_date,
+    to_string,
+    dateformat,
+    is_domestic,
+    is_enterprise,
+    has_category,
+    get_description,
+)
+from datetime import datetime
 
 
-class ComponentUtilsTests(testing.OOTestCase):
-    def setUp(self):
-        self.txn = Transaction().start(self.database)
-        self.cursor = self.txn.cursor
-        self.uid = self.txn.user
+class MockCategory:
+    def __init__(self, code=None, id=None):
+        self.code = code
+        self.id = id
 
-    def tearDown(self):
-        self.txn.stop()
 
-    def test__get_unit_magnitude_AE(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
+class MockPol:
+    def __init__(self, category_id):
+        self.category_id = category_id
 
+
+class MockLinia:
+    def __init__(self, name, tipus):
+        self.name = name
+        self.tipus = tipus
+
+
+class MockInvoice:
+    def __init__(self, linia_ids):
+        self.linia_ids = linia_ids
+
+
+class TestGetUnitMagnitude(testing.OOTestCase):
+    def test_get_unit_magnitude_AE(self):
         result = get_unit_magnitude("AE")
         self.assertEqual(result, "kWh")
 
-    def test__get_unit_magnitude_AS(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_AS(self):
         result = get_unit_magnitude("AS")
         self.assertEqual(result, "kWh")
 
-    def test__get_unit_magnitude_PM(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_PM(self):
         result = get_unit_magnitude("PM")
         self.assertEqual(result, "kW")
 
-    def test__get_unit_magnitude_EP(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_EP(self):
         result = get_unit_magnitude("EP")
         self.assertEqual(result, "kW")
 
-    def test__get_unit_magnitude_R1(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_R1(self):
         result = get_unit_magnitude("R1")
         self.assertEqual(result, "kVarh")
 
-    def test__get_unit_magnitude_R2(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_R2(self):
         result = get_unit_magnitude("R2")
         self.assertEqual(result, "kVarh")
 
-    def test__get_unit_magnitude_R3(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_R3(self):
         result = get_unit_magnitude("R3")
         self.assertEqual(result, "kVarh")
 
-    def test__get_unit_magnitude_R4(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_R4(self):
         result = get_unit_magnitude("R4")
         self.assertEqual(result, "kVarh")
 
-    def test__get_unit_magnitude_unknown(self):
-        from som_informe.report.components.component_utils import get_unit_magnitude
-
+    def test_get_unit_magnitude_unknown(self):
         result = get_unit_magnitude("UNKNOWN")
         self.assertEqual(result, "eV")
 
-    def test__dateformat_with_valid_date(self):
-        from som_informe.report.components.component_utils import dateformat
 
+class TestDateformat(testing.OOTestCase):
+    def test_dateformat_with_valid_date(self):
         result = dateformat("2021-10-01")
         self.assertEqual(result, "01-10-2021")
 
-    def test__dateformat_with_empty_string(self):
-        from som_informe.report.components.component_utils import dateformat
-
+    def test_dateformat_with_empty_string(self):
         result = dateformat("")
         self.assertEqual(result, "")
 
-    def test__dateformat_with_none(self):
-        from som_informe.report.components.component_utils import dateformat
-
+    def test_dateformat_with_none(self):
         result = dateformat(None)
         self.assertEqual(result, "")
 
-    def test__dateformat_with_date_and_hours(self):
-        from som_informe.report.components.component_utils import dateformat
-
+    def test_dateformat_with_date_and_hours(self):
         result = dateformat("2021-10-01 14:30:00", hours=True)
         self.assertEqual(result, "01-10-2021 14:30:00")
 
-    def test__to_date_with_valid_date(self):
-        from som_informe.report.components.component_utils import to_date
 
+class TestToDate(testing.OOTestCase):
+    def test_to_date_with_valid_date(self):
         result = to_date("2021-10-01")
         self.assertEqual(result.strftime("%Y-%m-%d"), "2021-10-01")
 
-    def test__to_date_with_empty_string(self):
-        from som_informe.report.components.component_utils import to_date
-
+    def test_to_date_with_empty_string(self):
         result = to_date("")
         self.assertEqual(result, None)
 
-    def test__to_date_with_none(self):
-        from som_informe.report.components.component_utils import to_date
-
+    def test_to_date_with_none(self):
         result = to_date(None)
         self.assertEqual(result, None)
 
-    def test__to_date_with_date_and_hours(self):
-        from som_informe.report.components.component_utils import to_date
-
+    def test_to_date_with_date_and_hours(self):
         result = to_date("2021-10-01 14:30:00", hours=True)
         self.assertEqual(result.strftime("%Y-%m-%d %H:%M:%S"), "2021-10-01 14:30:00")
 
-    def test__to_string_with_valid_date(self):
-        from som_informe.report.components.component_utils import to_string
-        from datetime import datetime
 
+class TestToString(testing.OOTestCase):
+    def test_to_string_with_valid_date(self):
         result = to_string(datetime(2021, 10, 1))
         self.assertEqual(result, "01-10-2021")
 
-    def test__to_string_with_none(self):
-        from som_informe.report.components.component_utils import to_string
-
+    def test_to_string_with_none(self):
         result = to_string(None)
         self.assertEqual(result, "")
 
-    def test__to_string_with_date_and_hours(self):
-        from som_informe.report.components.component_utils import to_string
-        from datetime import datetime
-
+    def test_to_string_with_date_and_hours(self):
         result = to_string(datetime(2021, 10, 1, 14, 30, 00), hours=True)
         self.assertEqual(result, "01-10-2021 14:30:00")
 
-    def test__is_domestic_with_domestic_category(self):
-        from som_informe.report.components.component_utils import is_domestic
 
-        class MockCategory:
-            def __init__(self, code):
-                self.code = code
-
-        class MockPol:
-            def __init__(self):
-                self.category_id = [MockCategory("DOM")]
-
-        result = is_domestic(MockPol())
+class TestIsDomestic(testing.OOTestCase):
+    def test_is_domestic_with_domestic_category(self):
+        pol = MockPol([MockCategory(code="DOM")])
+        result = is_domestic(pol)
         self.assertEqual(result, True)
 
-    def test__is_domestic_without_domestic_category(self):
-        from som_informe.report.components.component_utils import is_domestic
-
-        class MockCategory:
-            def __init__(self, code):
-                self.code = code
-
-        class MockPol:
-            def __init__(self):
-                self.category_id = [MockCategory("EIE")]
-
-        result = is_domestic(MockPol())
+    def test_is_domestic_without_domestic_category(self):
+        pol = MockPol([MockCategory(code="EIE")])
+        result = is_domestic(pol)
         self.assertEqual(result, False)
 
-    def test__is_enterprise_with_enterprise_category(self):
-        from som_informe.report.components.component_utils import is_enterprise
 
-        class MockCategory:
-            def __init__(self, code):
-                self.code = code
-
-        class MockPol:
-            def __init__(self):
-                self.category_id = [MockCategory("EIE")]
-
-        result = is_enterprise(MockPol())
+class TestIsEnterprise(testing.OOTestCase):
+    def test_is_enterprise_with_enterprise_category(self):
+        pol = MockPol([MockCategory(code="EIE")])
+        result = is_enterprise(pol)
         self.assertEqual(result, True)
 
-    def test__is_enterprise_with_domestic_category(self):
-        from som_informe.report.components.component_utils import is_enterprise
-
-        class MockCategory:
-            def __init__(self, code):
-                self.code = code
-
-        class MockPol:
-            def __init__(self):
-                self.category_id = [MockCategory("DOM")]
-
-        result = is_enterprise(MockPol())
+    def test_is_enterprise_with_domestic_category(self):
+        pol = MockPol([MockCategory(code="DOM")])
+        result = is_enterprise(pol)
         self.assertEqual(result, False)
 
-    def test__has_category_with_matching_category(self):
-        from som_informe.report.components.component_utils import has_category
 
-        class MockCategory:
-            def __init__(self, id):
-                self.id = id
-
-        class MockPol:
-            def __init__(self):
-                self.category_id = [MockCategory(1), MockCategory(2)]
-
-        result = has_category(MockPol(), [2])
+class TestHasCategory(testing.OOTestCase):
+    def test_has_category_with_matching_category(self):
+        pol = MockPol([MockCategory(id=1), MockCategory(id=2)])
+        result = has_category(pol, [2])
         self.assertEqual(result, True)
 
-    def test__has_category_without_matching_category(self):
-        from som_informe.report.components.component_utils import has_category
-
-        class MockCategory:
-            def __init__(self, id):
-                self.id = id
-
-        class MockPol:
-            def __init__(self):
-                self.category_id = [MockCategory(1), MockCategory(2)]
-
-        result = has_category(MockPol(), [3])
+    def test_has_category_without_matching_category(self):
+        pol = MockPol([MockCategory(id=1), MockCategory(id=2)])
+        result = has_category(pol, [3])
         self.assertEqual(result, False)
 
-    def test__get_invoice_lines_with_valid_data(self):
-        from som_informe.report.components.component_utils import get_invoice_lines
 
-        class MockLinia:
-            def __init__(self, name, tipus):
-                self.name = name
-                self.tipus = tipus
-
-        class MockInvoice:
-            def __init__(self):
-                self.linia_ids = [
-                    MockLinia("P1", "energia"),
-                    MockLinia("P2", "energia"),
-                ]
-
-        result = get_invoice_lines(MockInvoice(), "AE", "91")
+class TestGetInvoiceLines(testing.OOTestCase):
+    def test_get_invoice_lines_with_valid_data(self):
+        invoice = MockInvoice([
+            MockLinia("P1", "energia"),
+            MockLinia("P2", "energia"),
+        ])
+        result = get_invoice_lines(invoice, "AE", "91")
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].name, "P1")
 
-    def test__get_invoice_lines_with_PM_93_becomes_9392(self):
-        from som_informe.report.components.component_utils import get_invoice_lines
-
-        class MockLinia:
-            def __init__(self, name, tipus):
-                self.name = name
-                self.tipus = tipus
-
-        class MockInvoice:
-            def __init__(self):
-                self.linia_ids = [
-                    MockLinia("P2", "potencia"),
-                ]
-
-        # PM with periode 93 should become 9392 and look for P2
-        result = get_invoice_lines(MockInvoice(), "PM", "93")
+    def test_get_invoice_lines_with_PM_93_becomes_9392(self):
+        invoice = MockInvoice([
+            MockLinia("P2", "potencia"),
+        ])
+        result = get_invoice_lines(invoice, "PM", "93")
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].name, "P2")
 
-    def test__get_invoice_lines_with_unknown_magnitude(self):
-        from som_informe.report.components.component_utils import get_invoice_lines
-
-        class MockInvoice:
-            def __init__(self):
-                self.linia_ids = []
-
-        result = get_invoice_lines(MockInvoice(), "UNKNOWN", "91")
+    def test_get_invoice_lines_with_unknown_magnitude(self):
+        invoice = MockInvoice([])
+        result = get_invoice_lines(invoice, "UNKNOWN", "91")
         self.assertEqual(result, [])
 
-    def test__get_invoice_lines_with_unknown_periode(self):
-        from som_informe.report.components.component_utils import get_invoice_lines
-
-        class MockInvoice:
-            def __init__(self):
-                self.linia_ids = []
-
-        result = get_invoice_lines(MockInvoice(), "AE", "UNKNOWN")
+    def test_get_invoice_lines_with_unknown_periode(self):
+        invoice = MockInvoice([])
+        result = get_invoice_lines(invoice, "AE", "UNKNOWN")
         self.assertEqual(result, [])
+
+
+class TestGetDescription(testing.OOTestCase):
+    def test_get_description_with_valid_key(self):
+        result = get_description("01", "tarifaATR")
+        self.assertIsNotNone(result)
+
+    def test_get_description_with_invalid_key_on_error_false(self):
+        result = get_description("INVALID_KEY", "tarifaATR", on_error_return_false=False)
+        self.assertIn("ERROR", result)
+        self.assertIn("INVALID_KEY", result)
+
+    def test_get_description_with_invalid_key_on_error_true(self):
+        result = get_description("INVALID_KEY", "tarifaATR", on_error_return_false=True)
+        self.assertEqual(result, False)

--- a/som_informe/tests/test_component_utils.py
+++ b/som_informe/tests/test_component_utils.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+
+
+class ComponentUtilsTests(testing.OOTestCase):
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test__get_unit_magnitude_AE(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("AE")
+        self.assertEqual(result, "kWh")
+
+    def test__get_unit_magnitude_AS(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("AS")
+        self.assertEqual(result, "kWh")
+
+    def test__get_unit_magnitude_PM(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("PM")
+        self.assertEqual(result, "kW")
+
+    def test__get_unit_magnitude_EP(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("EP")
+        self.assertEqual(result, "kW")
+
+    def test__get_unit_magnitude_R1(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("R1")
+        self.assertEqual(result, "kVarh")
+
+    def test__get_unit_magnitude_R2(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("R2")
+        self.assertEqual(result, "kVarh")
+
+    def test__get_unit_magnitude_R3(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("R3")
+        self.assertEqual(result, "kVarh")
+
+    def test__get_unit_magnitude_R4(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("R4")
+        self.assertEqual(result, "kVarh")
+
+    def test__get_unit_magnitude_unknown(self):
+        from som_informe.report.components.component_utils import get_unit_magnitude
+
+        result = get_unit_magnitude("UNKNOWN")
+        self.assertEqual(result, "eV")
+
+    def test__dateformat_with_valid_date(self):
+        from som_informe.report.components.component_utils import dateformat
+
+        result = dateformat("2021-10-01")
+        self.assertEqual(result, "01-10-2021")
+
+    def test__dateformat_with_empty_string(self):
+        from som_informe.report.components.component_utils import dateformat
+
+        result = dateformat("")
+        self.assertEqual(result, "")
+
+    def test__dateformat_with_none(self):
+        from som_informe.report.components.component_utils import dateformat
+
+        result = dateformat(None)
+        self.assertEqual(result, "")
+
+    def test__dateformat_with_date_and_hours(self):
+        from som_informe.report.components.component_utils import dateformat
+
+        result = dateformat("2021-10-01 14:30:00", hours=True)
+        self.assertEqual(result, "01-10-2021 14:30:00")
+
+    def test__to_date_with_valid_date(self):
+        from som_informe.report.components.component_utils import to_date
+
+        result = to_date("2021-10-01")
+        self.assertEqual(result.strftime("%Y-%m-%d"), "2021-10-01")
+
+    def test__to_date_with_empty_string(self):
+        from som_informe.report.components.component_utils import to_date
+
+        result = to_date("")
+        self.assertEqual(result, None)
+
+    def test__to_date_with_none(self):
+        from som_informe.report.components.component_utils import to_date
+
+        result = to_date(None)
+        self.assertEqual(result, None)
+
+    def test__to_date_with_date_and_hours(self):
+        from som_informe.report.components.component_utils import to_date
+
+        result = to_date("2021-10-01 14:30:00", hours=True)
+        self.assertEqual(result.strftime("%Y-%m-%d %H:%M:%S"), "2021-10-01 14:30:00")
+
+    def test__to_string_with_valid_date(self):
+        from som_informe.report.components.component_utils import to_string
+        from datetime import datetime
+
+        result = to_string(datetime(2021, 10, 1))
+        self.assertEqual(result, "01-10-2021")
+
+    def test__to_string_with_none(self):
+        from som_informe.report.components.component_utils import to_string
+
+        result = to_string(None)
+        self.assertEqual(result, "")
+
+    def test__to_string_with_date_and_hours(self):
+        from som_informe.report.components.component_utils import to_string
+        from datetime import datetime
+
+        result = to_string(datetime(2021, 10, 1, 14, 30, 00), hours=True)
+        self.assertEqual(result, "01-10-2021 14:30:00")
+
+    def test__is_domestic_with_domestic_category(self):
+        from som_informe.report.components.component_utils import is_domestic
+
+        class MockCategory:
+            def __init__(self, code):
+                self.code = code
+
+        class MockPol:
+            def __init__(self):
+                self.category_id = [MockCategory("DOM")]
+
+        result = is_domestic(MockPol())
+        self.assertEqual(result, True)
+
+    def test__is_domestic_without_domestic_category(self):
+        from som_informe.report.components.component_utils import is_domestic
+
+        class MockCategory:
+            def __init__(self, code):
+                self.code = code
+
+        class MockPol:
+            def __init__(self):
+                self.category_id = [MockCategory("EIE")]
+
+        result = is_domestic(MockPol())
+        self.assertEqual(result, False)
+
+    def test__is_enterprise_with_enterprise_category(self):
+        from som_informe.report.components.component_utils import is_enterprise
+
+        class MockCategory:
+            def __init__(self, code):
+                self.code = code
+
+        class MockPol:
+            def __init__(self):
+                self.category_id = [MockCategory("EIE")]
+
+        result = is_enterprise(MockPol())
+        self.assertEqual(result, True)
+
+    def test__is_enterprise_with_domestic_category(self):
+        from som_informe.report.components.component_utils import is_enterprise
+
+        class MockCategory:
+            def __init__(self, code):
+                self.code = code
+
+        class MockPol:
+            def __init__(self):
+                self.category_id = [MockCategory("DOM")]
+
+        result = is_enterprise(MockPol())
+        self.assertEqual(result, False)
+
+    def test__has_category_with_matching_category(self):
+        from som_informe.report.components.component_utils import has_category
+
+        class MockCategory:
+            def __init__(self, id):
+                self.id = id
+
+        class MockPol:
+            def __init__(self):
+                self.category_id = [MockCategory(1), MockCategory(2)]
+
+        result = has_category(MockPol(), [2])
+        self.assertEqual(result, True)
+
+    def test__has_category_without_matching_category(self):
+        from som_informe.report.components.component_utils import has_category
+
+        class MockCategory:
+            def __init__(self, id):
+                self.id = id
+
+        class MockPol:
+            def __init__(self):
+                self.category_id = [MockCategory(1), MockCategory(2)]
+
+        result = has_category(MockPol(), [3])
+        self.assertEqual(result, False)
+
+    def test__get_invoice_lines_with_valid_data(self):
+        from som_informe.report.components.component_utils import get_invoice_lines
+
+        class MockLinia:
+            def __init__(self, name, tipus):
+                self.name = name
+                self.tipus = tipus
+
+        class MockInvoice:
+            def __init__(self):
+                self.linia_ids = [
+                    MockLinia("P1", "energia"),
+                    MockLinia("P2", "energia"),
+                ]
+
+        result = get_invoice_lines(MockInvoice(), "AE", "91")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "P1")
+
+    def test__get_invoice_lines_with_PM_93_becomes_9392(self):
+        from som_informe.report.components.component_utils import get_invoice_lines
+
+        class MockLinia:
+            def __init__(self, name, tipus):
+                self.name = name
+                self.tipus = tipus
+
+        class MockInvoice:
+            def __init__(self):
+                self.linia_ids = [
+                    MockLinia("P2", "potencia"),
+                ]
+
+        # PM with periode 93 should become 9392 and look for P2
+        result = get_invoice_lines(MockInvoice(), "PM", "93")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "P2")
+
+    def test__get_invoice_lines_with_unknown_magnitude(self):
+        from som_informe.report.components.component_utils import get_invoice_lines
+
+        class MockInvoice:
+            def __init__(self):
+                self.linia_ids = []
+
+        result = get_invoice_lines(MockInvoice(), "UNKNOWN", "91")
+        self.assertEqual(result, [])
+
+    def test__get_invoice_lines_with_unknown_periode(self):
+        from som_informe.report.components.component_utils import get_invoice_lines
+
+        class MockInvoice:
+            def __init__(self):
+                self.linia_ids = []
+
+        result = get_invoice_lines(MockInvoice(), "AE", "UNKNOWN")
+        self.assertEqual(result, [])

--- a/som_informe/tests/test_component_utils.py
+++ b/som_informe/tests/test_component_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from destral import testing
+from mock import patch
 from som_informe.report.components.component_utils import (
     get_unit_magnitude,
     get_invoice_lines,
@@ -91,6 +92,11 @@ class TestDateformat(testing.OOTestCase):
         result = dateformat("2021-10-01 14:30:00", hours=True)
         self.assertEqual(result, "01-10-2021 14:30:00")
 
+    def test_dateformat_with_date_and_hours_without_flag(self):
+        # Test slicing behavior: should extract date part only
+        result = dateformat("2021-10-01 14:30:00")
+        self.assertEqual(result, "01-10-2021")
+
 
 class TestToDate(testing.OOTestCase):
     def test_to_date_with_valid_date(self):
@@ -135,6 +141,12 @@ class TestIsDomestic(testing.OOTestCase):
         result = is_domestic(pol)
         self.assertEqual(result, False)
 
+    def test_is_domestic_with_no_categories(self):
+        # Test case where for loop never executes
+        pol = MockPol([])
+        result = is_domestic(pol)
+        self.assertEqual(result, False)
+
 
 class TestIsEnterprise(testing.OOTestCase):
     def test_is_enterprise_with_enterprise_category(self):
@@ -147,6 +159,12 @@ class TestIsEnterprise(testing.OOTestCase):
         result = is_enterprise(pol)
         self.assertEqual(result, False)
 
+    def test_is_enterprise_with_unknown_category(self):
+        # All non-DOM categories are enterprise
+        pol = MockPol([MockCategory(code="XXX")])
+        result = is_enterprise(pol)
+        self.assertEqual(result, True)
+
 
 class TestHasCategory(testing.OOTestCase):
     def test_has_category_with_matching_category(self):
@@ -157,6 +175,11 @@ class TestHasCategory(testing.OOTestCase):
     def test_has_category_without_matching_category(self):
         pol = MockPol([MockCategory(id=1), MockCategory(id=2)])
         result = has_category(pol, [3])
+        self.assertEqual(result, False)
+
+    def test_has_category_with_empty_categories(self):
+        pol = MockPol([])
+        result = has_category(pol, [1, 2])
         self.assertEqual(result, False)
 
 
@@ -188,17 +211,67 @@ class TestGetInvoiceLines(testing.OOTestCase):
         result = get_invoice_lines(invoice, "AE", "UNKNOWN")
         self.assertEqual(result, [])
 
+    def test_get_invoice_lines_filters_non_matching(self):
+        # Test that filter correctly excludes lines with same name but different type
+        invoice = MockInvoice([
+            MockLinia("P1", "energia"),
+            MockLinia("P1", "potencia"),  # same name, different type
+            MockLinia("P2", "energia"),  # same type, different name
+        ])
+        result = get_invoice_lines(invoice, "AE", "91")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].tipus, "energia")
+
+    def test_get_invoice_lines_with_reactiva(self):
+        invoice = MockInvoice([
+            MockLinia("P1", "reactiva"),
+            MockLinia("P2", "reactiva"),
+        ])
+        result = get_invoice_lines(invoice, "R1", "91")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "P1")
+
+    def test_get_invoice_lines_with_generacio(self):
+        invoice = MockInvoice([
+            MockLinia("P1", "generacio"),
+        ])
+        result = get_invoice_lines(invoice, "AS", "91")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].tipus, "generacio")
+
+    def test_get_invoice_lines_with_exces_potencia(self):
+        invoice = MockInvoice([
+            MockLinia("P1", "exces_potencia"),
+        ])
+        result = get_invoice_lines(invoice, "EP", "91")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].tipus, "exces_potencia")
+
+    def test_get_invoice_lines_with_period_A1(self):
+        invoice = MockInvoice([
+            MockLinia("P1", "energia"),
+        ])
+        result = get_invoice_lines(invoice, "AE", "A1")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "P1")
+
 
 class TestGetDescription(testing.OOTestCase):
-    def test_get_description_with_valid_key(self):
+    @patch("som_informe.report.components.component_utils.gestion_atr_get_description")
+    def test_get_description_propagates_value(self, mock_get):
+        mock_get.return_value = "Tarifa 2.0TD"
         result = get_description("01", "tarifaATR")
-        self.assertIsNotNone(result)
+        self.assertEqual(result, "Tarifa 2.0TD")
 
-    def test_get_description_with_invalid_key_on_error_false(self):
+    @patch("som_informe.report.components.component_utils.gestion_atr_get_description")
+    def test_get_description_with_invalid_key_on_error_false(self, mock_get):
+        mock_get.side_effect = ValueError("Invalid key")
         result = get_description("INVALID_KEY", "tarifaATR", on_error_return_false=False)
         self.assertIn("ERROR", result)
         self.assertIn("INVALID_KEY", result)
 
-    def test_get_description_with_invalid_key_on_error_true(self):
+    @patch("som_informe.report.components.component_utils.gestion_atr_get_description")
+    def test_get_description_with_invalid_key_on_error_true(self, mock_get):
+        mock_get.side_effect = KeyError("Invalid key")
         result = get_description("INVALID_KEY", "tarifaATR", on_error_return_false=True)
         self.assertEqual(result, False)


### PR DESCRIPTION
## Objectiu

Augmentar la cobertura de tests del mòdul `som_informe` per millorar la qualitat del codi i reduir el risc de regressions.

## Targeta on es demana o Incidència

https://trello.com/c/XXX

## Comportament antic

El fitxer `component_utils.py` tenía 0 tests, fet que feia difícil detectar regressions en les funcions helpers.

## Comportament nou

S'han afegit 37 tests per cobrir les funcions:
- `get_unit_magnitude` (9 tests)
- `dateformat` (5 tests)
- `to_date` (4 tests)
- `to_string` (3 tests)
- `is_domestic` (3 tests)
- `is_enterprise` (3 tests)
- `has_category` (3 tests)
- `get_invoice_lines` (9 tests)
- `get_description` (3 tests)

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions