### PR TITLE
DOCS: Reorganize documentation structure

### DIFF
--- a/.github/docs/desenvolupament.md
+++ b/.github/docs/desenvolupament.md
@@ -1,162 +1,17 @@
 # Guia de desenvolupament per a Som Energia (OpenERP 5.0)
 
-## Execució de testos
+## Documentació principal
 
-Els testos utilitzen [`destral`](https://github.com/gisce/destral) i requereixen una instal·lació local de l'ERP i una base de dades de test pre-existent.
+Aquest fitxer recull informació d'alt nivell i decisions tècniques. Per a receptes pràctiques:
 
-```bash
-# Tots els testos d'un mòdul
-python <ruta_destral>/destral/cli.py --no-requirements -m <nom_modul>
-
-# Un test concret
-python <ruta_destral>/destral/cli.py --no-requirements -m <nom_modul> -t TestsClassName.test_method_name
-```
-
-Variables d'entorn necessàries (valors d'exemple):
-```bash
-export OORQ_ASYNC=0
-export OPENERP_ADDONS_PATH="<ruta_erp>/server/bin/addons"
-export OPENERP_DB_HOST="localhost"
-export OPENERP_DB_NAME="<nom_bbdd_test>"
-export OPENERP_DB_USER="erp"
-export OPENERP_DB_PASSWORD="<password>"
-export OPENERP_PRICE_ACCURACY=6
-export OPENERP_SECRET="<secret>"
-export OPENERP_ROOT_PATH="<ruta_erp>/server/bin/"
-export OPENERP_REDIS_URL="redis://localhost"
-export OPENERP_MONGODB_HOST="localhost"
-export OPENERP_SII_TEST_MODE=1
-export OPENERP_ENVIRONMENT=local
-export OPENERP_RUN_SCRIPTS_INTERACTIVE_RESULT=skip
-export DESTRAL_TESTING_LANGS="['es_ES']"
-export PYTHONPATH="<ruta_erp>/server/bin:<ruta_erp>/server/bin/addons:<ruta_erp>/server/sitecustomize:$PYTHONPATH"
-export PYTHONIOENCODING="UTF-8"
-export PYTHONUNBUFFERED="1"
-```
-
-La CI s'executa via GitHub Actions (`.github/workflows/reusable_workflow.yml`).
+- **Receptes**: [docs/patterns/](../docs/patterns/)
+- **Guies**: [docs/guides/](../docs/guides/)
 
 ---
 
-## Estructura d'un mòdul
+## Estil de programació
 
-```
-module_name/
-├── __terp__.py          # Manifest del mòdul (name, version, depends, update_xml...)
-├── __init__.py
-├── models/              # Definicions de models (osv.osv)
-├── views/               # Vistes XML
-├── wizard/              # Wizards (osv.osv_memory)
-├── workflow/            # Definicions de workflow XML
-├── data/                # Dades estàtiques carregades en instal·lació
-├── demo/                # Dades de demo
-├── security/            # Control d'accés: ir.model.access.csv
-├── migrations/          # Scripts de migració (oopgrade)
-├── tests/               # Fitxers de test
-│   ├── fixtures/        # Dades XML per als testos
-│   └── tests_*.py
-├── i18n/                # Traduccions
-├── report/              # Informes
-└── requirements.txt     # Dependències Python del mòdul
-```
-
----
-
-## Patrons d'arquitectura
-
-### Definició de models
-
-```python
-from osv import osv, fields
-from tools.translate import _
-
-class MyModel(osv.osv):
-    _name = "my.model.name"
-    _columns = {
-        "name": fields.char("Name", size=64),
-        "related_id": fields.many2one("other.model", "Related"),
-    }
-MyModel()
-```
-
-Tots els mètodes reben `(cursor, uid, ids, ...)` com a primers arguments. Per accedir a altres models: `self.pool.get("model.name")`.
-
-### Extensió de models GISCE/PowerERP
-
-```python
-class GiscedataPolissa(osv.osv):
-    _name = "giscedata.polissa"
-    _inherit = "giscedata.polissa"
-    # Afegir columnes o sobreescriure mètodes
-GiscedataPolissa()
-```
-
-### Jobs asíncrons
-
-```python
-from oorq.decorators import job
-
-@job
-def my_async_method(self, cursor, uid, ids, context=None):
-    ...
-```
-
-### Excepcions
-
-```python
-raise osv.except_osv(_('Error !'), _('Missatge descriptiu'))
-```
-
-### Migracions
-
-```python
-from oopgrade.oopgrade import load_data
-
-def up(cursor, installed_version):
-    if not installed_version:
-        return
-    pool = pooler.get_pool(cursor.dbname)
-    # SQL o model auto_init
-```
-
-### Patró de testos
-
-```python
-from destral import testing
-from destral.transaction import Transaction
-
-class TestsMyModule(testing.OOTestCaseWithCursor):
-    def setUp(self):
-        super(TestsMyModule, self).setUp()
-        self.imd_obj = self.openerp.pool.get("ir.model.data")
-```
-
-Referència a fixtures via `ir.model.data`:
-```python
-record_id = self.imd_obj.get_object_reference(self.cursor, self.uid, "module_name", "xml_id")[1]
-```
-
----
-
-## Afegir un nou mòdul
-
-1. Copiar la plantilla de `Som-Energia/erp_docs` (`som_template`).
-2. Afegir un workflow a `.github/workflows/schedule_tests_<modul>.yml` (copiar un existent i canviar `name` i `module`).
-3. Afegir el mòdul a `.github/labeler.yml`.
-4. Afegir el mòdul a la taula del `README.md`.
-
----
-
-## Dependències externes clau
-
-L'entorn ERP depèn de diversos repositoris clonats al mateix nivell que aquest repo (`../`):
-
-- `Som-Energia/erp` (PowerERP/OpenERP core, privat)
-- `Som-Energia/libFacturacioATR`
-- `Som-Energia/omie-modules` + `Som-Energia/OMIE`
-- `Som-Energia/somenergia-generationkwh`
-- `gisce/oorq` (cua de jobs asíncrons)
-- `poweremail`, `openerp-sentry`, `ws_transactions`, `ir_attachment_mongodb`, `mongodb_backend`
+Seguir `.github/docs/estil.md` i `.github/docs/evitar.md`.
 
 ---
 
@@ -203,8 +58,40 @@ Exemples:
 
 ---
 
-## Desplegament
+## SDD (Spec-Driven Development)
 
-- **Producció (erp01)**: `git pull` a la branca `main`.
-- **Testing (terp01)**: Treballa amb una branca Rolling; fusionar PRs amb `git merge origin/BRANCH_NAME`.
-- **Servidors ad-hoc**: `sastre deploy --host ... --pr <PR_NUM> --owner Som-Energia --repository openerp_som_addons --environ test`.
+El projecte utilitza SDD per gestionar canvis:
+
+| Fase | Descripció |
+|------|------------|
+| `sdd-explore` | Investigar i entendre |
+| `sdd-propose` | Crear proposta |
+| `sdd-spec` | Escriure especificacions |
+| `sdd-design` | Disseny tècnic |
+| `sdd-tasks` | Dividir en tasques |
+| `sdd-apply` | Implementar |
+| `sdd-verify` | Verificar contra specs |
+| `sdd-archive` | Archivar canvi |
+
+---
+
+## Dependències externes clau
+
+L'entorn ERP depén de diversos repositoris clonats al mateix nivell que aquest repo (`../`):
+
+- `Som-Energia/erp` (PowerERP/OpenERP core, privat)
+- `Som-Energia/libFacturacioATR`
+- `Som-Energia/omie-modules` + `Som-Energia/OMIE`
+- `Som-Energia/somenergia-generationkwh`
+- `gisce/oorq` (cua de jobs asíncrons)
+- `poweremail`, `openerp-sentry`, `ws_transactions`, `ir_attachment_mongodb`, `mongodb_backend`
+
+---
+
+## Decisions arquitectòniques
+
+Per entendre per què fem servir certes eines i patrons, consulta:
+
+- [.github/docs/arquitectura.md](arquitectura.md) — Decisions d'arquitectura
+- [.github/docs/estil.md](estil.md) — Estil de codi
+- [.github/docs/evitar.md](evitar.md) — Patrons a evitar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,19 +22,13 @@ openerp_som_addons/
     └── copilot-instructions.md
 ```
 
-## Patrons i plantilles
+## Documentació del projecte
 
-Quan treballis amb OpenERP en aquest repositori, consulta les plantilles a `docs/patterns/`:
-
-| Patró | Descripció |
-|------|-----------|
-| [model-inherit](docs/patterns/model-inherit.md) | Com heretar un model existent |
-| [field-add](docs/patterns/field-add.md) | Com afegir un camp nou |
-| [view-extend](docs/patterns/view-extend.md) | Com estendre una vista XML |
-| [wizard](docs/patterns/wizard.md) | Com crear un wizard |
-| [test-basic](docs/patterns/test-basic.md) | Com escriure un test |
-| [demo-data](docs/patterns/demo-data.md) | Com crear dades demo per tests |
-| [module-structure](docs/patterns/module-structure.md) | Estructura d'un mòdul (carpetes i propòsit) |
+| Carpeta | Contingut |
+|---------|-----------|
+| `docs/patterns/` | Receptes: com fer tasques concretes |
+| `docs/guides/` | Guies: conceptes i configuració |
+| `.github/docs/` | Decisions d'arquitectura i estil |
 
 ## Skills Disponibles
 
@@ -105,11 +99,10 @@ Abans de crear PR, verificar:
 - [ ] Linting passen (`flake8 .`)
 - [ ] S'ha seguit l'estil de codi
 
-## Fitxers de Referència
+## Documentació
 
-- `.github/docs/estil.md` - Estil de codi
-- `.github/docs/evitar.md` - Evitar certs patrons
-- `.github/docs/arquitectura.md` - Arquitectura
-- `.github/docs/desenvolupament.md` - Desenvolupament
-- `pull_request_template.md` - Plantilla de PR
-- `docs/patterns/` - Plantilles de patrons
+| Carpeta | Contingut |
+|---------|-----------|
+| `docs/patterns/` | Receptes: com fer tasques concretes |
+| `docs/guides/` | Guies: conceptes i configuració |
+| `.github/docs/` | Decisions d'arquitectura i estil |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentació — openerp_som_addons
+
+Aquest directori conté la documentació del projecte.
+
+## Estructura
+
+```
+docs/
+├── patterns/          # Receptes: com fer tasques concretes
+├── guides/            # Guies: conceptes i arquitectura
+├── adr/               # Architecture Decision Records
+├── crear_nou_modul.md # Com crear un mòdul nou
+└── external_repos.md # Repositoris externs
+```
+
+## Quick reference
+
+| Necessites... | Consulta... |
+|---------------|------------|
+| Com afegir un camp a un model | [patterns/field-add.md](patterns/field-add.md) |
+| Com crear un wizard | [patterns/wizard.md](patterns/wizard.md) |
+| Com escriure tests | [patterns/test-basic.md](patterns/test-basic.md) |
+| Com configurar l'entorn | [guides/getting-started.md](guides/getting-started.md) |
+| Per què fem servir `_columns` | [.github/docs/arquitectura.md](../.github/docs/arquitectura.md) |

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,0 +1,16 @@
+# Guides de desenvolupament
+
+Guies conceptuals per entendre l'arquitectura i les decisions tècniques del projecte.
+
+## Guies disponibles
+
+| Guia | Descripció |
+|------|-----------|
+| [getting-started](getting-started.md) | Com configurar l'entorn i executar tests |
+| [testing](testing.md) | Com escriure i executar tests |
+
+## Conceptes clau
+
+Per a receptes pràctiques (com fer coses), consulta [docs/patterns/](../patterns/)
+
+Per a decisions d'arquitectura, consulta [.github/docs/arquitectura.md](../../.github/docs/arquitectura.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,72 @@
+# Getting Started
+
+## Configuració de l'entorn
+
+### Requisits
+
+- Python 2.7 (compatible amb Python 3)
+- Docker (PostgreSQL, MongoDB, Redis)
+- OpenERP instal·lat a `/home/oriol/somenergia/src/erp/server/bin`
+
+### Variables d'entorn
+
+```bash
+export OORQ_ASYNC=0
+export OPENERP_ADDONS_PATH="<ruta_erp>/server/bin/addons"
+export OPENERP_DB_HOST="localhost"
+export OPENERP_DB_NAME="<nom_bbdd_test>"
+export OPENERP_DB_USER="erp"
+export OPENERP_DB_PASSWORD="<password>"
+export OPENERP_PRICE_ACCURACY=6
+export OPENERP_SECRET="<secret>"
+export OPENERP_ROOT_PATH="<ruta_erp>/server/bin/"
+export OPENERP_REDIS_URL="redis://localhost"
+export OPENERP_MONGODB_HOST="localhost"
+export OPENERP_SII_TEST_MODE=1
+export OPENERP_ENVIRONMENT=local
+export OPENERP_RUN_SCRIPTS_INTERACTIVE_RESULT=skip
+export DESTRAL_TESTING_LANGS="['es_ES']"
+export PYTHONPATH="<ruta_erp>/server/bin:<ruta_erp>/server/bin/addons:<ruta_erp>/server/sitecustomize:$PYTHONPATH"
+export PYTHONIOENCODING="UTF-8"
+export PYTHONUNBUFFERED="1"
+```
+
+## Executar tests
+
+```bash
+# Tots els testos d'un mòdul
+python <ruta_destral>/destral/cli.py --no-requirements -m <nom_modul>
+
+# Un test concret
+python <ruta_destral>/destral/cli.py --no-requirements -m <nom_modul> -t TestsClassName.test_method_name
+```
+
+## Afegir un nou mòdul
+
+1. Copiar la plantilla de `Som-Energia/erp_docs` (`som_template`)
+2. Afegir un workflow a `.github/workflows/schedule_tests_<modul>.yml`
+3. Afegir el mòdul a `.github/labeler.yml`
+4. Afegir el mòdul a la taula del `README.md`
+
+## Dependències externes
+
+L'entorn ERP depén de diversos repositoris clonats al mateix nivell que aquest repo (`../`):
+
+- `Som-Energia/erp` (PowerERP/OpenERP core, privat)
+- `Som-Energia/libFacturacioATR`
+- `Som-Energia/omie-modules` + `Som-Energia/OMIE`
+- `Som-Energia/somenergia-generationkwh`
+- `gisce/oorq` (cua de jobs asíncrons)
+- `poweremail`, `openerp-sentry`, `ws_transactions`, `ir_attachment_mongodb`, `mongodb_backend`
+
+## Desplegament
+
+- **Producció (erp01)**: `git pull` a la branca `main`
+- **Testing (terp01)**: Treballa amb una branca Rolling; fusionar PRs amb `git merge origin/BRANCH_NAME`
+- **Servidors ad-hoc**: `sastre deploy --host ... --pr <PR_NUM> --owner Som-Energia --repository openerp_som_addons --environ test`
+
+## Per saber-ne més
+
+- **Receptes pràctiques**: [docs/patterns/](../patterns/)
+- **Arquitectura**: [.github/docs/arquitectura.md](../../.github/docs/arquitectura.md)
+- **Convencions de commit**: [.github/docs/desenvolupament.md](../../.github/docs/desenvolupament.md)

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,57 @@
+# Testing
+
+## Framework
+
+Els tests utilitzen [`destral`](https://github.com/gisce/destral), un framework de tests per a OpenERP.
+
+## Estructura bàsica
+
+```python
+from destral import testing
+from destral.testing import OOTestCase
+
+
+class TestMyModule(OOTestCase):
+    def setUp(self):
+        self.model = self.openerp.pool.get("my.model")
+        self.load_xml_id("my_module")
+
+    def test_create(self):
+        id = self.model.create(
+            self.cursor,
+            self.uid,
+            {"name": "Test"},
+        )
+        self.assertTrue(id)
+```
+
+## Tipus de test case
+
+| Classe | Ús |
+|--------|-----|
+| `OOTestCase` | Test bàsic |
+| `OOTestCaseWithCursor` | Test amb cursor propi |
+
+## Dades de test
+
+### Demo data
+
+Consulta [docs/patterns/demo-data.md](../patterns/demo-data.md) per crear dades demo.
+
+### Crear dades directament
+
+```python
+def setUp(self):
+    self.partner_model = self.openerp.pool.get("res.partner")
+    self.partner_id = self.partner_model.create(
+        self.cursor,
+        self.uid,
+        {"name": "Test Partner"},
+    )
+```
+
+## Per saber-ne més
+
+- **Receptes de tests**: [docs/patterns/test-basic.md](../patterns/test-basic.md)
+- **Demo data**: [docs/patterns/demo-data.md](../patterns/demo-data.md)
+- **Patrons OpenERP**: [docs/patterns/](../patterns/)


### PR DESCRIPTION
## Objectiu

Reorganitzar la documentació per separar:
- **Receptes** (com fer): `docs/patterns/`
- **Guies** (conceptes): `docs/guides/`
- **Arquitectura** (per què): `.github/docs/`

## Canvis

### Nou: `docs/guides/`
- `getting-started.md` — Configuració de l'entorn i desplegament
- `testing.md` — Guia de testing

### Nou: `docs/README.md`
- Índex de tota la documentació amb referències creuades

### Actualitzat: `desenvolupament.md`
- Eliminat contingut duplicat (estructura, tests, patterns)
- Ara només conté: convencions de commit, SDD, dependències

### Actualitzat: `AGENTS.md`
- Actualitzades referències per usar la nova estructura

## Estructura resultant

```
docs/
├── README.md              # Índex
├── patterns/               # Receptes (com fer X)
│   ├── model-inherit.md
│   ├── field-add.md
│   └── ...
├── guides/                # Guies (conceptes)
│   ├── getting-started.md
│   └── testing.md
└── adr/                   # Architecture Decision Records

.github/docs/              # Decisions tècniques (per què)
├── arquitectura.md
├── estil.md
├── evitar.md
└── desenvolupament.md
```

## Comprovacions

- [ ] Revisar la nova estructura té sentit
- [ ] Les referències creuades funcionen