### PR TITLE
Modificar la vista de contracte per tal d'amagar la pestanya Autoconsum quan el tipus actual és 00

### DIFF
--- a/som_polissa/migrations/5.0.26.5.0/post-0001_hide_autoconsum_page_when_00.py
+++ b/som_polissa/migrations/5.0.26.5.0/post-0001_hide_autoconsum_page_when_00.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    module = 'som_polissa'
+    file = 'views/giscedata_polissa_view.xml'
+    update_records = ['view_som_giscedata_polissa_form']
+    mg = MigrationHelper(cursor, module)
+    mg.update_xml_records(xml_path=file, update_record_ids=update_records)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa/views/giscedata_polissa_view.xml
+++ b/som_polissa/views/giscedata_polissa_view.xml
@@ -317,7 +317,7 @@
                     <field name="historic_autoconsum" />
                 </xpath>
                 <xpath expr="//page[@string='Autoconsum']" position="attributes">
-                    <attribute name="attrs">{'invisible':[('historic_autoconsum','=', False)]}</attribute>
+                    <attribute name="attrs">{'invisible':[('tipus_subseccio','in', ['00', '0C'])]}</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
## Objectiu

Modificar la vista de contracte per tal d'amagar la pestanya Autoconsum quan el tipus actual és 00

## Targeta on es demana o Incidència

SAC GISCE [254230]

## Comportament antic

Mostrava la pestanya sempre que hi haguès històrics disponibles

## Comportament nou

Si el tipus d'auto de la pòlissa és 00 (o 0C) no mostra la pestanya.

## Comprovacions

- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [x] Script de migració