### PR TITLE
✨ (webclient) Docker per executar un webclient en local

### DIFF
--- a/webclient-docker/.dockerignore
+++ b/webclient-docker/.dockerignore
@@ -1,0 +1,3 @@
+docker-compose.yml
+.dockerignore
+*.md

--- a/webclient-docker/Dockerfile
+++ b/webclient-docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:alpine
+
+RUN apk add --no-cache bash curl unzip jq ca-certificates
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY update-webclient.sh /usr/local/bin/update-webclient.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/update-webclient.sh /usr/local/bin/entrypoint.sh \
+    && mkdir -p /var/lib/webclient /usr/share/nginx/html
+
+EXPOSE 8081
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/webclient-docker/README.md
+++ b/webclient-docker/README.md
@@ -1,0 +1,161 @@
+# webclient-docker
+
+Contenidor que serveix el [webclient de GISCE](https://github.com/gisce/webclient) a partir de la darrera release publicada al repositori privat, i s'auto-actualitza cada 6 hores.
+
+## Què fa
+
+- Aixeca un `nginx:alpine` que escolta al port **8081** del host.
+- A l'arrencada i cada `CHECK_INTERVAL` segons, consulta `api.github.com/repos/gisce/webclient/releases/latest`, compara el `tag_name` amb el que té guardat, i si és nou descarrega el `.zip` de la release i el descomprimeix a `/usr/share/nginx/html`.
+- Exposa un `location /api` que fa proxy a `http://localhost:8068` (l'ERP del host).
+- Fa servir `network_mode: host`, així que `localhost` dins el contenidor és el host real (necessari per arribar al túnel SSH lligat a 127.0.0.1).
+
+## Requisits
+
+- Docker i Docker Compose v2 (`docker compose ...`).
+- El port 8081 del host lliure.
+- L'ERP escoltant al 8068 del host (típicament via túnel SSH).
+- Un **GitHub personal access token** amb permís de lectura al repo privat `gisce/webclient`:
+  - **Fine-grained**: ha d'incloure l'organització `gisce`, el repo `webclient` i permís `Contents: Read` (no s'ha provat).
+  - **Classic**: scope `repo`.
+
+## Posada en marxa
+
+1. Crea el fitxer `.env` al costat del `docker-compose.yml` (ja està a `.gitignore`):
+
+   ```
+   GITHUB_TOKEN=ghp_el_teu_token
+   ```
+
+   Sense cometes ni espais.
+
+2. Arrenca:
+
+   ```bash
+   docker compose up -d --build
+   ```
+
+3. Comprova:
+
+   ```bash
+   docker compose ps
+   docker compose logs -f
+   ```
+
+   El log ha de mostrar `[update-webclient] Installed <tag>`. Llavors el webclient es serveix a http://localhost:8081.
+
+## Configuració (variables d'entorn)
+
+| Variable | Defecte | Descripció |
+|---|---|---|
+| `GITHUB_TOKEN` | — | Token amb lectura a `gisce/webclient`. Obligatori (repo privat). |
+| `CHECK_INTERVAL` | `21600` | Segons entre comprovacions de noves releases (21600 = 6h). |
+| `WEBCLIENT_REPO` | `gisce/webclient` | Repositori `owner/name` d'on agafar les releases. |
+
+## Canviar el port del host
+
+Per defecte nginx escolta al 8081. Amb `network_mode: host` el port del contenidor és directament el port del host, així que per canviar-lo cal editar la directiva `listen` a `nginx.conf` i reconstruir:
+
+```bash
+docker compose up -d --build
+```
+
+## Canviar l'upstream de `/api`
+
+Si l'ERP no és al 8068 del host, edita `nginx.conf`:
+
+```nginx
+location /api {
+    proxy_pass http://localhost:NOU_PORT/;
+    ...
+}
+```
+
+i reconstrueix. Si l'ERP corre en un contenidor o màquina remota, recorda que `localhost` aquí vol dir el host (estem en `network_mode: host`).
+
+## Forçar una actualització ara mateix
+
+```bash
+docker compose exec webclient /usr/local/bin/update-webclient.sh
+```
+
+Si no hi ha una release nova, dirà `Already at <tag>`. Per forçar la redescarrega, esborra primer l'estat:
+
+```bash
+docker compose exec webclient rm -f /var/lib/webclient/current_tag
+docker compose exec webclient /usr/local/bin/update-webclient.sh
+```
+
+## Troubleshooting
+
+### El contenidor està en `Restarting`
+
+L'script d'actualització ha fallat i l'entrypoint no arrenca nginx fins que la primera descàrrega tingui èxit (millor això que servir un 404 buit). Mira els logs:
+
+```bash
+docker compose logs --tail 50
+```
+
+### `curl: (22) The requested URL returned error: 401`
+
+El token arriba al contenidor però GitHub el rebutja. Ordre de comprovacions:
+
+1. El token funciona fora de Docker?
+   ```bash
+   curl -sI -H "Authorization: Bearer $GITHUB_TOKEN" \
+     https://api.github.com/repos/gisce/webclient/releases/latest | head -3
+   ```
+2. Si dona 200 aquí i 401 dins: problema al `.env` (cometes, CRLF, espais). Mira què veu el contenidor:
+   ```bash
+   docker compose exec webclient printenv GITHUB_TOKEN
+   ```
+3. Si dona 401 també fora: token expirat, sense SSO autoritzat a `gisce`, o sense scope suficient.
+
+Després de corregir el `.env`, cal recrear el contenidor perquè agafi el valor nou:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+### `curl: (22) The requested URL returned error: 404`
+
+Token vàlid però sense accés al repo `gisce/webclient`. Si és fine-grained, probablement no tens el repo seleccionat en crear-lo. Si és classic, necessita l'scope `repo`.
+
+### El webclient carrega però `/api` dona 502 o no respon
+
+L'ERP al host no és accessible des del contenidor. Comprova:
+
+```bash
+ss -ltn | grep :8068
+```
+
+Ha de sortir `0.0.0.0:8068` o `127.0.0.1:8068`. Com que el contenidor fa servir `network_mode: host`, qualsevol de les dues val.
+
+### El port 8081 està ocupat
+
+```bash
+ss -ltn | grep :8081
+```
+
+Si hi ha una altra cosa, canvia el `listen` a `nginx.conf` i reconstrueix.
+
+## Estructura del directori
+
+```
+webclient-docker/
+├── Dockerfile              # nginx:alpine + curl/unzip/jq
+├── docker-compose.yml      # network_mode: host, llegeix .env
+├── nginx.conf              # listen 8081 + location /api
+├── entrypoint.sh           # update inicial + bucle + exec nginx
+├── update-webclient.sh     # descàrrega/instal·lació del zip de la release
+├── .dockerignore
+├── .gitignore              # protegeix el .env local
+├── .env                    # (no committejat) GITHUB_TOKEN=...
+└── README.md
+```
+
+## Aturar i netejar
+
+```bash
+docker compose down            # atura i esborra el contenidor
+docker compose down -v         # també esborra el volum amb l'estat (forçarà redescarrega la propera vegada)
+```

--- a/webclient-docker/docker-compose.yml
+++ b/webclient-docker/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  webclient:
+    build: .
+    image: gisce-webclient:latest
+    container_name: gisce-webclient
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      CHECK_INTERVAL: "21600"
+      GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
+    volumes:
+      - webclient-state:/var/lib/webclient
+
+volumes:
+  webclient-state:

--- a/webclient-docker/entrypoint.sh
+++ b/webclient-docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+CHECK_INTERVAL="${CHECK_INTERVAL:-21600}"  # 6h
+
+/usr/local/bin/update-webclient.sh
+
+(
+    while true; do
+        sleep "$CHECK_INTERVAL"
+        /usr/local/bin/update-webclient.sh \
+            || echo "[entrypoint] update failed, retry in ${CHECK_INTERVAL}s" >&2
+    done
+) &
+
+exec nginx -g 'daemon off;'

--- a/webclient-docker/nginx.conf
+++ b/webclient-docker/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 8081;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api {
+        proxy_pass http://localhost:8068/;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/webclient-docker/update-webclient.sh
+++ b/webclient-docker/update-webclient.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="${WEBCLIENT_REPO:-gisce/webclient}"
+HTML_DIR="${HTML_DIR:-/usr/share/nginx/html}"
+STATE_FILE="${STATE_FILE:-/var/lib/webclient/current_tag}"
+
+mkdir -p "$(dirname "$STATE_FILE")" "$HTML_DIR"
+
+auth=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
+release_json=$(curl -fsSL "${auth[@]}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$REPO/releases/latest")
+
+tag=$(echo "$release_json" | jq -r '.tag_name')
+zip_url=$(echo "$release_json" \
+    | jq -r '.assets[] | select(.name | endswith(".zip")) | .url' \
+    | head -n1)
+
+if [[ -z "$tag" || "$tag" == "null" ]]; then
+    echo "[update-webclient] Could not read tag_name from GitHub response" >&2
+    exit 1
+fi
+if [[ -z "$zip_url" || "$zip_url" == "null" ]]; then
+    echo "[update-webclient] No .zip asset in release $tag" >&2
+    exit 1
+fi
+
+current_tag=""
+[[ -f "$STATE_FILE" ]] && current_tag=$(cat "$STATE_FILE")
+
+if [[ "$current_tag" == "$tag" ]]; then
+    echo "[update-webclient] Already at $tag"
+    exit 0
+fi
+
+echo "[update-webclient] Updating ${current_tag:-<none>} -> $tag"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+curl -fsSL "${auth[@]}" \
+    -H "Accept: application/octet-stream" \
+    -o "$tmp_dir/webclient.zip" "$zip_url"
+mkdir -p "$tmp_dir/extracted"
+unzip -q "$tmp_dir/webclient.zip" -d "$tmp_dir/extracted"
+
+shopt -s nullglob
+entries=("$tmp_dir/extracted"/*)
+shopt -u nullglob
+if [[ ${#entries[@]} -eq 1 && -d "${entries[0]}" ]]; then
+    src_dir="${entries[0]}"
+else
+    src_dir="$tmp_dir/extracted"
+fi
+
+if [[ ! -f "$src_dir/index.html" ]]; then
+    echo "[update-webclient] No index.html found after unzip, aborting" >&2
+    exit 1
+fi
+
+rm -rf "${HTML_DIR:?}"/* "${HTML_DIR:?}"/.[!.]* 2>/dev/null || true
+shopt -s dotglob
+cp -a "$src_dir"/* "$HTML_DIR/"
+shopt -u dotglob
+
+echo "$tag" > "$STATE_FILE"
+echo "[update-webclient] Installed $tag"


### PR DESCRIPTION
## Objectiu
Poder executar un docker que aixequi un client web en local i renviï tota la api al port `8068` del ERP

## Targeta on es demana o Incidència
-

## Comportament antic
Ho configuràvem tot a la màquina HOST

## Comportament nou
Ara amb un Docker i un Github Token ja podem tenir un client web a la última

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
