### PR TITLE
FIX: handle boolean lang_partner in electricity info report

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -2422,6 +2422,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             self.cursor, self.uid, "gdo_and_impact_yearly_switch_date", "2099-05-01"
         )
 
+        lang_partner = fact.lang_partner if isinstance(fact.lang_partner, basestring) else 'es_ES'
         data = {
             "is_visible": fact.date_invoice < swich_date,
             "year_graph": 2020,
@@ -2429,7 +2430,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "inport_export_value": 1.3,
             "mix_image_som_energia": "electricity_information_mix_som.png",
             "mix_image_rest": "electricity_information_mix_rest_"
-            + fact.lang_partner.lower()
+            + lang_partner.lower()
             + "_2021.png",
             "renovable": {
                 "som_energia": "100%",


### PR DESCRIPTION
## Objectiu

Corregir l'error `AttributeError: 'bool' object has no attribute 'lower'` que es produeix quan `lang_partner` és un boolean enlloc d'un string.

## Targeta on es demana o Incidència

Error detectat a producció (erp01).
https://sentry.somenergia.coop/organizations/som-energia/issues/211615/?project=11&query=is%3Aunresolved%20%27bool%27%20object%20has%20no%20attribute%20%27lower%27&referrer=issue-stream

## Comportament antic

En generar el PDF de la factura, si el partner no tenía idioma definit, `lang_partner` retornava un boolean (`False` o `True`) i el codi fallava en cridar `.lower()`.

## Comportament nou

S'afegeix un check defensiu abans de cridar `.lower()`:
```python
lang_partner = fact.lang_partner if isinstance(fact.lang_partner, basestring) else 'es_ES'
```

Si `lang_partner` no és un string, defaulta a `'es_ES'`.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions