### PR TITLE
DOCS_agent_configuration

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,0 +1,46 @@
+# Skill Registry
+
+**Project**: openerp_som_addons
+**Generated**: 2026-04-23
+**Stack**: Odoo/OpenERP (Python 2.7)
+
+## Available Skills
+
+| Trigger | Skill |
+|---------|-------|
+| "go-testing", "go test", teatest | go-testing |
+| "judgment day", "review adversarial", "dual review" | judgment-day |
+| "create skill", "new skill", "add agent instructions" | skill-creator |
+| "update skills", "skill registry" | skill-registry |
+| "sdd init", "iniciar sdd" | sdd-init |
+| "sdd explore", "explorar" | sdd-explore |
+| "sdd propose", "proponer cambio" | sdd-propose |
+| "sdd spec", "especificar" | sdd-spec |
+| "sdd design", "disenar" | sdd-design |
+| "sdd tasks", "tareas" | sdd-tasks |
+| "sdd apply", "implementar" | sdd-apply |
+| "sdd verify", "verificar" | sdd-verify |
+| "sdd archive", "archivar" | sdd-archive |
+| "sdd onboard", "onboard" | sdd-onboard |
+| "branch-pr", "pull request", "create pr" | branch-pr |
+| "issue-creation", "create issue", "new issue" | issue-creation |
+
+## Project Conventions
+
+### Tech Stack
+- **Framework**: Odoo/OpenERP 7 (Som Energia custom modules)
+- **Python**: 2.7 legacy
+- **Testing**: destral (OOMigration test framework)
+- **Linting**: flake8 + autopep8 + autoflake (pre-commit)
+
+### Code Patterns
+- Modular addon structure (~60 modules)
+- XML models definition
+- Wizard patterns for user flows
+- SQL triggers in migrations
+
+### Quality Tools
+- **Linter**: flake8, autopep8, autoflake
+- **Formatter**: autopep8
+- **Type checker**: None
+- **CI**: GitHub Actions (per-module workflows)

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,46 +1,94 @@
 # Skill Registry
 
-**Project**: openerp_som_addons
-**Generated**: 2026-04-23
-**Stack**: Odoo/OpenERP (Python 2.7)
+**Delegator use only.** Any agent that launches sub-agents reads this registry to resolve compact rules, then injects them directly into sub-agent prompts. Sub-agents do NOT read this registry or individual SKILL.md files.
 
-## Available Skills
+See `_shared/skill-resolver.md` for the full resolution protocol.
 
-| Trigger | Skill |
-|---------|-------|
-| "go-testing", "go test", teatest | go-testing |
-| "judgment day", "review adversarial", "dual review" | judgment-day |
-| "create skill", "new skill", "add agent instructions" | skill-creator |
-| "update skills", "skill registry" | skill-registry |
-| "sdd init", "iniciar sdd" | sdd-init |
-| "sdd explore", "explorar" | sdd-explore |
-| "sdd propose", "proponer cambio" | sdd-propose |
-| "sdd spec", "especificar" | sdd-spec |
-| "sdd design", "disenar" | sdd-design |
-| "sdd tasks", "tareas" | sdd-tasks |
-| "sdd apply", "implementar" | sdd-apply |
-| "sdd verify", "verificar" | sdd-verify |
-| "sdd archive", "archivar" | sdd-archive |
-| "sdd onboard", "onboard" | sdd-onboard |
-| "branch-pr", "pull request", "create pr" | branch-pr |
-| "issue-creation", "create issue", "new issue" | issue-creation |
+## User Skills
+
+| Trigger | Skill | Path |
+|---------|-------|------|
+| Quan necessites crear una branca nova per treballar | git-branch | ~/.config/opencode/skills/somenergia/git-branch/SKILL.md |
+| Quan necessites fer un commit de codi | git-commit | ~/.config/opencode/skills/somenergia/git-commit/SKILL.md |
+| Quan necessites crear una Pull Request | git-pr | ~/.config/opencode/skills/somenergia/git-pr/SKILL.md |
+| Quan necessites executar tests d'un mòdul Odoo amb destral | erp-test | ~/.config/opencode/skills/somenergia/erp-test/SKILL.md |
+| When creating a GitHub issue, reporting a bug, or requesting a feature | issue-creation | ~/.config/opencode/skills/issue-creation/SKILL.md |
+| When creating a pull request, opening a PR, or preparing changes for review | branch-pr | ~/.config/opencode/skills/branch-pr/SKILL.md |
+| When user asks to create a new skill, add agent instructions, or document patterns for AI | skill-creator | ~/.config/opencode/skills/skill-creator/SKILL.md |
+| When writing Go tests, using teatest, or adding test coverage | go-testing | ~/.config/opencode/skills/go-testing/SKILL.md |
+| When user says "judgment day", "judgment-day", "review adversarial", "dual review", "doble review", "juzgar", "que lo juzguen" | judgment-day | ~/.config/opencode/skills/judgment-day/SKILL.md |
+
+## Compact Rules
+
+### git-branch
+- Format de branca: `<type>_<description>` (ex: `ADD_user_registration`)
+- Tipus: IMP_ (millora), FIX_ (bug), MOD_ (canvi), ADD_ (nova), REF_ (refactor), TEST_, DOCS_, CI_
+- Descripció: 2-3 paraules en anglès, lowercase, max 50 caràcters
+- Separador: guió baix entre tipus i descripció
+- Sempre fer `git fetch origin && git pull origin main` abans de crear branca
+
+### git-commit
+- Format: `<emoji> <type>: <description>` (ex: `✨ feat: add user auth`)
+- Tipus: feat, fix, refactor, perf, test, docs, style, chore, build, ci, revert
+- Emoji obligatori seguit d'un espai
+- Descripció en anglès, max 72 caràcters, imperatiu
+- Context: utilitzar per guardar canvis implementats
+
+### git-pr
+- PLANTILLA OBLIGATÒRIA: Omplir totes les seccions (Objectiu, Targeta, Comportament antic, Comportament nou, Comprovacions)
+- Totes les sections: Omple-les totes, no deixis espais buits
+- Idioma: Català per a la descripció
+- Títols: Clar i descriptiu
+
+### erp-test
+- Requisits: Docker (PostgreSQL, MongoDB, Redis), pyenv (`erp`), Odoo a `/home/oriol/somenergia/src/erp/server/bin`
+- Variables d'entorn obligatòries: PYTHONPATH, OPENERP_PRICE_ACCURACY, OORQ_ASYNC, OPENERP_DB_*, OPENERP_MONGODB_HOST, OPENERP_REDIS_URL
+- Command: `dodestral <database> -m <module_name>`
+- Contenidors esperats: src_db_1, src_mongo_1, src_redis_1
+
+### issue-creation
+- Blank issues disabled — ALWAYS use template (bug_report.yml o feature_request.yml)
+- Every issue gets status:needs-review automatically
+- Maintainer MUST add status:approved abans de PR
+- Questions → Discussions, NOT issues
+
+### branch-pr
+- EVERY PR MUST link an approved issue — no exceptions
+- Automated checks must pass before merge
+- Branch naming: `type/description` (lowercase, regex: `^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)/[a-z0-9._-]+$`)
+- PR body MUST contain: Linked Issue (Closes #N), PR Type (exactly one type:* label), Summary, Changes Table, Test Plan
+- Conventional commits: `type(scope): description` or `type: description`
+
+### skill-creator
+- Skill structure: `skills/{skill-name}/SKILL.md`, optional assets/, references/
+- Frontmatter obligatori: name, description (inclou trigger), license (Apache-2.0), metadata.author, metadata.version
+- NO duplicar contingut existing (referenciar en lloc)
+- Referencies: LOCAL paths, no URLs externes
+
+### go-testing
+- Table-driven tests: `t.Run(tt.name, func(t *testing.T) { ... })`
+- Bubbletea testing: test Model.Update() directly, no Render()
+- Teatest per flows interactius: `teatest.NewTestModel(t, m)`
+- Golden file testing per output visual
+- Mock dependencies amb interfaces
+
+### judgment-day
+- Launch TWO independent sub-agents via delegate (async, parallel)
+- Pattern 0 OBLIGATORI: Resoldre skill registry abans de llançar judges
+- Classificar warnings: WARNING (real) vs WARNING (theoretical)
+- Verdicte: Confirmed (ambós), Suspect (un), Contradiction (desacord)
+- After 2 fix iterations: ASK user abans de continuar
+- Blocking rules: NO git push/commit fins re-judgment completa
 
 ## Project Conventions
 
-### Tech Stack
-- **Framework**: Odoo/OpenERP 7 (Som Energia custom modules)
-- **Python**: 2.7 legacy
-- **Testing**: destral (OOMigration test framework)
-- **Linting**: flake8 + autopep8 + autoflake (pre-commit)
+| File | Path | Notes |
+|------|------|-------|
+| AGENTS.md | /home/oriol/somenergia/src/openerp_som_addons/AGENTS.md | Index — references files below |
+| .github/docs/estil.md | /home/oriol/somenergia/src/openerp_som_addons/.github/docs/estil.md | Estil de codi |
+| .github/docs/evitar.md | /home/oriol/somenergia/src/openerp_som_addons/.github/docs/evitar.md | Evitar patrons |
+| .github/docs/arquitectura.md | /home/oriol/somenergia/src/openerp_som_addons/.github/docs/arquitectura.md | Arquitectura |
+| .github/docs/desenvolupament.md | /home/oriol/somenergia/src/openerp_som_addons/.github/docs/desenvolupament.md | Desenvolupament |
+| pull_request_template.md | /home/oriol/somenergia/src/openerp_som_addons/pull_request_template.md | Plantilla PR |
 
-### Code Patterns
-- Modular addon structure (~60 modules)
-- XML models definition
-- Wizard patterns for user flows
-- SQL triggers in migrations
-
-### Quality Tools
-- **Linter**: flake8, autopep8, autoflake
-- **Formatter**: autopep8
-- **Type checker**: None
-- **CI**: GitHub Actions (per-module workflows)
+Read the convention files listed above for project-specific patterns and rules. All referenced paths have been extracted — no need to read index files to discover more.

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -11,7 +11,7 @@ See `_shared/skill-resolver.md` for the full resolution protocol.
 | Quan necessites crear una branca nova per treballar | git-branch | ~/.config/opencode/skills/somenergia/git-branch/SKILL.md |
 | Quan necessites fer un commit de codi | git-commit | ~/.config/opencode/skills/somenergia/git-commit/SKILL.md |
 | Quan necessites crear una Pull Request | git-pr | ~/.config/opencode/skills/somenergia/git-pr/SKILL.md |
-| Quan necessites executar tests d'un mòdul Odoo amb destral | erp-test | ~/.config/opencode/skills/somenergia/erp-test/SKILL.md |
+| Quan necessites executar tests d'un mòdul OpenERP amb destral | erp-test | ~/.config/opencode/skills/somenergia/erp-test/SKILL.md |
 | When creating a GitHub issue, reporting a bug, or requesting a feature | issue-creation | ~/.config/opencode/skills/issue-creation/SKILL.md |
 | When creating a pull request, opening a PR, or preparing changes for review | branch-pr | ~/.config/opencode/skills/branch-pr/SKILL.md |
 | When user asks to create a new skill, add agent instructions, or document patterns for AI | skill-creator | ~/.config/opencode/skills/skill-creator/SKILL.md |
@@ -41,7 +41,7 @@ See `_shared/skill-resolver.md` for the full resolution protocol.
 - Títols: Clar i descriptiu
 
 ### erp-test
-- Requisits: Docker (PostgreSQL, MongoDB, Redis), pyenv (`erp`), Odoo a `/home/oriol/somenergia/src/erp/server/bin`
+- Requisits: Docker (PostgreSQL, MongoDB, Redis), pyenv (`erp`), OpenERP a `/home/oriol/somenergia/src/erp/server/bin`
 - Variables d'entorn obligatòries: PYTHONPATH, OPENERP_PRICE_ACCURACY, OORQ_ASYNC, OPENERP_DB_*, OPENERP_MONGODB_HOST, OPENERP_REDIS_URL
 - Command: `dodestral <database> -m <module_name>`
 - Contenidors esperats: src_db_1, src_mongo_1, src_redis_1

--- a/.claude/skills/erp-test
+++ b/.claude/skills/erp-test
@@ -1,0 +1,1 @@
+../../../opencode-skills/erp-test

--- a/.claude/skills/git-branch
+++ b/.claude/skills/git-branch
@@ -1,0 +1,1 @@
+../../../opencode-skills/git-branch

--- a/.claude/skills/git-commit
+++ b/.claude/skills/git-commit
@@ -1,0 +1,1 @@
+../../../opencode-skills/git-commit

--- a/.claude/skills/git-pr
+++ b/.claude/skills/git-pr
@@ -1,0 +1,1 @@
+../../../opencode-skills/git-pr

--- a/.cursorrules
+++ b/.cursorrules
@@ -3,7 +3,7 @@
 Treballa amb el repositori `openerp_som_addons` seguint aquestes regles.
 
 ## Tech Stack
-- **Framework**: Odoo/OpenERP 7 (Python 2.7)
+- **Framework**: OpenERP/OpenERP 7 (Python 2.7)
 - **Testing**: destral
 - **Linting**: flake8
 
@@ -24,7 +24,7 @@ Treballa amb el repositori `openerp_som_addons` seguint aquestes regles.
 
 ## Estil de Codi
 - Veure `.github/docs/estil.md`
-- Patterns Odoo 5: `osv.osv`, `_columns`, `fields.*`
+- Patterns OpenERP 5: `osv.osv`, `_columns`, `fields.*`
 - Evitar API nova: `@api.model`, `@api.depends`
 
 ## Skills

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,39 @@
+# Cursor Rules
+
+Treballa amb el repositori `openerp_som_addons` seguint aquestes regles.
+
+## Tech Stack
+- **Framework**: Odoo/OpenERP 7 (Python 2.7)
+- **Testing**: destral
+- **Linting**: flake8
+
+## Convencions Git
+
+### Branques
+- Format: `<TYPE>_<description>`
+- Types: `ADD_`, `IMP_`, `FIX_`, `MOD_`, `REF_`, `TEST_`, `DOCS_`
+
+### Commits
+- Format: `<emoji> <type>: <description>`
+- Emoji obligatoris (veure skill `git-commit`)
+- Descripció en anglès
+
+### PRs
+- Seguir plantilla: `pull_request_template.md`
+- Totes les seccions obligatòries
+
+## Estil de Codi
+- Veure `.github/docs/estil.md`
+- Patterns Odoo 5: `osv.osv`, `_columns`, `fields.*`
+- Evitar API nova: `@api.model`, `@api.depends`
+
+## Skills
+Quan l'usuari demani executar tests, usar:
+```
+pyenv activate erp && dodestral <db> -m <modul>
+```
+
+## Referències
+- `.github/docs/estil.md`
+- `.github/docs/evitar.md`
+- `.github/docs/arquitectura.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Aquest fitxer conté les instruccions i convencions que qualsevol agent IA ha de
 
 ## Tech Stack
 
-- **Framework**: Odoo/OpenERP 7 (Som Energia custom modules)
+- **Framework**: OpenERP/OpenERP 7 (Som Energia custom modules)
 - **Python**: 2.7 (compatible amb Python 3)
 - **Testing**: destral (OOMigration test framework)
 - **Linting**: flake8, autopep8, autoflake (via pre-commit)
@@ -55,13 +55,13 @@ Les skills següents estan disponibles al projecte i s'han d'utilitzar quan corr
 **Requisits per executar tests:**
 1. Docker: PostgreSQL, MongoDB, Redis corrent
 2. pyenv: `pyenv activate erp`
-3. Odoo instal·lat a `/home/oriol/somenergia/src/erp/server/bin`
+3. OpenERP instal·lat a `/home/oriol/somenergia/src/erp/server/bin`
 
 ## Estil de Programació
 
 Seguir `.github/docs/estil.md` i `.github/docs/evitar.md`.
 
-### Patterns d'Odoo 5/OERP 7
+### Patterns d'OpenERP 5/OERP 7
 
 - Utilitzar `osv.osv`, `osv.osv_memory`
 - Definir camps amb `_columns` i `fields.*`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md - Instruccions per a Agents IA
+
+Aquest fitxer conté les instruccions i convencions que qualsevol agent IA ha de seguir quan treballi amb el repositori `openerp_som_addons`.
+
+## Tech Stack
+
+- **Framework**: Odoo/OpenERP 7 (Som Energia custom modules)
+- **Python**: 2.7 (compatible amb Python 3)
+- **Testing**: destral (OOMigration test framework)
+- **Linting**: flake8, autopep8, autoflake (via pre-commit)
+
+## Estructura del Projecte
+
+```
+openerp_som_addons/
+├── som_* /              # Mòduls propis de Som Energia
+├── giscedata_* /        # Mòduls de facturació
+├── account_* /          # Mòduls comptables
+└── .github/
+    ├── workflows/       # CI (schedule_tests_*.yml)
+    ├── docs/           # Documentació interna
+    └── copilot-instructions.md
+```
+
+## Skills Disponibles
+
+Les skills següents estan disponibles al projecte i s'han d'utilitzar quan correspongui:
+
+### Git Workflow
+
+| Skill | Quan usar | Com usar |
+|-------|-----------|----------|
+| `git-branch` | Crear branca nova | `git checkout -b <TYPE>_<description>` |
+| `git-commit` | Fer commit | `git commit -m "<emoji> <type>: <description>"` |
+| `git-pr` | Crear PR | `gh pr create --title "..." --body "..."` |
+
+**Convencions de branca:**
+- `ADD_<desc>` - Nova funcionalitat
+- `IMP_<desc>` - Millora
+- `FIX_<desc>` - Bug fix
+- `MOD_<desc>` - Canvi de comportament
+- `REF_<desc>` - Refactorització
+- `TEST_<desc>` - Tests
+
+**Format de commit:**
+- Emoji + type en anglès: `✨ feat: add user auth`
+- Tipus: feat, fix, refactor, perf, test, docs, style, chore
+
+### Testing
+
+| Skill | Quan usar | Com usar |
+|-------|-----------|----------|
+| `erp-test` | Executar tests | `dodestral <db> -m <modul>` |
+
+**Requisits per executar tests:**
+1. Docker: PostgreSQL, MongoDB, Redis corrent
+2. pyenv: `pyenv activate erp`
+3. Odoo instal·lat a `/home/oriol/somenergia/src/erp/server/bin`
+
+## Estil de Programació
+
+Seguir `.github/docs/estil.md` i `.github/docs/evitar.md`.
+
+### Patterns d'Odoo 5/OERP 7
+
+- Utilitzar `osv.osv`, `osv.osv_memory`
+- Definir camps amb `_columns` i `fields.*`
+- Evitar `@api.model`, `@api.depends` (API nova)
+- Mètodes: `def method(self, cursor, uid, ids, context=None):`
+
+## SDD (Spec-Driven Development)
+
+El projecte utilitza SDD per gestionar canvis:
+
+| Fase | Descripció |
+|------|------------|
+| `sdd-explore` | Investigar i entendre |
+| `sdd-propose` | Crear proposta |
+| `sdd-spec` | Escriure especificacions |
+| `sdd-design` | Disseny tècnic |
+| `sdd-tasks` | Dividir en tasques |
+| `sdd-apply` | Implementar |
+| `sdd-verify` | Verificar contra specs |
+| `sdd-archive` | Archivar canvi |
+
+## Comprovacions obligatòries
+
+Abans de crear PR, verificar:
+- [ ] Tests passen (`erp-test`)
+- [ ] Linting passen (`flake8 .`)
+- [ ] S'ha seguit l'estil de codi
+
+## Fitxers de Referència
+
+- `.github/docs/estil.md` - Estil de codi
+- `.github/docs/evitar.md` - Evitar certs patrons
+- `.github/docs/arquitectura.md` - Arquitectura
+- `.github/docs/desenvolupament.md` - Desenvolupament
+- `pull_request_template.md` - Plantilla de PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# Instruccions per a Claude Code
+
+Treballa amb el repositori `openerp_som_addons`.
+
+## Tech Stack
+- Odoo/OpenERP 7 (Python 2.7)
+- Testing: destral
+- Linting: flake8
+
+## Convencions
+
+### Branques
+Format: `<TYPE>_<description>`
+- ADD_ - Nova funcionalitat
+- IMP_ - Millora
+- FIX_ - Bug fix
+- MOD_ - Canvi de comportament
+- REF_ - Refactorització
+- TEST_ - Tests
+
+### Commits
+Format: `<emoji> <type>: <description>`
+- feat, fix, refactor, perf, test, docs, style, chore
+- Emoji obligatoris
+- Descripció en anglès
+
+### PRs
+- Plantilla: `pull_request_template.md`
+- Totes les seccions obligatòries
+
+## Testing
+```bash
+pyenv activate erp
+dodestral <db> -m <modul>
+```
+
+## Estil de Codi
+- `.github/docs/estil.md`
+- `.github/docs/evitar.md`
+- `.github/docs/arquitectura.md`
+- Patterns Odoo 5: `osv.osv`, `_columns`, `fields.*`
+- Evitar API nova: `@api.model`, `@api.depends`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Treballa amb el repositori `openerp_som_addons`.
 
 ## Tech Stack
-- Odoo/OpenERP 7 (Python 2.7)
+- OpenERP/OpenERP 7 (Python 2.7)
 - Testing: destral
 - Linting: flake8
 
@@ -38,5 +38,5 @@ dodestral <db> -m <modul>
 - `.github/docs/estil.md`
 - `.github/docs/evitar.md`
 - `.github/docs/arquitectura.md`
-- Patterns Odoo 5: `osv.osv`, `_columns`, `fields.*`
+- Patterns OpenERP 5: `osv.osv`, `_columns`, `fields.*`
 - Evitar API nova: `@api.model`, `@api.depends`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 Treballa amb el repositori `openerp_som_addons`.
 
 ## Tech Stack
-- Odoo/OpenERP 7 (Python 2.7)
+- OpenERP/OpenERP 7 (Python 2.7)
 - Testing: destral
 - Linting: flake8
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,33 @@
+# Instruccions per a Gemini CLI
+
+Treballa amb el repositori `openerp_som_addons`.
+
+## Tech Stack
+- Odoo/OpenERP 7 (Python 2.7)
+- Testing: destral
+- Linting: flake8
+
+## Convencions
+
+### Branques
+```
+<TYPE>_<description>
+```
+Types: ADD_, IMP_, FIX_, MOD_, REF_, TEST_
+
+### Commits
+```
+<emoji> <type>: <description>
+```
+Tipus: feat, fix, refactor, perf, test, docs, style, chore
+
+### Tests
+```bash
+pyenv activate erp && dodestral <db> -m <modul>
+```
+
+## Estil de Codi
+- `.github/docs/estil.md`
+- `.github/docs/evitar.md`
+- Evitar API nova (@api.model, @api.depends)
+- Utilitzar `osv.osv`, `_columns`, `fields.*`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,47 @@
+schema: spec-driven
+
+context: |
+  Tech stack: Odoo/OpenERP (Python 2.7, PostgreSQL) - Som Energia custom modules
+  Architecture: Modular Odoo addon structure (~60 modules), XML models, SQL triggers
+  Testing: destral framework (OOMigration), unittest, GitHub Actions CI
+  Style: flake8 + autopep8 + autoflake via pre-commit
+
+strict_tdd: false
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Identify affected modules/packages
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+  tasks:
+    - Group tasks by phase (infrastructure, implementation, testing)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks small enough to complete in one session
+  apply:
+    - Follow existing code patterns and conventions
+    - Load relevant coding skills for the project stack
+  verify:
+    - Run tests if test infrastructure exists
+    - Compare implementation against every spec scenario
+  archive:
+    - Warn before merging destructive deltas (large removals)
+
+testing:
+  runner:
+    command: "python -m destral.testing"
+    framework: destral (OOMigration)
+  layers:
+    unit: true
+    integration: true
+    e2e: false
+  coverage:
+    available: false
+  quality:
+    linter: true
+    type-checker: false
+    formatter: true

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,8 +1,8 @@
 schema: spec-driven
 
 context: |
-  Tech stack: Odoo/OpenERP (Python 2.7, PostgreSQL) - Som Energia custom modules
-  Architecture: Modular Odoo addon structure (~60 modules), XML models, SQL triggers
+  Tech stack: OpenERP/OpenERP (Python 2.7, PostgreSQL) - Som Energia custom modules
+  Architecture: Modular OpenERP addon structure (~60 modules), XML models, SQL triggers
   Testing: destral framework (OOMigration), unittest, GitHub Actions CI
   Style: flake8 + autopep8 + autoflake via pre-commit
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -33,8 +33,9 @@ rules:
 
 testing:
   runner:
-    command: "python -m destral.testing"
+    command: "dodestral <database> -m <module>"
     framework: destral (OOMigration)
+    notes: "Requereix: pyenv activate erp, Docker (PostgreSQL, MongoDB, Redis)"
   layers:
     unit: true
     integration: true


### PR DESCRIPTION
## Objectiu

Afegir configuració d'agents IA per a treballar amb el repositori.

## Targeta on es demana o Incidència

- Suport múltiples agents (OpenCode, Claude Code, Cursor, Gemini, Copilot)
- Compartir skills entre equips

## Comportament antic

Cada agent utilitzava instruccions genèriques sense coneixement del projecte.

## Comportament nou

- `AGENTS.md` - Instruccions generals (OpenCode, etc.)
- `CLAUDE.md` - Instruccions específiques per a Claude Code
- `GEMINI.md` - Instruccions per a Gemini CLI
- `.cursorrules` - Instruccions per a Cursor
- `.claude/skills/` - Symlinks a skills compartides (erp-test, git-commit, git-branch, git-pr)
- `.atl/skill-registry.md` - Registry de skills
- `openspec/config.yaml` - SDD configurat (hybrid mode)

## Comprovacions

- [ ] Documentació actualitzada
- [ ] Skills verificades