### PR TITLE
DOCS: Add Odoo patterns and module structure reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,14 @@ Copilot ha de tenir en compte els fitxers següents quan existeixin:
 - `.github/docs/evitar.md`
 - `.github/docs/arquitectura.md`
 - `.github/docs/desenvolupament.md`
+- `docs/patterns/` — Plantilles de patrons (receptes per a tasques recurrents):
+  - `docs/patterns/model-inherit.md` — Com heretar un model
+  - `docs/patterns/field-add.md` — Com afegir un camp
+  - `docs/patterns/view-extend.md` — Com estendre una vista XML
+  - `docs/patterns/wizard.md` — Com crear un wizard
+  - `docs/patterns/test-basic.md` — Com escriure tests
+  - `docs/patterns/demo-data.md` — Com crear dades demo
+  - `docs/patterns/module-structure.md` — Estructura d'un mòdul
 
 ## Notes finals
 Aquestes instruccions són prioritàries per sobre de qualsevol suggeriment general del model.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Aquest fitxer conté les instruccions i convencions que qualsevol agent IA ha de
 
 ## Tech Stack
 
-- **Framework**: OpenERP/OERP 7 (Som Energia custom modules)
+- **Framework**: OpenERP v5 (Som Energia custom modules)
 - **Python**: 2.7 (compatible amb Python 3)
 - **Testing**: destral (OOMigration test framework)
 - **Linting**: flake8, autopep8, autoflake (via pre-commit)
@@ -24,7 +24,7 @@ openerp_som_addons/
 
 ## Patrons i plantilles
 
-Quan treballis amb OpenERP/Odoo en aquest repositori, consulta les plantilles a `docs/patterns/`:
+Quan treballis amb OpenERP en aquest repositori, consulta les plantilles a `docs/patterns/`:
 
 | Patró | Descripció |
 |------|-----------|
@@ -76,7 +76,7 @@ Les skills següents estan disponibles al projecte i s'han d'utilitzar quan corr
 
 Seguir `.github/docs/estil.md` i `.github/docs/evitar.md`.
 
-### Patterns d'OpenERP 5/OERP 7
+### Patterns d'OpenERP 5
 
 - Utilitzar `osv.osv`, `osv.osv_memory`
 - Definir camps amb `_columns` i `fields.*`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md — openerp_som_addons
+
+Aquest repositori conté addons per a OpenERP 5.0 utilitzats per Som Energia.
+
+## Patrons i plantilles
+
+Quan treballis amb OpenERP/Odoo en aquest repositori, consulta les plantilles a `docs/patterns/`:
+
+| Patró | Descripció |
+|------|-----------|
+| [model-inherit](docs/patterns/model-inherit.md) | Com heretar un model existent |
+| [field-add](docs/patterns/field-add.md) | Com afegir un camp nou |
+| [view-extend](docs/patterns/view-extend.md) | Com estendre una vista XML |
+| [wizard](docs/patterns/wizard.md) | Com crear un wizard |
+| [test-basic](docs/patterns/test-basic.md) | Com escriure un test |
+| [demo-data](docs/patterns/demo-data.md) | Com crear dades demo per tests |
+| [module-structure](docs/patterns/module-structure.md) | Estructura d'un mòdul (carpetes i propòsit) |
+
+## Estil i convencions
+
+- Python compatible amb OpenERP 5 (Python 2.7 però compatible Python 3.11)
+- ORM antic: `osv.osv`, `osv.osv_memory`, `_columns`, `fields.*`
+- Límit de línia: 100 caràcters
+- Passar `flake8` abans de commit
+
+## Estructura típica d'un mòdul
+
+```
+module_name/
+├── __init__.py
+├── __terp__.py
+├── models/
+├── views/
+├── wizard/
+├── report/
+├── security/
+├── data/
+├── i18n/
+├── tests/
+└── demo/
+```
+
+## Documentació adicional
+
+- `.github/copilot-instructions.md` — Instruccions per a GitHub Copilot
+- `.github/docs/` — Documents d'estil, arquitectura i bones pràctiques

--- a/docs/patterns/_index.md
+++ b/docs/patterns/_index.md
@@ -1,0 +1,24 @@
+# Patterns de desenvolupament — openerp_som_addons
+
+Col.lecció de receptes i patrons recurrents per treballar amb mòduls OpenERP/Odoo a Som Energia.
+
+## Índex
+
+| Patró | Descripció |
+|------|-----------|
+| [model-inherit](model-inherit.md) | Com heredar un model existent |
+| [field-add](field-add.md) | Com afegir un camp nou |
+| [view-extend](view-extend.md) | Com estendre una vista XML |
+| [wizard](wizard.md) | Com crear un wizard |
+| [test-basic](test-basic.md) | Com escriure un test |
+| [demo-data](demo-data.md) | Com crear dades demo per tests |
+| [module-structure](module-structure.md) | Estructura d'un mòdul (carpetes i propòsit) |
+
+## Com usar
+
+Cada fitxer segueix l'estructura:
+1. **Problema** — Situació on cal aplicar el patró
+2. **Solució** — Passos a seguir
+3. **Exemple** — Codi real del repositori
+
+Vegeu [model-inherit](model-inherit.md) per entendre l'estructura.

--- a/docs/patterns/demo-data.md
+++ b/docs/patterns/demo-data.md
@@ -1,0 +1,156 @@
+# Patró: Demo Data per Tests
+
+## Problema
+
+Necessites dades de prova per executar tests sense dependre de l'estat de la base de dades.
+
+## Solució
+
+1. Crear un fitxer XML de dades demo dins `demo/`
+2. Carregar-lo als tests amb `load_xml_id`
+
+## Estructura típica
+
+```
+module_name/
+├── demo/
+│   └── my_data.xml
+└── tests/
+    └── test_module.py
+```
+
+## Exemple: XML de demo data
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <!-- Partner de prova -->
+        <record id="demo_partner_1" model="res.partner">
+            <field name="name">Client Demo</field>
+            <field name="vat">ES12345678Z</field>
+            <field name="email">demo@example.com</field>
+        </record>
+
+        <!-- Polissa de prova -->
+        <record id="demo_polissa_1" model="giscedata.polissa">
+            <field name="name">1234</field>
+            <field name="cups">ES1234000000000001AA0</field>
+            <field name="tarifa">tarifae</field>
+            <field name="potencia">4500</field>
+            <field name="state">actiu</field>
+        </record>
+    </data>
+</openerp>
+```
+
+## Carregar als tests
+
+```python
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.testing import OOTestCase
+
+
+class TestMyFeature(OOTestCase):
+    """Tests pel mòdul."""
+
+    def setUp(self):
+        """Carrega les dades demo."""
+        # Carregar totes les dades demo del mòdul
+        self.load_xml_id("my_module")
+        # O carregar un fitxer específic
+        # self.load_xml_id("my_module.my_data_file")
+
+    def test_with_partner(self):
+        """Test que utilitza el partner demo."""
+        partner_model = self.openerp.pool.get("res.partner")
+        # Obtenir ID del partner demo
+        partner_id = self.refs["demo_partner_1"]
+        # O buscar-lo directament
+        partner_id = partner_model.search(
+            self.cursor,
+            self.uid,
+            [("vat", "=", "ES12345678Z")],
+        )[0]
+```
+
+## Exemple: Dades complexes amb relacions
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <!-- Primer crear el partner -->
+        <record id="demo_partner_complex" model="res.partner">
+            <field name="name">Soci Demo</field>
+            <field name="is_soci" eval="True"/>
+        </record>
+
+        <!-- Ara crear la pòlissa que referencia el partner -->
+        <record id="demo_polissa_complex" model="giscedata.polissa">
+            <field name="name">5678</field>
+            <field name="cups">ES1234000000000002AA0</field>
+            <field name="tarifa">tarifa3a</field>
+            <field name="potencia">5500</field>
+            <field name="state">actiu</field>
+            <field name="soci" ref="demo_partner_complex"/>
+        </record>
+    </data>
+</openerp>
+```
+
+## Crear dades directament als tests
+
+ Quan les dades XML no són prou flexibles:
+
+```python
+def setUp(self):
+    """Crear dades específiques per al test."""
+    self.partner_model = self.openerp.pool.get("res.partner")
+    self.polissa_model = self.openerp.pool.get("giscedata.polissa")
+
+    # Crear partner
+    self.partner_id = self.partner_model.create(
+        self.cursor,
+        self.uid,
+        {
+            "name": "Partner Test",
+            "vat": "ES99999999R",
+        },
+    )
+
+    # Crear pòlissa associada
+    self.polissa_id = self.polissa_model.create(
+        self.cursor,
+        self.uid,
+        {
+            "name": "9999",
+            "cups": "ES1234000000009999AA0",
+            "tarifa": "tarifae",
+            "soci": self.partner_id,
+        },
+    )
+```
+
+## Dades de referència (cross-module)
+
+```python
+# Referenciar dades d'altres mòduls
+def setUp(self):
+    # Carregar mòdul que conté les dades
+    self.load_xml_id("som_polissa")
+    # Obtenir referència
+    polissa_id = self.refs["som_polissa.demo_polissa"]
+```
+
+## Noupdate
+
+| Valor | Ús |
+|-------|-----|
+| `noupdate="1"` | Dades fixes, no es sobreescriuen en actualitzacions |
+| `noupdate="0"` | Dades que es poden modificar en actualitzacions |
+
+Per tests, **sempre** utilitzar `noupdate="1"`.
+
+**Font:** `som_autoreclama/tests/test_som_autoreclama_base.py`, `som_polissa_soci/tests/test_somenergia_soci.py`

--- a/docs/patterns/field-add.md
+++ b/docs/patterns/field-add.md
@@ -1,0 +1,109 @@
+# Patró: Afegir un camp
+
+## Problema
+
+Necessites afegir un camp nou a un model existent (per exemple, `giscedata.polissa`, `res.partner`).
+
+## Solució
+
+1. Crear una classe que hereti del model (vegeu [model-inherit](model-inherit.md))
+2. Definir `_columns` amb el camp nou
+
+Els tipus de camps més comuns:
+- `char` — Text curt (max 256 caràcters)
+- `text` — Text llarg
+- `integer` — Enter
+- `float` — Decimal
+- `boolean` — Sí/No
+- `date` — Data
+- `datetime` — Data i hora
+- `many2one` — Relació N:1
+- `one2many` — Relació 1:N
+- `many2many` — Relació N:N
+
+## Exemple
+
+```python
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+
+class GiscedataPolissa(osv.osv):
+    """Afegim un camp a giscedata.polissa."""
+
+    _name = "giscedata.polissa"
+    _inherit = "giscedata.polissa"
+
+    _columns = {
+        "x_new_field": fields.char(
+            u"Nou camp",
+            size=256,
+            required=True,
+            help=u"Descripció del camp",
+        ),
+    }
+
+
+GiscedataPolissa()
+```
+
+### Exemple amb many2one
+
+```python
+_columns = {
+    "x_partner_id": fields.many2one(
+        "res.partner",
+        u"Client associat",
+        required=True,
+    ),
+}
+```
+
+### Exemple amb selection
+
+```python
+_columns = {
+    "x_estat": fields.selection(
+        [
+            ("pendent", u"Pendent"),
+            ("actiu", u"Actiu"),
+            ("cancelat", u"Cancel·lat"),
+        ],
+        u"Estat",
+        required=True,
+    ),
+}
+```
+
+## Camps calculats
+
+```python
+def _get_default_value(self, cursor, uid, context=None):
+    return "valor per defecte"
+
+
+_columns = {
+    "x_default_field": fields.char(
+        u"Valor per defecte",
+        size=256,
+        readonly=True,
+        fnct=_get_default_value,
+    ),
+}
+```
+
+## Camps relacionats
+
+```python
+_columns = {
+    "x_partner_name": fields.related(
+        "partner_id",
+        "name",
+        type="char",
+        string=u"Nom del client",
+        readonly=True,
+    ),
+}
+```
+
+**Font:** `som_autoreclama/models/giscedata_polissa.py`, `som_gurb/models/som_gurb_cups.py`

--- a/docs/patterns/model-inherit.md
+++ b/docs/patterns/model-inherit.md
@@ -1,0 +1,36 @@
+# Patró: Model Inherit
+
+## Problema
+
+Necessites afegir mètodes o modificacions a un model existent (`giscedata.polissa`, `res.partner`, etc.) sense modificar el mòdul original.
+
+## Solució
+
+1. Crear un fitxer Python dins el mòdul
+2. Definir una classe que hereti del model existent
+3. Definir `_name` i `_inherit` amb el mateix nom
+
+## Exemple
+
+```python
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+
+class GiscedataPolissa(osv.osv):
+    """Afegim funcionalitat extra a giscedata.polissa."""
+
+    _name = "giscedata.polissa"
+    _inherit = "giscedata.polissa"
+
+    def my_custom_method(self, cursor, uid, ids, context=None):
+        # Fer alguna cosa
+        return True
+
+
+GiscedataPolissa()
+```
+
+**Font:** `som_autoreclama/models/giscedata_polissa.py`
+
+Tota la resta (camps, mètodes, etc.) s'afegeixen al model original.

--- a/docs/patterns/module-structure.md
+++ b/docs/patterns/module-structure.md
@@ -1,0 +1,252 @@
+# Patró: Estructura d'un Mòdul
+
+## Problema
+
+No sabem quines carpetes i fitxers ha de tenir un mòdul i quin és el propòsit de cada un.
+
+## Estructura completa
+
+```
+module_name/
+├── __init__.py              #① Import del mòdul
+├── __terp__.py              #② Meta-informació del mòdul
+├── security/                #③ permisos i grups
+│   ├── ir.model.access.csv  # Permisos d'accés
+│   └── ir.module.category.csv
+├── data/                    #④ Dades inicials (no demo)
+│   ├── module_data.xml      # Seqüències, valors per defecte
+│   └── module_config.xml    # Configuracions
+├── demo/                    #⑤ Dades de demo (per tests)
+│   └── demo_data.xml        # Dades de prova
+├── models/                  #⑥ Models Python
+│   ├── __init__.py          # Importar tots els fitxers
+│   ├── model_1.py           # Un fitxer per model (o grup de models)
+│   └── model_2.py
+├── views/                   #⑦ Vistes XML
+│   ├── model_1_view.xml     # Form, tree, search
+│   └── model_2_view.xml
+├── wizard/                   #⑧ Wizards (forms temporals)
+│   ├── __init__.py
+│   ├── wizard_1.py
+│   └── wizard_1_view.xml
+├── report/                   #⑨ Reports (Odoo reports antics)
+│   ├── __init__.py
+│   ├── report_1.py
+│   └── report_1.rml         # Plantilles RML/PDF
+├── i18n/                     #⑩ Traduccions
+│   ├── ca.po                 # Català
+│   └── es.po                 # Castellà
+└── tests/                    #⑪ Tests
+    ├── __init__.py
+    ├── test_model_1.py
+    └── test_model_2.py
+```
+
+## Detall de cada carpeta
+
+### `__init__.py` i `__terp__.py`
+
+```python
+# __init__.py
+import models
+import wizard
+import report
+```
+
+```python
+# __terp__.py
+{
+    "name": "Module Name",
+    "version": "1.0",
+    "depends": ["base"],
+    "author": "Som Energia",
+    "description": """Descripció del mòdul""",
+    "init_xml": [],
+    "update_xml": [
+        "security/ir.model.access.csv",
+        "data/module_data.xml",
+        "views/model_view.xml",
+    ],
+    "installable": True,
+}
+```
+
+### `security/` — Permisos
+
+```csv
+# ir.model.access.csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_delete
+access_model_name,access.model.name,model_model_name,base.group_user,1,1,1,1
+```
+
+### `data/` — Dades inicials
+
+Dades necessàries perquè el mòdul funcioni:
+- Seqüències (`ir.sequence`)
+- Valors per defecte
+- Configuracions de paràmetres
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Seqüència -->
+        <record id="seq_my_sequence" model="ir.sequence">
+            <field name="name">Seqüència demo</field>
+            <field name="code">my.sequence.code</field>
+            <field name="padding">5</field>
+        </record>
+    </data>
+</openerp>
+```
+
+### `demo/` — Dades de demo per tests
+
+Igual que `data/` però **només per a tests**. Utilitza `noupdate="1"`.
+
+### `models/` — Models Python
+
+```python
+# models/__init__.py
+import giscedata_polissa
+import som_my_model
+```
+
+```python
+# models/som_my_model.py
+from osv import osv, fields
+
+
+class SomMyModel(osv.osv):
+    _name = "som.my.model"
+    _inherit = "som.my.model"
+
+    _columns = {
+        "name": fields.char(u"Nom", size=256),
+    }
+
+
+SomMyModel()
+```
+
+### `views/` — Vistes XML
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Vista de formulari -->
+        <record id="view_som_my_model_form" model="ir.ui.view">
+            <field name="name">som.my.model.form</field>
+            <field name="model">som.my.model</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Model">
+                    <group colspan="4" col="4">
+                        <field name="name"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <!-- Action -->
+        <record id="action_som_my_model" model="ir.actions.act_window">
+            <field name="name">Model</field>
+            <field name="res_model">som.my.model</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <!-- Menú -->
+        <menuitem id="menu_som_my_model" parent="menu_parent" action="action_som_my_model"/>
+    </data>
+</openerp>
+```
+
+### `wizard/` — Wizards
+
+```python
+# wizard/__init__.py
+import wizard_action
+```
+
+```python
+# wizard/wizard_action.py
+from osv import osv, fields
+
+
+class WizardAction(osv.osv_memory):
+    _name = "wizard.action"
+
+    _columns = {
+        "name": fields.char(u"Nom", size=256),
+    }
+
+    def action_execute(self, cursor, uid, ids, context=None):
+        # Fer alguna cosa
+        return {"type": "ir.actions.act_window_close"}
+
+
+WizardAction()
+```
+
+### `report/` — Reports
+
+Mòduls antics de reports (abans de Odoo 10). Actualment s'utilitzen altres mètodes.
+
+### `i18n/` — Traduccions
+
+```
+i18n/
+├── ca.po    # Català
+├── es.po    # Castellà
+└── en.po    # Anglès
+```
+
+```po
+# i18n/ca.po
+msgid "Name"
+msgstr "Nom"
+```
+
+### `tests/` — Tests
+
+```python
+# tests/__init__.py
+from destral import testing
+```
+
+```python
+# tests/test_som_my_model.py
+from destral import testing
+from destral.testing import OOTestCase
+
+
+class TestSomMyModel(OOTestCase):
+    def setUp(self):
+        self.model = self.openerp.pool.get("som.my.model")
+
+    def test_create(self):
+        id = self.model.create(
+            self.cursor,
+            self.uid,
+            {"name": "Test"},
+        )
+        self.assertTrue(id)
+```
+
+## Resum: Quan crear cada carpeta
+
+| Carpeta | Necessària si... |
+|---------|------------------|
+| `models/` | Sempre que hi hagi models |
+| `views/` | Sempre que hi hagi vistes |
+| `security/` | Cal configurar accesos a models o wizards |
+| `data/` | Cal crear seqüències o configs |
+| `demo/` | Cal fer tests |
+| `wizard/` | Cal fer assitents i accions sobre models |
+| `report/` | Cal generar PDF/reports antics |
+| `i18n/` | Cal traduir |
+| `tests/` | Cal tests |
+
+**Font:** Mòduls de `openerp_som_addons`, especialment `som_autoreclama/`, `som_polissa/`

--- a/docs/patterns/test-basic.md
+++ b/docs/patterns/test-basic.md
@@ -1,0 +1,122 @@
+# Patró: Test bàsic
+
+## Problema
+
+Necessites escriure tests per validar el codi dels mòduls.
+
+## Solució
+
+1. Crear `tests/test_modul.py` dins el mòdul
+2. Importar `testing` de `destral`
+3. Definir classe de test heretant de `testing.OOTestCase`
+
+## Estructura bàsica
+
+```python
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.testing import OOTestCase
+import osv
+
+
+class TestMyFeature(OOTestCase):
+    """Tests pel mòdul."""
+
+    def setUp(self):
+        """Inicialitza els tests."""
+        self.model = self.openerp.pool.get("my.model")
+        # Carregar dades de demo
+        self.refs = self.load_xml_id("module.data_file_xml_id")
+
+    def test_my_feature(self):
+        """Test que fa alguna cosa."""
+        # Crear registre
+        id = self.model.create(
+            self.cursor,
+            self.uid,
+            {"name": "Test"},
+        )
+        # Verificar
+        record = self.model.read(
+            self.cursor,
+            self.uid,
+            id,
+            ["name"],
+        )
+        self.assertEqual(record["name"], "Test")
+```
+
+## Tipus de test case
+
+| Classe | Ús |
+|--------|-----|
+| `OOTestCase` | Test bàsic |
+| `OOTestCaseWithCursor` | Test amb cursor propi |
+
+Prioritzem tests amb OOTestCaseWithCursor
+
+```python
+class TestWithDB(OOTestCaseWithCursor):
+    def test_something(self):
+        # Cursor propi disponible
+        cursor = self.cursor
+        uid = self.uid
+```
+
+## Assertions més comunes
+
+```python
+self.assertTrue(condition)
+self.assertFalse(condition)
+self.assertEqual(actual, expected)
+self.assertNotEqual(actual, expected)
+self.assertIn(element, collection)
+self.assertIsNone(value)
+self.assertIsNotNone(value)
+```
+
+## Carregar dades
+
+### Des de XML
+
+```python
+# Carregar demo data
+self.load_xml_id("module.my_demo_data")
+# Obtenir referència
+partner_id = self.refs["res_partner_demo"]
+```
+
+### Directament
+
+```python
+def setUp(self):
+    self.partner_model = self.openerp.pool.get("res.partner")
+    self.partner_id = self.partner_model.create(
+        self.cursor,
+        self.uid,
+        {"name": "Test Partner"},
+    )
+```
+
+## Test amb SQL
+
+```python
+def test_sql(self):
+    self.cursor.execute(
+        "SELECT id FROM res_partner WHERE name = %s",
+        ("Test Partner",),
+    )
+    result = self.cursor.fetchone()
+    self.assertIsNotNone(result)
+```
+
+## Executar els tests
+
+```bash
+# Des del directori del projecte
+python -m pytest src/destral -- -m test_modul
+# O amb make
+make test module=som_modul
+```
+
+**Fonts:** `som_autoreclama/tests/test_som_autoreclama_base.py`, `som_switching/tests/tests_activaciones.py`

--- a/docs/patterns/view-extend.md
+++ b/docs/patterns/view-extend.md
@@ -1,0 +1,86 @@
+# Patró: Estendre una vista XML
+
+## Problema
+
+Necessites afegir camps nous o modificar la interfície d'un model existent.
+
+## Solució
+
+1. Crear un fitxer XML al mòdul
+2. Definir una extensió de vista (`record` amb `id` i `model`)
+
+## Tipus de vistes
+
+| Tipus | Descripció |
+|-------|-----------|
+| `form` | Vista de formulari (edició) |
+| `tree` | Vista de llista |
+| `search` | Vista de cerca |
+| `graph` | Vista de gràfics |
+| `calendar` | Vista de calendari |
+
+## Exemple: Afegir camps a un formulari
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Extensió de vista de formulari -->
+        <record id="view_giscedata_polissa_form" model="ir.ui.view">
+            <field name="name">giscedata.polissa.form</field>
+            <field name="model">giscedata.polissa</field>
+            <field name="inherit_id" ref="original_module.view_form_id"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="x_new_field" position="after">
+                    <field name="existing_field"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>
+```
+
+## Posicions
+
+| Posició | Descripció |
+|--------|-----------|
+| `replace` | Substitueix el camp |
+| `before` | Insereix abans del camp |
+| `after` | Insereix après del camp |
+| `inside` | Insereix dins (per grups) |
+
+## Exemple: Afegir grup de camps
+
+```xml
+<field name="arch" type="xml">
+    <group colspan="4" col="4">
+        <field name="x_field_1"/>
+        <field name="x_field_2"/>
+    </group>
+</field>
+```
+
+## Exemple: Ocultar camp
+
+```xml
+<field name="existing_field" position="replace"/>
+```
+
+## Exemple: Vista de cerca
+
+```xml
+<record id="view_partner_search" model="ir.ui.view">
+    <field name="name">res.partner.search</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="type">search</field>
+    <field name="arch" type="xml">
+        <field name="x_custom_field" position="after">
+            <field name="x_new_field"/>
+        </field>
+    </field>
+</record>
+```
+
+**Font:** `som_leads_polissa/views/giscedata_crm_lead_view.xml`, `som_gurb/views/som_gurb_group_view.xml`

--- a/docs/patterns/wizard.md
+++ b/docs/patterns/wizard.md
@@ -1,0 +1,111 @@
+# Patró: Crear un Wizard
+
+## Problema
+
+Necessites crear un formulari temporal per executar una acció (importar dades, executar processos, etc.).
+
+## Solució
+
+1. Crear un fitxer Python pel wizard
+2. Crear un fitxer XML per la vista
+3. Crear un fitxer XML per registrar-lo
+
+## Wizard senzill
+
+### Python
+
+```python
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+import pooler
+
+
+class WizardMyAction(osv.osv_memory):
+    """Wizard per executar una acció."""
+
+    _name = "wizard.my.action"
+
+    _columns = {
+        "name": fields.char(u"Nom", size=256, required=True),
+        "partner_id": fields.many2one("res.partner", u"Client"),
+    }
+
+    def action_execute(self, cursor, uid, ids, context=None):
+        """Executa l'acció."""
+        pool = pooler.get_pool(cursor.dbname)
+        wiz = self.browse(cursor, uid, ids[0], context=context)
+
+        # Fer alguna cosa
+        return {"type": "ir.actions.act_window_close"}
+
+
+WizardMyAction()
+```
+
+### Vista XML
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_wizard_my_action_form" model="ir.ui.view">
+            <field name="name">wizard.my.action.form</field>
+            <field name="model">wizard.my.action</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Acció">
+                    <group colspan="4" col="4">
+                        <field name="name"/>
+                        <field name="partner_id"/>
+                    </group>
+                    <group colspan="4" col="4">
+                        <button name="action_execute" string="Executar" type="object"/>
+                        <button name="oe_dialog_button_cancel" string="Cancel·lar" special="cancel" type="object"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+    </data>
+</openerp>
+```
+
+### Registre (action)
+
+```xml
+<record id="action_wizard_my_action" model="ir.actions.act_window">
+    <field name="name">Acció</field>
+    <field name="res_model">wizard.my.action</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="context">{}</field>
+</record>
+```
+
+## Wizard amb assistent (steps)
+
+```python
+class WizardMultiStep(osv.osv_memory):
+    _name = "wizard.multi.step"
+
+    def _default_step(self, cursor, uid, context=None):
+        return 1
+
+    _columns = {
+        "step": fields.integer(),
+        "name": fields.char(u"Nom", size=256),
+    }
+
+    _defaults = {
+        "step": _default_step,
+    }
+
+    def step_1(self, cursor, uid, ids, context=None):
+        return {"name": u"Pagament 2"}
+
+    def step_2(self, cursor, uid, ids, context=None):
+        # Executar acció final
+        return {"type": "ir.actions.act_window_close"}
+```
+
+**Font:** `som_autoreclama/wizard/wizard_som_autoreclama_set_correct_state.py`, `som_stash/wizard/wizard_som_stasher.py`


### PR DESCRIPTION
## Objectiu

Afegir documentació de patrons (plantilles) perquè els desenvolupadors i agents LLM sapiguen com fer tasques recurrents a OpenERP/Odoo.

## Targeta on es demana o Incidència

Per decisió interna de l'equip - necessitat de patrones documentats.

## Comportament antic

No existia documentació estructurada de com fer coses. Només un checklist a `docs/crear_nou_modul.md`.

## Comportament nou

Nou directori `docs/patterns/` amb 9 fitxers:
- `model-inherit.md`: Com heretar un model existent
- `field-add.md`: Com afegir un camp nou
- `view-extend.md`: Com estendre una vista XML
- `wizard.md`: Com crear un wizard
- `test-basic.md`: Com escriure un test
- `demo-data.md`: Com crear dades demo per tests
- `module-structure.md`: Estructura d'un mòdul

També s'ha afegit `AGENTS.md` a l'arrel del repo i actualitzat `.github/copilot-instructions.md`.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions