### PR TITLE
Millores backend canvi de preus

### DIFF
--- a/som_polissa_condicions_generals/__terp__.py
+++ b/som_polissa_condicions_generals/__terp__.py
@@ -19,6 +19,7 @@
         "giscedata_facturacio_iese",
         "som_indexada",
         "som_extend_facturacio_comer",
+        "l10n_es_igic",
     ],
     "init_xml": [],
     "demo_xml": ["demo/res_partner_demo.xml"],

--- a/som_polissa_condicions_generals/data/giscedata_polissa_condicions_generals_data.xml
+++ b/som_polissa_condicions_generals/data/giscedata_polissa_condicions_generals_data.xml
@@ -48,5 +48,24 @@
             <field name="enforce_from_account" model="poweremail.core_accounts" search="[('email_id','=', 'info@somenergia.coop')]"/>
             <field name="def_body_text"></field>
         </record>
+
+        <!-- Default IVA and IE config variables -->
+        <record model="res.config" id="default_iva_21_tax_id">
+            <field name="name">default_iva_21_tax_id</field>
+            <field name="value"></field>
+            <field name="description">Defineix el ID del IVA 21% per mostrar el text a CCPP i mails</field>
+        </record>
+        <record model="res.config" id="default_iese_tax_id">
+            <field name="name">default_iese_tax_id</field>
+            <field name="value"></field>
+            <field name="description">Defineix el ID del Impost Elèctric (IESE) per mostrar el text a CCPP i mails</field>
+        </record>
+
+        <!-- Serveis d'ajust estimated kwh price -->
+        <record model="res.config" id="serveis_ajust_estimated_kwh_price">
+            <field name="name">serveis_ajust_estimated_kwh_price</field>
+            <field name="value">0.028</field>
+            <field name="description">Preu kWh estimat per al servei d'ajust</field>
+        </record>
     </data>
 </openerp>

--- a/som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0001_imp_backend_canvipreus_fixmes_migrate_fields_data.py
+++ b/som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0001_imp_backend_canvipreus_fixmes_migrate_fields_data.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'data/giscedata_polissa_condicions_generals_data.xml',
+    ]
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_polissa_condicions_generals', data_file,
+            idref=None, mode='update'
+        )
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa_condicions_generals/models/__init__.py
+++ b/som_polissa_condicions_generals/models/__init__.py
@@ -3,3 +3,4 @@ from __future__ import absolute_import
 from . import report_backend_ccpp
 from . import report_backend_ccpp_m1
 from . import report_backend_ccpp_ignore_modcon
+from . import giscedata_polissa

--- a/som_polissa_condicions_generals/models/giscedata_polissa.py
+++ b/som_polissa_condicions_generals/models/giscedata_polissa.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from osv import osv
+
+
+class GiscedataPolissa(osv.osv):
+    _name = "giscedata.polissa"
+    _inherit = "giscedata.polissa"
+
+    def get_simplified_taxes(self, cursor, uid, polissa_id, context=False):
+        if context is None:
+            context = {}
+
+        polissa = self.browse(cursor, uid, polissa_id, context=context)
+
+        fp_obj = self.pool.get('account.fiscal.position')
+        atax_obj = self.pool.get('account.tax')
+        conf_obj = self.pool.get('res.config')
+
+        fiscal_position = polissa.fiscal_position_id
+        if not fiscal_position:
+            fiscal_position = polissa.titular.property_account_position
+
+        iva_tax_id = int(conf_obj.get(cursor, uid, 'default_iva_21_tax_id'))
+        iese_tax_id = int(conf_obj.get(cursor, uid, 'default_iese_tax_id'))
+
+        iva_tax = atax_obj.browse(cursor, uid, iva_tax_id, context=context)
+        iese_tax = atax_obj.browse(cursor, uid, iese_tax_id, context=context)
+
+        mapped_tax_ids = fp_obj.map_tax(
+            cursor, uid, fiscal_position, [iva_tax, iese_tax], context=context)
+        tax_data = atax_obj.read(
+            cursor, uid, mapped_tax_ids, ['name', 'amount'], context=context)
+
+        simplified_taxes = {}
+        for tax in tax_data:
+            if 'IVA' in tax['name']:
+                simplified_taxes['IVA'] = 0.1 if context.get('iva10') else tax['amount']
+            elif 'IGIC' in tax['name']:
+                simplified_taxes['IGIC'] = tax['amount']
+            else:
+                simplified_taxes['IE'] = tax['amount']
+
+        return simplified_taxes
+
+
+GiscedataPolissa()

--- a/som_polissa_condicions_generals/models/giscedata_polissa.py
+++ b/som_polissa_condicions_generals/models/giscedata_polissa.py
@@ -7,9 +7,8 @@ class GiscedataPolissa(osv.osv):
     _name = "giscedata.polissa"
     _inherit = "giscedata.polissa"
 
-    def get_simplified_taxes(self, cursor, uid, polissa_id, context=False):
-        if context is None:
-            context = {}
+    def get_simplified_taxes(self, cursor, uid, polissa_id, context=None):
+        context = context or {}
 
         polissa = self.browse(cursor, uid, polissa_id, context=context)
 

--- a/som_polissa_condicions_generals/models/giscedata_polissa.py
+++ b/som_polissa_condicions_generals/models/giscedata_polissa.py
@@ -10,7 +10,11 @@ class GiscedataPolissa(osv.osv):
     def get_simplified_taxes(self, cursor, uid, polissa_id, context=None):
         context = context or {}
 
-        polissa = self.browse(cursor, uid, polissa_id, context=context)
+        state = self.read(cursor, uid, polissa_id, ["state"], context={})["state"]
+        if state == "esborrany":
+            polissa = self.browse(cursor, uid, polissa_id, context={})
+        else:
+            polissa = self.browse(cursor, uid, polissa_id, context=context)
 
         fp_obj = self.pool.get('account.fiscal.position')
         atax_obj = self.pool.get('account.tax')

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -412,10 +412,12 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                     ctx.update({'force_fiscal_position': fp_id, 'iva10': True})
             simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=ctx)
             iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
-            text_impostos = " ({} {:.0f}%, IE {:.2f}%)".format(
+            ie_percent_str = "{:.2f}".format(
+                simple_taxes['IE'] * 100).rstrip('0').rstrip('.').replace('.', ',')
+            text_impostos = " ({} {:.0f}%, IE {}%)".format(
                 iva_str,
                 simple_taxes[iva_str] * 100,
-                simple_taxes['IE'] * 100,
+                ie_percent_str
             )
 
             pricelist['text_impostos'] = text_impostos

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -410,7 +410,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                     fp_id = imd_obj.get_object_reference(
                         cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
                     ctx.update({'force_fiscal_position': fp_id, 'iva10': True})
-                simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=context)
+                simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=ctx)
                 iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
                 text_impostos = " ({} {:.0f}%, IE {:.2f}%)".format(
                     iva_str,

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -164,6 +164,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         # res['fiscal_position'] = pol.fiscal_position
         res['potencia_max'] = pol.potencia
         res['mode_facturacio'] = pol.mode_facturacio
+        res['mode_facturacio_calculat'] = pol.mode_facturacio
 
         res['te_assignacio_gkwh'] = pol.te_assignacio_gkwh
         res['bank'] = pol.bank or False
@@ -201,6 +202,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         has_some_modcon = res['modcon_pendent_indexada'] or res['modcon_pendent_periodes']
         if use_modcon_pricelist and has_some_modcon:
             res['pricelist'] = pol.modcontractuals_ids[0].llista_preu
+            res['mode_facturacio_calculat'] = pol.modcontractuals_ids[0].mode_facturacio
         elif pol.llista_preu:
             res['pricelist'] = pol.llista_preu
         else:
@@ -341,7 +343,6 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         modcon_pendent_indexada = False
         modcon_pendent_periodes = False
         use_modcon_pricelist = not context.get('ignore_modcon_pricelist', False)
-        res['use_modcon_pricelist'] = use_modcon_pricelist
         if use_modcon_pricelist and pol.state != 'esborrany':
             ultima_modcon = pol.modcontractuals_ids[0]
             modcon_pendent_indexada = ultima_modcon.state == 'pendent' and \
@@ -408,10 +409,14 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                 if iva_10_active and pol.potencia < 10 and today_str >= start_date_iva_10 and today_str <= end_date_iva_10:  # noqa: E501
                     fp_id = imd_obj.get_object_reference(
                         cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
-                    text_impostos = " (IVA 10%, IE 0,5%)"
-                    ctx.update({'force_fiscal_position': fp_id})
-                else:
-                    text_impostos = " (IVA 21%, IE 0,5%)"
+                    ctx.update({'force_fiscal_position': fp_id, 'iva10': True})
+                simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=context)
+                iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
+                text_impostos = " ({} {:.0f}%, IE {:.2f}%)".format(
+                    iva_str,
+                    simple_taxes[iva_str] * 100,
+                    simple_taxes['IE'] * 100,
+                )
 
             pricelist['text_impostos'] = text_impostos
 

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -410,13 +410,13 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                     fp_id = imd_obj.get_object_reference(
                         cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
                     ctx.update({'force_fiscal_position': fp_id, 'iva10': True})
-                simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=ctx)
-                iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
-                text_impostos = " ({} {:.0f}%, IE {:.2f}%)".format(
-                    iva_str,
-                    simple_taxes[iva_str] * 100,
-                    simple_taxes['IE'] * 100,
-                )
+            simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=ctx)
+            iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
+            text_impostos = " ({} {:.0f}%, IE {:.2f}%)".format(
+                iva_str,
+                simple_taxes[iva_str] * 100,
+                simple_taxes['IE'] * 100,
+            )
 
             pricelist['text_impostos'] = text_impostos
 

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -167,6 +167,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         # res['fiscal_position'] = pol.fiscal_position
         res['potencia_max'] = pol.potencia
         res['mode_facturacio'] = pol.mode_facturacio
+        res['mode_facturacio_calculat'] = pol.mode_facturacio
 
         res['te_assignacio_gkwh'] = pol.te_assignacio_gkwh
 
@@ -201,6 +202,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         has_some_modcon = res['modcon_pendent_indexada'] or res['modcon_pendent_periodes']
         if use_modcon_pricelist and has_some_modcon:
             res['pricelist'] = pol.modcontractuals_ids[0].llista_preu
+            res['mode_facturacio_calculat'] = pol.modcontractuals_ids[0].mode_facturacio
         elif pol.llista_preu:
             res['pricelist'] = pol.llista_preu
         else:
@@ -341,7 +343,6 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         modcon_pendent_indexada = False
         modcon_pendent_periodes = False
         use_modcon_pricelist = not context.get('ignore_modcon_pricelist', False)
-        res['use_modcon_pricelist'] = use_modcon_pricelist
         if use_modcon_pricelist and pol.state != 'esborrany':
             ultima_modcon = pol.modcontractuals_ids[0]
             modcon_pendent_indexada = ultima_modcon.state == 'pendent' and \
@@ -408,10 +409,14 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                 if iva_10_active and pol.potencia <= 10 and today_str >= start_date_iva_10 and today_str <= end_date_iva_10:  # noqa: E501
                     fp_id = imd_obj.get_object_reference(
                         cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
-                    text_impostos = " (IVA 10%, IE 0,5%)"
-                    ctx.update({'force_fiscal_position': fp_id})
-                else:
-                    text_impostos = " (IVA 21%, IE 0,5%)"
+                    ctx.update({'force_fiscal_position': fp_id, 'iva10': True})
+                simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=context)
+                iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
+                text_impostos = " ({} {:.0f}%, IE {:.2f}%)".format(
+                    iva_str,
+                    simple_taxes[iva_str] * 100,
+                    simple_taxes['IE'] * 100,
+                )
 
             pricelist['text_impostos'] = text_impostos
 

--- a/som_polissa_condicions_generals/report/components/disclaimers.mako
+++ b/som_polissa_condicions_generals/report/components/disclaimers.mako
@@ -2,7 +2,7 @@
     <div class="modi_condicions">
         <p>
             ${_(u"Al contractar s'accepten aquestes ")}
-            %if not prices['auvi'] and ((polissa['mode_facturacio'] == 'index' and not polissa['modcon_pendent_periodes']) or polissa['modcon_pendent_indexada']):
+            %if not prices['auvi'] and polissa['mode_facturacio_calculat'] == 'index':
                 ${_(u"Condicions Particulars, Específiques i les Condicions Generals,")}
             %elif prices['auvi']:
                 ${_(u"Condicions Particulars, Específiques de l'Autoconsum Virtual, Específiques de la tarifa Indexada i les Condicions Generals,")}

--- a/som_polissa_condicions_generals/report/components/prices_info.mako
+++ b/som_polissa_condicions_generals/report/components/prices_info.mako
@@ -233,7 +233,7 @@
                 %if polissa['auto'] != '00':
                 <tr>
                     <td class="bold">${_(u"Excedents d'autoconsum (€/kWh)")}</td>
-                    %if (polissa['mode_facturacio'] == 'index' and not polissa['modcon_pendent_periodes']) or polissa['modcon_pendent_indexada']:
+                    %if polissa['mode_facturacio_calculat'] == 'index':
                         <td class="center" colspan="6">
                             <span class="normal_font_weight">${_(u"Tarifa indexada(2) - el preu horari de la compensació d'excedents és igual al PHM")}</span>
                         </td>
@@ -274,7 +274,7 @@
             %if polissa['te_assignacio_gkwh']:
                 <span class="bold">(1) </span> ${_(u"Terme d'energia en cas de participar-hi, segons condicions del contracte GenerationkWh.")}<br/>
             %endif
-            %if (polissa['mode_facturacio'] == 'index' and not polissa['modcon_pendent_periodes']) or polissa['modcon_pendent_indexada'] or prices['auvi']:
+            %if polissa['mode_facturacio_calculat'] == 'index':
                 <span class="bold">(2) </span> ${_(u"Pots consultar el significat de les variables a les condicions específiques que trobaràs a continuació.")}
             %endif
             </div>
@@ -374,7 +374,7 @@
                     %if polissa['auto'] != '00':
                     <tr>
                         <td><span class="bold">${_(u"Excedents d'autoconsum (€/kWh)")}</span></td>
-                        %if (polissa['mode_facturacio'] == 'index' and not polissa['modcon_pendent_periodes']) or polissa['modcon_pendent_indexada']:
+                        %if polissa['mode_facturacio_calculat'] == 'index':
                             <td class="center reset_line_height" colspan="6">
                                 <span class="normal_font_weight">${_(u"Tarifa indexada(2) - el preu horari de la compensació d'excedents és igual al PHM")}</span>
                             </td>
@@ -396,7 +396,7 @@
                 %if polissa['te_assignacio_gkwh']:
                     <span class="bold">(1) </span> ${_(u"Terme d'energia en cas de participar-hi, segons condicions del contracte GenerationkWh.")}<br/>
                 %endif
-                %if (polissa['mode_facturacio'] == 'index' and not polissa['modcon_pendent_periodes']) or polissa['modcon_pendent_indexada']:
+                %if polissa['mode_facturacio_calculat'] == 'index':
                     <span class="bold">(2) </span> ${_(u"Pots consultar el significat de les variables a les condicions específiques que trobaràs a continuació.")}
                 %endif
                 </div>
@@ -411,29 +411,16 @@
     </div>
     <div class="styled_box padding_bottom">
         <div class="center avis_impostos">
-            % if prices['use_modcon_pricelist']:  # FIXME: Simplify this logic D:
-                %if (polissa['mode_facturacio'] == 'index' and not polissa['modcon_pendent_periodes']) or polissa['modcon_pendent_indexada']:
-                    ${_(u"Els preus del terme de potència")}
-                %else:
-                    ${_(u"Tots els preus que apareixen en aquest contracte")}
-                %endif
-                ${_(u"inclouen l'impost elèctric i l'IVA (IGIC a Canàries), amb el tipus impositiu vigent actualment per a cada tipus de contracte sense perjudici de les exempcions o bonificacions que puguin ser d'aplicació.")}
-                %if polissa['te_assignacio_gkwh'] or ((polissa['mode_facturacio'] == 'atr' and not polissa['modcon_pendent_indexada']) or polissa['modcon_pendent_periodes']):
-                    <br/>
-                    ${_(u"Els costos dels Serveis d'Ajust tenen un preu horari variable, fixat per Red Eléctrica Española (REE), no inclosos en el terme d'energia.")}
-                %endif
-            % else:
-                %if polissa['mode_facturacio'] == 'index':
-                    ${_(u"Els preus del terme de potència")}
-                %else:
-                    ${_(u"Tots els preus que apareixen en aquest contracte")}
-                %endif
-                ${_(u"inclouen l'impost elèctric i l'IVA (IGIC a Canàries), amb el tipus impositiu vigent actualment per a cada tipus de contracte sense perjudici de les exempcions o bonificacions que puguin ser d'aplicació.")}
-                %if polissa['te_assignacio_gkwh'] or polissa['mode_facturacio'] == 'atr':
-                    <br/>
-                    ${_(u"Els costos dels Serveis d'Ajust tenen un preu horari variable, fixat per Red Eléctrica Española (REE), no inclosos en el terme d'energia.")}
-                %endif
-            % endif
+            %if polissa['mode_facturacio_calculat'] == 'index':
+                ${_(u"Els preus del terme de potència")}
+            %else:
+                ${_(u"Tots els preus que apareixen en aquest contracte")}
+            %endif
+            ${_(u"inclouen l'impost elèctric i l'IVA (IGIC a Canàries), amb el tipus impositiu vigent actualment per a cada tipus de contracte sense perjudici de les exempcions o bonificacions que puguin ser d'aplicació.")}
+            %if polissa['te_assignacio_gkwh'] or polissa['mode_facturacio_calculat'] == 'atr':
+                <br/>
+                ${_(u"Els costos dels Serveis d'Ajust tenen un preu horari variable, fixat per Red Eléctrica Española (REE), no inclosos en el terme d'energia.")}
+            %endif
         </div>
     </div>
 </%def>

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -105,14 +105,18 @@ class ReportBackendMailcanvipreus(ReportBackend):
     @report_browsify
     def get_data(self, cursor, uid, env, context=None):
         imd_obj = self.pool.get('ir.model.data')
+        pol_o = self.pool.get("giscedata.polissa")
         if context is None:
             context = {}
 
         context['iva10'] = env.polissa_id.potencia < 10
 
-        impostos_str, impostos_value = self.getImpostos(env.polissa_id.fiscal_position_id, context)
+        self.simplified_taxes = pol_o.get_simplified_taxes(
+            cursor, uid, env.polissa_id.id, context=context)
 
-        if impostos_str == 'IVA del 10%':
+        impostos_str = self.get_iva_text()
+
+        if 'IVA' in self.simplified_taxes and self.simplified_taxes['IVA'] < 0.21:
             fp_id = imd_obj.get_object_reference(
                 cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
             context.update({'force_fiscal_position': fp_id})
@@ -312,9 +316,9 @@ class ReportBackendMailcanvipreus(ReportBackend):
             != pol.modcontractuals_ids[0].mode_facturacio
                 and pol.modcontractuals_ids[0].mode_facturacio == 'index'):
             context["force_pricelist"] = pol.modcontractuals_ids[1].llista_preu.id
-        elif(pol.modcontractuals_ids[0].state == "pendent"
-             and pol.mode_facturacio
-             != pol.modcontractuals_ids[0].mode_facturacio
+        elif (pol.modcontractuals_ids[0].state == "pendent"
+              and pol.mode_facturacio
+              != pol.modcontractuals_ids[0].mode_facturacio
                 and pol.modcontractuals_ids[0].mode_facturacio == 'atr'):
             context["force_pricelist"] = pol.modcontractuals_ids[0].llista_preu.id
         for terme, values in periods.items():
@@ -341,7 +345,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
     ):
         bo_social_price = self.get_bo_social_price(
             cursor, uid, polissa_id.llista_preu, context=context)
-        preu_estimat_servei_ajust = 0.028  # FIXME: Això segurament haurà d'anar a un altre lloc
+        preu_estimat_servei_ajust = float(self.imd_obj.get_object_reference(
+            cursor, uid, 'som_polissa_condicions_generals', 'serveis_ajust_estimated_kwh_price')[1])
 
         ctx = context or {}
         if date:
@@ -439,61 +444,17 @@ class ReportBackendMailcanvipreus(ReportBackend):
             )
         return conany
 
-    # FIMXE: tot hardcoded hahahaha salu2
-    def calcularImpostosPerCostAnualEstimat(self, preu, fiscal_position, context=False):
-        iva = 0.1 if context and context.get('iva10') else 0.21
-        impost_electric = 0.005
-        if fiscal_position:
-            if fiscal_position.id in [33, 47, 56, 52, 61, 38, 21, 19, 87, 89, 94, 97, 99, 101]:
-                iva = 0.03
-            if fiscal_position.id in [34, 48, 53, 57, 53, 62, 39, 25, 88, 90, 98, 100]:
-                iva = 0.0
+    def calc_tax_for_anual_estimation(self, preu, context=None):
+        iva = self.simplified_taxes.get('IGIC', self.simplified_taxes.get('IVA', 0.21))
+        impost_electric = self.simplified_taxes.get('IE', 0)
         preu_imp = round(preu * (1 + impost_electric), 2)
         return round(preu_imp * (1 + iva))
 
-    def getImpostos(self, fiscal_position, context=False):
-        imp_str = "IVA del 10%" if context and context.get('iva10') else "IVA del 21%"
-        imp_value = 21
-        if fiscal_position:
-            if fiscal_position.id in [33, 47, 56, 52, 61, 38, 21, 19, 87, 89, 94, 97, 99, 101]:
-                imp_str = "IGIC del 3%"
-                imp_value = 3
-            if fiscal_position.id in [34, 48, 53, 57, 53, 62, 39, 25, 88, 90, 98, 100]:
-                imp_str = "IGIC del 0%"
-                imp_value = 0
-        return imp_str, float(imp_value)
-
-    def get_iva_text(self, cursor, uid, polissa, context=False):
-        if context is None:
-            context = {}
-
-        iva_percent = 0.1 if context and context.get('iva10') else 0.21
-
-        fp_obj = self.pool.get('account.fiscal.position')
-        atax_obj = self.pool.get('account.tax')
-        imd_obj = self.pool.get('ir.model.data')
-
-        fiscal_position = polissa.fiscal_position_id
-        if not fiscal_position:
-            fiscal_position = polissa.titular.property_account_position
-
-        try:
-            iva_tax_id = imd_obj.get_object_reference(cursor, uid, 'account', 'tax_iva21')[1]
-            mapped_tax_ids = fp_obj.map_tax(cursor, uid, fiscal_position, [
-                                            iva_tax_id], context=context)
-            if mapped_tax_ids:
-                tax_data = atax_obj.read(cursor, uid, mapped_tax_ids[0], [
-                                         'amount'], context=context)
-                if tax_data:
-                    iva_percent = tax_data['amount']
-        except Exception:
-            pass
-
-        tax_text_map = {
-            0.03: "IGIC del 3%",
-            0.00: "IGIC del 0%",
-        }
-        return tax_text_map.get(iva_percent, "IVA del {}%".format(int(iva_percent * 100)))
+    def get_iva_text(self, context=None):
+        if 'IGIC' in self.simplified_taxes:
+            return 'IGIC del {}%'.format(int(self.simplified_taxes['IGIC'] * 100))
+        else:
+            return 'IVA del {}%'.format(int(self.simplified_taxes['IVA'] * 100))
 
     def has_gurb(self, cursor, uid, polissa, context=False):
         gurb_cups_obj = self.pool.get("som.gurb.cups")
@@ -558,12 +519,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 context=context,
             )
 
-            preu_vell_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_vell, env.polissa_id.fiscal_position_id, context=context
-            )
-            preu_nou_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_nou, env.polissa_id.fiscal_position_id, context=context
-            )
+            preu_vell_imp = self.calc_tax_for_anual_estimation(preu_vell)
+            preu_nou_imp = self.calc_tax_for_anual_estimation(preu_nou)
 
         return {
             "origen": origen,
@@ -615,12 +572,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 context=context,
             )
 
-            preu_vell_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_vell, env.polissa_id.fiscal_position_id, context=context
-            )
-            preu_nou_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_nou, env.polissa_id.fiscal_position_id, context=context
-            )
+            preu_vell_imp = self.calc_tax_for_anual_estimation(preu_vell)
+            preu_nou_imp = self.calc_tax_for_anual_estimation(preu_nou)
 
         return {
             "gkwh_estimation": {

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -7,9 +7,6 @@ from som_indexada.utils import calculate_new_indexed_prices
 from datetime import date, timedelta
 
 
-PRICE_CHANGE_DATE = "2026-05-01"  # FIXME: This should not be hardcoded
-
-
 class ReportBackendMailcanvipreus(ReportBackend):
     _source_model = "som.enviament.massiu"
     _name = "report.backend.mailcanvipreus"
@@ -105,13 +102,13 @@ class ReportBackendMailcanvipreus(ReportBackend):
     @report_browsify
     def get_data(self, cursor, uid, env, context=None):
         imd_obj = self.pool.get('ir.model.data')
-        pol_o = self.pool.get("giscedata.polissa")
+        pol_obj = self.pool.get("giscedata.polissa")
         if context is None:
             context = {}
 
         context['iva10'] = env.polissa_id.potencia < 10
 
-        self.simplified_taxes = pol_o.get_simplified_taxes(
+        self.simplified_taxes = pol_obj.get_simplified_taxes(
             cursor, uid, env.polissa_id.id, context=context)
 
         impostos_str = self.get_iva_text()
@@ -515,7 +512,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 potencies,
                 afegir_servei_ajust=True,
                 bo_social_separat=True,
-                date=PRICE_CHANGE_DATE,
+                date=self.get_price_change_date(cursor, uid, env.polissa_id, context),
                 context=context,
             )
 
@@ -567,7 +564,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 {},
                 afegir_servei_ajust=True,
                 bo_social_separat=False,
-                date=PRICE_CHANGE_DATE,
+                date=self.get_price_change_date(cursor, uid, env.polissa_id, context),
                 is_gkwh=True,
                 context=context,
             )
@@ -585,6 +582,15 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 "consum_total": consum_total,
             }
         }
+
+    def get_price_change_date(self, cursor, uid, polissa, context=None):
+        today = date.today().strftime("%Y-%m-%d")
+        if polissa.llista_preu:
+            versions = polissa.llista_preu.version_id
+            for version in versions:
+                if version.active and version.date_start and version.date_start > today:
+                    return version.date_start
+        return (date.today() + timedelta(days=60)).strftime("%Y-%m-%d")
 
     def esCanaries(self, cursor, uid, env, context=False):
         return env.polissa_id.cups.id_municipi.subsistema_id.code in [

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -449,10 +449,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
         return round(preu_imp * (1 + iva))
 
     def get_iva_text(self, context=None):
-        if 'IGIC' in self.simplified_taxes:
-            return 'IGIC del {}%'.format(int(self.simplified_taxes['IGIC'] * 100))
-        else:
-            return 'IVA del {}%'.format(int(self.simplified_taxes['IVA'] * 100))
+        iva_str = 'IVA' if 'IVA' in self.simplified_taxes else 'IGIC'
+        return '{} del {:.2f}%'.format(iva_str, self.simplified_taxes[iva_str] * 100)
 
     def has_gurb(self, cursor, uid, polissa, context=False):
         gurb_cups_obj = self.pool.get("som.gurb.cups")

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -340,9 +340,10 @@ class ReportBackendMailcanvipreus(ReportBackend):
         is_gkwh=False,
         context=None,
     ):
+        imd_obj = self.pool.get('ir.model.data')
         bo_social_price = self.get_bo_social_price(
             cursor, uid, polissa_id.llista_preu, context=context)
-        preu_estimat_servei_ajust = float(self.imd_obj.get_object_reference(
+        preu_estimat_servei_ajust = float(imd_obj.get_object_reference(
             cursor, uid, 'som_polissa_condicions_generals', 'serveis_ajust_estimated_kwh_price')[1])
 
         ctx = context or {}
@@ -386,7 +387,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
         tarifa_obj = self.pool.get("giscedata.polissa.tarifa")
         if not self._bo_social_price:
             self._bo_social_price = (
-                tarifa_obj.get_bo_social_price(cursor, uid, pricelist, context=context)
+                tarifa_obj.get_bo_social_price(cursor, uid, pricelist, context=context)[0]
             ) * 365
         return self._bo_social_price
 

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -340,11 +340,11 @@ class ReportBackendMailcanvipreus(ReportBackend):
         is_gkwh=False,
         context=None,
     ):
-        imd_obj = self.pool.get('ir.model.data')
+        conf_obj = self.pool.get('res.config')
         bo_social_price = self.get_bo_social_price(
             cursor, uid, polissa_id.llista_preu, context=context)
-        preu_estimat_servei_ajust = float(imd_obj.get_object_reference(
-            cursor, uid, 'som_polissa_condicions_generals', 'serveis_ajust_estimated_kwh_price')[1])
+        preu_estimat_servei_ajust = float(
+            conf_obj.get(cursor, uid, 'serveis_ajust_estimated_kwh_price'))
 
         ctx = context or {}
         if date:

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -339,9 +339,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
         is_gkwh=False,
         context=None,
     ):
-        # bo_social_price = 2.299047  # 2024
-        # bo_social_price = 4.650987  # 2025
-        bo_social_price = 6.979247  # 2026  # FIXME: Això s'ha d'agafar del ERP D:
+        bo_social_price = self.get_bo_social_price(
+            cursor, uid, polissa_id.llista_preu, context=context)
         preu_estimat_servei_ajust = 0.028  # FIXME: Això segurament haurà d'anar a un altre lloc
 
         ctx = context or {}
@@ -378,6 +377,16 @@ class ReportBackendMailcanvipreus(ReportBackend):
             imports += bo_social_price
 
         return imports
+
+    _bo_social_price = False
+
+    def get_bo_social_price(self, cursor, uid, pricelist, context=None):
+        tarifa_obj = self.pool.get("giscedata.polissa.tarifa")
+        if not self._bo_social_price:
+            self._bo_social_price = (
+                tarifa_obj.get_bo_social_price(cursor, uid, pricelist, context=context)
+            ) * 365
+        return self._bo_social_price
 
     def aplicarCoeficients(self, consum_anual, tarifa):
         coeficients = {
@@ -453,6 +462,38 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 imp_str = "IGIC del 0%"
                 imp_value = 0
         return imp_str, float(imp_value)
+
+    def get_iva_text(self, cursor, uid, polissa, context=False):
+        if context is None:
+            context = {}
+
+        iva_percent = 0.1 if context and context.get('iva10') else 0.21
+
+        fp_obj = self.pool.get('account.fiscal.position')
+        atax_obj = self.pool.get('account.tax')
+        imd_obj = self.pool.get('ir.model.data')
+
+        fiscal_position = polissa.fiscal_position_id
+        if not fiscal_position:
+            fiscal_position = polissa.titular.property_account_position
+
+        try:
+            iva_tax_id = imd_obj.get_object_reference(cursor, uid, 'account', 'tax_iva21')[1]
+            mapped_tax_ids = fp_obj.map_tax(cursor, uid, fiscal_position, [
+                                            iva_tax_id], context=context)
+            if mapped_tax_ids:
+                tax_data = atax_obj.read(cursor, uid, mapped_tax_ids[0], [
+                                         'amount'], context=context)
+                if tax_data:
+                    iva_percent = tax_data['amount']
+        except Exception:
+            pass
+
+        tax_text_map = {
+            0.03: "IGIC del 3%",
+            0.00: "IGIC del 0%",
+        }
+        return tax_text_map.get(iva_percent, "IVA del {}%".format(int(iva_percent * 100)))
 
     def has_gurb(self, cursor, uid, polissa, context=False):
         gurb_cups_obj = self.pool.get("som.gurb.cups")

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -7,9 +7,6 @@ from som_indexada.utils import calculate_new_indexed_prices
 from datetime import date, timedelta
 
 
-PRICE_CHANGE_DATE = "2026-05-01"  # FIXME: This should not be hardcoded
-
-
 class ReportBackendMailcanvipreus(ReportBackend):
     _source_model = "som.enviament.massiu"
     _name = "report.backend.mailcanvipreus"
@@ -105,13 +102,13 @@ class ReportBackendMailcanvipreus(ReportBackend):
     @report_browsify
     def get_data(self, cursor, uid, env, context=None):
         imd_obj = self.pool.get('ir.model.data')
-        pol_o = self.pool.get("giscedata.polissa")
+        pol_obj = self.pool.get("giscedata.polissa")
         if context is None:
             context = {}
 
         context['iva10'] = env.polissa_id.potencia <= 10
 
-        self.simplified_taxes = pol_o.get_simplified_taxes(
+        self.simplified_taxes = pol_obj.get_simplified_taxes(
             cursor, uid, env.polissa_id.id, context=context)
 
         impostos_str = self.get_iva_text()
@@ -515,7 +512,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 potencies,
                 afegir_servei_ajust=True,
                 bo_social_separat=True,
-                date=PRICE_CHANGE_DATE,
+                date=self.get_price_change_date(cursor, uid, env.polissa_id, context),
                 context=context,
             )
 
@@ -567,7 +564,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 {},
                 afegir_servei_ajust=True,
                 bo_social_separat=False,
-                date=PRICE_CHANGE_DATE,
+                date=self.get_price_change_date(cursor, uid, env.polissa_id, context),
                 is_gkwh=True,
                 context=context,
             )
@@ -585,6 +582,15 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 "consum_total": consum_total,
             }
         }
+
+    def get_price_change_date(self, cursor, uid, polissa, context=None):
+        today = date.today().strftime("%Y-%m-%d")
+        if polissa.llista_preu:
+            versions = polissa.llista_preu.version_id
+            for version in versions:
+                if version.active and version.date_start and version.date_start > today:
+                    return version.date_start
+        return (date.today() + timedelta(days=60)).strftime("%Y-%m-%d")
 
     def esCanaries(self, cursor, uid, env, context=False):
         return env.polissa_id.cups.id_municipi.subsistema_id.code in [

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -381,15 +381,11 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
         return imports
 
-    _bo_social_price = False
-
     def get_bo_social_price(self, cursor, uid, pricelist, context=None):
         tarifa_obj = self.pool.get("giscedata.polissa.tarifa")
-        if not self._bo_social_price:
-            self._bo_social_price = (
-                tarifa_obj.get_bo_social_price(cursor, uid, pricelist, context=context)[0]
-            ) * 365
-        return self._bo_social_price
+        return (
+            tarifa_obj.get_bo_social_price(cursor, uid, pricelist, context=context)[0]
+        ) * 365
 
     def aplicarCoeficients(self, consum_anual, tarifa):
         coeficients = {

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -446,7 +446,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
     def get_iva_text(self, context=None):
         iva_str = 'IVA' if 'IVA' in self.simplified_taxes else 'IGIC'
-        return '{} del {:.2f}%'.format(iva_str, self.simplified_taxes[iva_str] * 100)
+        return '{} del {:.0f}%'.format(iva_str, self.simplified_taxes[iva_str] * 100)
 
     def has_gurb(self, cursor, uid, polissa, context=False):
         gurb_cups_obj = self.pool.get("som.gurb.cups")

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -582,9 +582,12 @@ class ReportBackendMailcanvipreus(ReportBackend):
         today = date.today().strftime("%Y-%m-%d")
         if polissa.llista_preu:
             versions = polissa.llista_preu.version_id
-            for version in versions:
-                if version.active and version.date_start and version.date_start > today:
-                    return version.date_start
+            future_version_starts = [
+                v.date_start for v in versions
+                if v.active and v.date_start and v.date_start > today
+            ]
+            if future_version_starts:
+                return min(future_version_starts)
         return (date.today() + timedelta(days=60)).strftime("%Y-%m-%d")
 
     def esCanaries(self, cursor, uid, env, context=False):

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -105,14 +105,18 @@ class ReportBackendMailcanvipreus(ReportBackend):
     @report_browsify
     def get_data(self, cursor, uid, env, context=None):
         imd_obj = self.pool.get('ir.model.data')
+        pol_o = self.pool.get("giscedata.polissa")
         if context is None:
             context = {}
 
         context['iva10'] = env.polissa_id.potencia <= 10
 
-        impostos_str, impostos_value = self.getImpostos(env.polissa_id.fiscal_position_id, context)
+        self.simplified_taxes = pol_o.get_simplified_taxes(
+            cursor, uid, env.polissa_id.id, context=context)
 
-        if impostos_str == 'IVA del 10%':
+        impostos_str = self.get_iva_text()
+
+        if 'IVA' in self.simplified_taxes and self.simplified_taxes['IVA'] < 0.21:
             fp_id = imd_obj.get_object_reference(
                 cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
             context.update({'force_fiscal_position': fp_id})
@@ -312,9 +316,9 @@ class ReportBackendMailcanvipreus(ReportBackend):
             != pol.modcontractuals_ids[0].mode_facturacio
                 and pol.modcontractuals_ids[0].mode_facturacio == 'index'):
             context["force_pricelist"] = pol.modcontractuals_ids[1].llista_preu.id
-        elif(pol.modcontractuals_ids[0].state == "pendent"
-             and pol.mode_facturacio
-             != pol.modcontractuals_ids[0].mode_facturacio
+        elif (pol.modcontractuals_ids[0].state == "pendent"
+              and pol.mode_facturacio
+              != pol.modcontractuals_ids[0].mode_facturacio
                 and pol.modcontractuals_ids[0].mode_facturacio == 'atr'):
             context["force_pricelist"] = pol.modcontractuals_ids[0].llista_preu.id
         for terme, values in periods.items():
@@ -341,7 +345,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
     ):
         bo_social_price = self.get_bo_social_price(
             cursor, uid, polissa_id.llista_preu, context=context)
-        preu_estimat_servei_ajust = 0.028  # FIXME: Això segurament haurà d'anar a un altre lloc
+        preu_estimat_servei_ajust = float(self.imd_obj.get_object_reference(
+            cursor, uid, 'som_polissa_condicions_generals', 'serveis_ajust_estimated_kwh_price')[1])
 
         ctx = context or {}
         if date:
@@ -439,61 +444,17 @@ class ReportBackendMailcanvipreus(ReportBackend):
             )
         return conany
 
-    # FIMXE: tot hardcoded hahahaha salu2
-    def calcularImpostosPerCostAnualEstimat(self, preu, fiscal_position, context=False):
-        iva = 0.1 if context and context.get('iva10') else 0.21
-        impost_electric = 0.005
-        if fiscal_position:
-            if fiscal_position.id in [33, 47, 56, 52, 61, 38, 21, 19, 87, 89, 94, 97, 99, 101]:
-                iva = 0.03
-            if fiscal_position.id in [34, 48, 53, 57, 53, 62, 39, 25, 88, 90, 98, 100]:
-                iva = 0.0
+    def calc_tax_for_anual_estimation(self, preu, context=None):
+        iva = self.simplified_taxes.get('IGIC', self.simplified_taxes.get('IVA', 0.21))
+        impost_electric = self.simplified_taxes.get('IE', 0)
         preu_imp = round(preu * (1 + impost_electric), 2)
         return round(preu_imp * (1 + iva))
 
-    def getImpostos(self, fiscal_position, context=False):
-        imp_str = "IVA del 10%" if context and context.get('iva10') else "IVA del 21%"
-        imp_value = 21
-        if fiscal_position:
-            if fiscal_position.id in [33, 47, 56, 52, 61, 38, 21, 19, 87, 89, 94, 97, 99, 101]:
-                imp_str = "IGIC del 3%"
-                imp_value = 3
-            if fiscal_position.id in [34, 48, 53, 57, 53, 62, 39, 25, 88, 90, 98, 100]:
-                imp_str = "IGIC del 0%"
-                imp_value = 0
-        return imp_str, float(imp_value)
-
-    def get_iva_text(self, cursor, uid, polissa, context=False):
-        if context is None:
-            context = {}
-
-        iva_percent = 0.1 if context and context.get('iva10') else 0.21
-
-        fp_obj = self.pool.get('account.fiscal.position')
-        atax_obj = self.pool.get('account.tax')
-        imd_obj = self.pool.get('ir.model.data')
-
-        fiscal_position = polissa.fiscal_position_id
-        if not fiscal_position:
-            fiscal_position = polissa.titular.property_account_position
-
-        try:
-            iva_tax_id = imd_obj.get_object_reference(cursor, uid, 'account', 'tax_iva21')[1]
-            mapped_tax_ids = fp_obj.map_tax(cursor, uid, fiscal_position, [
-                                            iva_tax_id], context=context)
-            if mapped_tax_ids:
-                tax_data = atax_obj.read(cursor, uid, mapped_tax_ids[0], [
-                                         'amount'], context=context)
-                if tax_data:
-                    iva_percent = tax_data['amount']
-        except Exception:
-            pass
-
-        tax_text_map = {
-            0.03: "IGIC del 3%",
-            0.00: "IGIC del 0%",
-        }
-        return tax_text_map.get(iva_percent, "IVA del {}%".format(int(iva_percent * 100)))
+    def get_iva_text(self, context=None):
+        if 'IGIC' in self.simplified_taxes:
+            return 'IGIC del {}%'.format(int(self.simplified_taxes['IGIC'] * 100))
+        else:
+            return 'IVA del {}%'.format(int(self.simplified_taxes['IVA'] * 100))
 
     def has_gurb(self, cursor, uid, polissa, context=False):
         gurb_cups_obj = self.pool.get("som.gurb.cups")
@@ -558,12 +519,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 context=context,
             )
 
-            preu_vell_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_vell, env.polissa_id.fiscal_position_id, context=context
-            )
-            preu_nou_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_nou, env.polissa_id.fiscal_position_id, context=context
-            )
+            preu_vell_imp = self.calc_tax_for_anual_estimation(preu_vell)
+            preu_nou_imp = self.calc_tax_for_anual_estimation(preu_nou)
 
         return {
             "origen": origen,
@@ -615,12 +572,8 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 context=context,
             )
 
-            preu_vell_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_vell, env.polissa_id.fiscal_position_id, context=context
-            )
-            preu_nou_imp = self.calcularImpostosPerCostAnualEstimat(
-                preu_nou, env.polissa_id.fiscal_position_id, context=context
-            )
+            preu_vell_imp = self.calc_tax_for_anual_estimation(preu_vell)
+            preu_nou_imp = self.calc_tax_for_anual_estimation(preu_nou)
 
         return {
             "gkwh_estimation": {

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus_eie.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus_eie.py
@@ -53,27 +53,23 @@ class ReportBackendMailcanvipreusEiE(ReportBackend):
 
         return data
 
-    def getImpostos(self, fiscal_position, context=False):
-        imp_str = "IVA del 10%" if context and context.get('iva10') else "IVA del 21%"
-        imp_value = 21
-        if fiscal_position:
-            if fiscal_position.id in [33, 47, 56, 52, 61, 38, 21, 19, 87, 89, 94]:
-                imp_str = "IGIC del 3%"
-                imp_value = 3
-            if fiscal_position.id in [34, 48, 53, 57, 53, 62, 39, 25, 88, 90]:
-                imp_str = "IGIC del 0%"
-                imp_value = 0
-        return imp_str, float(imp_value)
+    def get_iva_text(self, context=None):
+        if 'IGIC' in self.simplified_taxes:
+            return 'IGIC del {}%'.format(int(self.simplified_taxes['IGIC'] * 100))
+        else:
+            return 'IVA del {}%'.format(int(self.simplified_taxes['IVA'] * 100))
 
     @report_browsify
     def get_data(self, cursor, uid, env, context=None):
         imd_obj = self.pool.get('ir.model.data')
+        pol_obj = self.pool.get("giscedata.polissa")
         if context is None:
             context = {}
 
-        impostos_str, impostos_value = self.getImpostos(env.polissa_id.fiscal_position_id, context)
+        self.simplified_taxes = pol_obj.get_simplified_taxes(
+            cursor, uid, env.polissa_id.id, context=context)
 
-        if impostos_str == 'IVA del 10%':
+        if 'IVA' in self.simplified_taxes and self.simplified_taxes['IVA'] < 0.21:
             fp_id = imd_obj.get_object_reference(
                 cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
             context.update({'force_fiscal_position': fp_id})

--- a/som_polissa_condicions_generals/tests/__init__.py
+++ b/som_polissa_condicions_generals/tests/__init__.py
@@ -3,3 +3,4 @@ from __future__ import absolute_import
 from .tests_report_backend_ccpp import *
 from .tests_report_backend_ccpp_ignore_modcon import *
 from .tests_contract_helper import *
+from .tests_giscedata_polissa import *

--- a/som_polissa_condicions_generals/tests/tests_giscedata_polissa.py
+++ b/som_polissa_condicions_generals/tests/tests_giscedata_polissa.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+from destral import testing
+from destral.transaction import Transaction
+
+
+class TestGiscedataPolissa(testing.OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+        self.pol_obj = self.openerp.pool.get("giscedata.polissa")
+        self.fp_obj = self.openerp.pool.get("account.fiscal.position")
+        self.partner_obj = self.openerp.pool.get("res.partner")
+        self.conf_obj = self.openerp.pool.get('res.config')
+        self.tax_obj = self.openerp.pool.get('account.tax')
+        self.imd_obj = self.openerp.pool.get('ir.model.data')
+
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iva_21_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [("name", "=", "IVA 21%")])[0],
+        )
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iese_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [
+                ("name", "=", "Impuesto especial sobre la electricidad")
+            ])[0],
+        )
+
+        fp_ids = self.fp_obj.search(
+            self.cursor, self.uid,
+            [("name", "=", "IVA Reduït (IVA 5%)")]
+        )
+        self.fp_iva_reduit_id = fp_ids[0] if fp_ids else None
+
+        self._pol_id = 1  # Any polissa can work
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test_get_simplified_taxes__no_fiscal_position__returns_iva_21_default(self):
+        pol_id = self._pol_id
+        self.pol_obj.write(
+            self.cursor, self.uid, pol_id,
+            {"fiscal_position_id": False}
+        )
+
+        result = self.pol_obj.get_simplified_taxes(self.cursor, self.uid, pol_id, context={})
+
+        expected = {"IVA": 0.21, "IE": 0.4864}
+        self.assertEqual(result, expected)
+
+    def test_get_simplified_taxes__context_iva10__returns_iva_10_context_override(self):
+        pol_id = self._pol_id
+        self.pol_obj.write(
+            self.cursor, self.uid, pol_id,
+            {"fiscal_position_id": False}
+        )
+
+        result = self.pol_obj.get_simplified_taxes(
+            self.cursor, self.uid, pol_id, context={"iva10": True}
+        )
+
+        expected = {"IVA": 0.1, "IE": 0.4864}
+        self.assertEqual(result, expected)
+
+    def test_get_simplified_taxes__iva_reduit_fp__returns_iva_5_with_ie(self):
+        pol_id = self._pol_id
+        self.pol_obj.write(
+            self.cursor, self.uid, pol_id,
+            {"fiscal_position_id": self.fp_iva_reduit_id, "titular": False}
+        )
+
+        result = self.pol_obj.get_simplified_taxes(self.cursor, self.uid, pol_id, context={})
+
+        expected = {"IVA": 0.05, "IE": 0.005}
+        self.assertEqual(result, expected)
+
+    def test_get_simplified_taxes__fp_without_tax_ids__returns_default_iva(self):
+        pol_id = self._pol_id
+        self.pol_obj.write(
+            self.cursor, self.uid, pol_id,
+            {"fiscal_position_id": 1, "titular": False}
+        )
+
+        result = self.pol_obj.get_simplified_taxes(self.cursor, self.uid, pol_id, context={})
+
+        expected = {"IVA": 0.21, "IE": 0.4864}
+        self.assertEqual(result, expected)
+
+    def test_get_simplified_taxes__context_iva10_overrides_fp_with_lowest_iva(self):
+        if not self.fp_iva_reduit_id:
+            self.skipTest("No IVA Reduït fiscal position")
+
+        pol_id = self._pol_id
+        self.pol_obj.write(
+            self.cursor, self.uid, pol_id,
+            {"fiscal_position_id": self.fp_iva_reduit_id, "titular": False}
+        )
+
+        result = self.pol_obj.get_simplified_taxes(
+            self.cursor, self.uid, pol_id, context={"iva10": True}
+        )
+
+        expected = {"IVA": 0.1, "IE": 0.005}
+        self.assertEqual(result, expected)
+
+    def test_get_simplified_taxes__with_igic(self):
+        pol_id = self._pol_id
+
+        # Create and map IGIC 3% tax
+        igic3_template_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'l10n_es_igic', 'igic_rep_3')[1]
+        igic3_tax_id = self.tax_obj.create_tax_from_template(
+            self.cursor, self.uid, igic3_template_id)
+
+        iva_map_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_polissa_condicions_generals', 'fp_iva_reduit_map')[1]
+        self.openerp.pool.get('account.fiscal.position.tax').write(
+            self.cursor, self.uid, iva_map_id, {"tax_dest_id": igic3_tax_id}
+        )
+
+        self.pol_obj.write(
+            self.cursor, self.uid, pol_id,
+            {"fiscal_position_id": self.fp_iva_reduit_id, "titular": False}
+        )
+
+        result = self.pol_obj.get_simplified_taxes(self.cursor, self.uid, pol_id, context={})
+
+        expected = {"IGIC": 0.03, "IE": 0.005}  # IE is reduced in fp_iva_reduit
+        self.assertEqual(result, expected)

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
@@ -20,10 +20,22 @@ class TestReportBackendCCPP(testing.OOTestCase):
         self.rpa_obj = self.openerp.pool.get("res.partner.address")
         self.pricelist_obj = self.openerp.pool.get("product.pricelist")
         self.wiz_change_to_index_obj = self.openerp.pool.get("wizard.change.to.indexada")
+        self.conf_obj = self.openerp.pool.get('res.config')
         self.contract1_id = self.get_ref("giscedata_polissa", "polissa_0001")
         self.contract_20TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_018")
         self.contract_30TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_019")
         self.contract_61TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_020")
+
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iva_21_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [("name", "=", "IVA 21%")])[0],
+        )
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iese_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [
+                ("name", "=", "Impuesto especial sobre la electricidad")
+            ])[0],
+        )
 
     def tearDown(self):
         self.txn.stop()
@@ -110,6 +122,7 @@ class TestReportBackendCCPP(testing.OOTestCase):
             u'modcon_pendent_indexada': False,
             u'modcon_pendent_periodes': False,
             u'mode_facturacio': u'atr',
+            u'mode_facturacio_calculat': u'atr',
             u'name': u'0018',
             u'periodes_energia': [u'P1', u'P2', u'P3'],
             u'periodes_potencia': [u'P1', u'P2'],

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
@@ -20,6 +20,7 @@ class TestReportBackendCCPP(testing.OOTestCase):
         self.rpa_obj = self.openerp.pool.get("res.partner.address")
         self.pricelist_obj = self.openerp.pool.get("product.pricelist")
         self.wiz_change_to_index_obj = self.openerp.pool.get("wizard.change.to.indexada")
+        self.tax_obj = self.openerp.pool.get('account.tax')
         self.conf_obj = self.openerp.pool.get('res.config')
         self.contract1_id = self.get_ref("giscedata_polissa", "polissa_0001")
         self.contract_20TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_018")

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
@@ -20,10 +20,22 @@ class TestReportBackendCCPP(testing.OOTestCase):
         self.rpa_obj = self.openerp.pool.get("res.partner.address")
         self.pricelist_obj = self.openerp.pool.get("product.pricelist")
         self.wiz_change_to_index_obj = self.openerp.pool.get("wizard.change.to.indexada")
+        self.conf_obj = self.openerp.pool.get('res.config')
         self.contract1_id = self.get_ref("giscedata_polissa", "polissa_0001")
         self.contract_20TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_018")
         self.contract_30TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_019")
         self.contract_61TD_id = self.get_ref("giscedata_polissa", "polissa_tarifa_020")
+
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iva_21_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [("name", "=", "IVA 21%")])[0],
+        )
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iese_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [
+                ("name", "=", "Impuesto especial sobre la electricidad")
+            ])[0],
+        )
 
     def tearDown(self):
         self.txn.stop()
@@ -111,6 +123,7 @@ class TestReportBackendCCPP(testing.OOTestCase):
             u'modcon_pendent_indexada': False,
             u'modcon_pendent_periodes': False,
             u'mode_facturacio': u'atr',
+            u'mode_facturacio_calculat': u'atr',
             u'name': u'0018',
             u'periodes_energia': [u'P1', u'P2', u'P3'],
             u'periodes_potencia': [u'P1', u'P2'],

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp_ignore_modcon.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp_ignore_modcon.py
@@ -15,6 +15,8 @@ class TestReportBackendCCPPIgnoreModcon(testing.OOTestCase):
         self.uid = self.txn.user
 
         self.pol_obj = self.openerp.pool.get("giscedata.polissa")
+        self.tax_obj = self.openerp.pool.get('account.tax')
+        self.conf_obj = self.openerp.pool.get('res.config')
         self.backend_obj = self.openerp.pool.get(
             "report.backend.condicions.particulars.ignore.modcon")
         self.pricelist_obj = self.openerp.pool.get("product.pricelist")
@@ -43,6 +45,18 @@ class TestReportBackendCCPPIgnoreModcon(testing.OOTestCase):
         self.assertEqual(result['tarifa_mostrar'], pricelist_name)
 
     def test_get_prices_data_with_keeps_current(self):
+        # Get prices data needs this configuration setted
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iva_21_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [("name", "=", "IVA 21%")])[0],
+        )
+        self.conf_obj.set(
+            self.cursor, self.uid, 'default_iese_tax_id',
+            self.tax_obj.search(self.cursor, self.uid, [
+                ("name", "=", "Impuesto especial sobre la electricidad")
+            ])[0],
+        )
+
         self.pol_obj.send_signal(
             self.cursor, self.uid, [self.contract_20TD_id], ["validar", "contracte"])
         context = {"active_id": self.contract_20TD_id, "change_type": "from_period_to_index"}

--- a/som_polissa_soci/__terp__.py
+++ b/som_polissa_soci/__terp__.py
@@ -13,6 +13,7 @@
         "giscedata_lectures_estimacio",
         "giscedata_polissa_category",
         "giscedata_switching_comer",
+        "giscedata_repercusio_bo_social",
     ],
     "test_depends": [
         "giscedata_tarifas_peajes_20150101",

--- a/som_polissa_soci/data/giscedata_facturacio_data.xml
+++ b/som_polissa_soci/data/giscedata_facturacio_data.xml
@@ -28,22 +28,10 @@
             <field name="require_bank_account" eval="True"/>
             <field name="partner_id">1</field>
         </record>
-        <record id="som_invoice_active_bo_social" model="res.config">
-            <field name="name">som_invoice_active_bo_social</field>
-            <field name="value">0</field>
-        </record>
-        <record id="som_invoice_start_date_bo_social" model="res.config">
-            <field name="name">som_invoice_start_date_bo_social</field>
-            <field name="value">2017-07-01</field>
-        </record>
+        <!-- Despite the name, is used for donation -->
         <record id="som_invoice_bo_social_journal_codes" model="res.config">
             <field name="name">som_invoice_bo_social_journal_codes</field>
             <field name="value">['ENERGIA', 'ENERGIA.R', 'RECUPERACION_IVA.R']</field>
-        </record>
-        <record id="som_invoice_end_date_bo_social" model="res.config">
-            <field name="name">som_invoice_end_date_bo_social</field>
-            <field name="value">2021-03-31</field>
-            <field name="description">Data final d'aplicació del BO SOCIAL</field>
         </record>
     </data>
 </openerp>

--- a/som_polissa_soci/data/giscedata_facturacio_data.xml
+++ b/som_polissa_soci/data/giscedata_facturacio_data.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0"?>
 <openerp>
-    <data>
-        <!-- Categ uom -->
-        <record model="product.uom.categ" id="categ_uom_day">
-            <field name="name">DIES</field>
-        </record>
-        <record model="product.uom" id="product_uom_day">
-            <field name="name">dia</field>
-            <field name="rounding">0.0</field>
-            <field name="category_id" ref="categ_uom_day"/>
-        </record>
-        <!-- Categoria extra -->
+    <data noupdate="1">
         <record model="product.category" id="categ_donacions">
             <field name="name">Donacions</field>
             <field name="sequence">1</field>
@@ -27,25 +17,6 @@
             <field name="supply_method">buy</field>
             <field name="description">Donatiu voluntari (0,01€/kWh)</field>
         </record>
-        <!-- Bo social -->
-        <record model="product.category" id="categ_bo_social">
-            <field name="name">Bo Social</field>
-            <field name="sequence">1</field>
-        </record>
-        <record model="product.product" id="bosocial_BS01">
-            <field name="name">Bo Social</field>
-            <field name="default_code">BS01</field>
-            <field name="categ_id" ref="categ_bo_social"/>
-            <field name="type">service</field>
-            <field name="uom_id" ref="product_uom_day"/>
-            <field name="uom_po_id" ref="product_uom_day"/>
-            <field name="property_account_income" model="account.account" search="[('code','=','700000000006')]"/>
-            <field name="procure_method">make_to_stock</field>
-            <field name="supply_method">buy</field>
-            <field name="description">Obligació finançament bo Social (€/dia)</field>
-        </record>
-    </data>
-	<data noupdate="1">
         <record id="mode_pagament_socis" model="payment.mode">
             <field name="name">QUOTA SOCIS</field>
             <field name="type" search="[('code', '=', 'RECIBO_CSB')]"/>

--- a/som_polissa_soci/migrations/5.0.25.0/post-0001_deactivate_bosocial.py
+++ b/som_polissa_soci/migrations/5.0.25.0/post-0001_deactivate_bosocial.py
@@ -40,6 +40,32 @@ def up(cursor, installed_version):
 
     logger.info("bosocial_BS01 and product_uom_day deactivated.")
 
+    logger.info("Removing bo social configuration from res.config and ir_model_data")
+
+    config_names = [
+        'som_invoice_active_bo_social',
+        'som_invoice_start_date_bo_social',
+        'som_invoice_end_date_bo_social',
+    ]
+
+    for config_name in config_names:
+        cursor.execute("""
+            DELETE FROM res_config
+            WHERE name = %s
+        """, (config_name,))
+        logger.info("Deleted res_config: %s", config_name)
+
+    cursor.execute("""
+        DELETE FROM ir_model_data
+        WHERE module = 'som_polissa_soci'
+          AND name IN (
+            'som_invoice_active_bo_social',
+            'som_invoice_start_date_bo_social',
+            'som_invoice_end_date_bo_social',
+          )
+    """)
+    logger.info("Deleted ir_model_data entries for bo social configs")
+
 
 def down(cursor, installed_version):
     pass

--- a/som_polissa_soci/migrations/5.0.25.0/post-0001_deactivate_bosocial.py
+++ b/som_polissa_soci/migrations/5.0.25.0/post-0001_deactivate_bosocial.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import logging
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Deactivating bosocial_BS01 product and product_uom_day")
+
+    cursor.execute("""
+        SELECT imd.res_id, imd.model
+        FROM ir_model_data imd
+        WHERE imd.module = 'som_polissa_soci'
+          AND imd.name IN ('bosocial_BS01', 'categ_bo_social', 'product_uom_day', 'categ_uom_day')
+    """)
+    records = cursor.fetchall()
+    logger.info("Found %d records in ir_model_data", len(records))
+
+    for res_id, model in records:
+        if model == 'product.product':
+            cursor.execute("""
+                UPDATE product_product
+                SET active = false
+                WHERE id = %s
+            """, (res_id,))
+        elif model == 'product.uom':
+            cursor.execute("""
+                UPDATE product_uom
+                SET active = false
+                WHERE id = %s
+            """, (res_id,))
+
+    cursor.execute("""
+        DELETE FROM ir_model_data
+        WHERE module = 'som_polissa_soci'
+          AND name IN ('bosocial_BS01', 'categ_bo_social', 'product_uom_day', 'categ_uom_day')
+    """)
+
+    logger.info("bosocial_BS01 and product_uom_day deactivated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa_soci/migrations/5.0.25.0/post-0001_deactivate_bosocial.py
+++ b/som_polissa_soci/migrations/5.0.25.0/post-0001_deactivate_bosocial.py
@@ -61,7 +61,7 @@ def up(cursor, installed_version):
           AND name IN (
             'som_invoice_active_bo_social',
             'som_invoice_start_date_bo_social',
-            'som_invoice_end_date_bo_social',
+            'som_invoice_end_date_bo_social'
           )
     """)
     logger.info("Deleted ir_model_data entries for bo social configs")

--- a/som_polissa_soci/models/giscedata_facturacio.py
+++ b/som_polissa_soci/models/giscedata_facturacio.py
@@ -2,7 +2,6 @@
 
 from osv import osv, fields
 from tools.translate import _
-from datetime import datetime
 
 
 class GiscedataFacturacioFacturador(osv.osv):
@@ -22,39 +21,16 @@ class GiscedataFacturacioFacturador(osv.osv):
             context = {}
         fact_obj = self.pool.get("giscedata.facturacio.factura")
         polissa_obj = self.pool.get("giscedata.polissa")
-        pricelist_version_o = self.pool.get("product.pricelist.version")
         product_obj = self.pool.get("product.product")
         factures_creades = super(GiscedataFacturacioFacturador, self).fact_via_lectures(
             cursor, uid, polissa_id, lot_id, context
         )
         ctx = context.copy()
 
-        start_date_bo_social = self.pool.get("res.config").get(
-            cursor, uid, "som_invoice_start_date_bo_social", "2017-07-01"
-        )
-        end_date_bo_social = self.pool.get("res.config").get(
-            cursor, uid, "som_invoice_end_date_bo_social", "2021-03-31"
-        )
-        # identificar el producte Bo Social
-        pbosocial_ids = product_obj.search(cursor, uid, [("default_code", "=", "BS01")])
-        active_bo_social = int(
-            self.pool.get("res.config").get(cursor, uid, "som_invoice_active_bo_social", "0")
-        )
-        pbosocial_id = len(pbosocial_ids) and pbosocial_ids[0]
-        fes_bo_social = pbosocial_id and active_bo_social or False
-
         factures_creades_modificables = []
         donatiu_pol = polissa_obj.read(cursor, uid, polissa_id, ["donatiu"], ctx)["donatiu"]
         if donatiu_pol:
             factures_creades_modificables = factures_creades
-        elif fes_bo_social:
-            # Si la pòlissa té donatiu, ja són totes modificables
-            factures_dates = fact_obj.read(cursor, uid, factures_creades, ["data_inici"], ctx)
-            factures_creades_modificables = [
-                f["id"]
-                for f in factures_dates
-                if f["data_inici"] >= start_date_bo_social and f["data_inici"] <= end_date_bo_social
-            ]
 
         if factures_creades_modificables:
             # identificar el producte donacions
@@ -90,96 +66,6 @@ class GiscedataFacturacioFacturador(osv.osv):
                             "name": p_br.description,
                         }
                         self.crear_linia(cursor, uid, fact.id, vals, ctx)
-                    # Only invoices with start date after 'start_date_bo_social'
-                    if (
-                        fes_bo_social
-                        and fact.data_inici >= start_date_bo_social
-                        and fact.data_inici <= end_date_bo_social
-                    ):
-                        dmn = [
-                            ("pricelist_id", "=", fact.llista_preu.id),
-                            ("active", "=", True),
-                            "|",
-                            "|",
-                            "|",
-                            # El primer detecta aquest cas:
-                            # factura:       |-------------|
-                            # l.preus: ...---------|
-                            "&",
-                            ("date_end", ">=", fact.data_inici),
-                            ("date_end", "<=", fact.data_final),
-                            # El segon detecta aquest altre cas:
-                            # factura:       |-------------|
-                            # l.preus:             |-------------|
-                            # I també aquest altre:
-                            # factura:       |-------------|
-                            # l.preus:             |-----------...
-                            # Tant el primer com el segon domini detecten aquest:
-                            # factura:       |-------------|
-                            # l.preus:          |-------|
-                            "&",
-                            ("date_start", ">=", fact.data_inici),
-                            ("date_start", "<=", fact.data_final),
-                            # El tercer detecta aquest cas:
-                            # factura:       |-------------|
-                            # l.preus:   |---------------------|
-                            "&",
-                            ("date_start", "<=", fact.data_inici),
-                            ("date_end", ">=", fact.data_final),
-                            # I aquest últim:
-                            # factura:       |-------------|
-                            # l.preus:   |---------------------...
-                            "&",
-                            ("date_start", "<=", fact.data_inici),
-                            ("date_end", "=", False),
-                        ]
-                        pricelist_version_ids = pricelist_version_o.search(
-                            cursor, uid, dmn, context=context
-                        )
-                        pricelist_version_f = ["date_start", "date_end"]
-                        pricelist_version_vs = pricelist_version_o.read(
-                            cursor, uid, pricelist_version_ids, pricelist_version_f, context=context
-                        )
-                        for pricelist_version_v in pricelist_version_vs:
-                            # Si la factura és del diari d'energia s'afegeix la
-                            # línia de factura rel·lacionada amb el producte Bo
-                            # Social.
-                            # S'afegeix una linia per cada canvi de preus que hi
-                            # hagi
-                            ctx.update({"lang": fact.partner_id.lang})
-                            p_br = product_obj.browse(cursor, uid, pbosocial_id, ctx)
-
-                            data_desde_plv = datetime.strptime(
-                                pricelist_version_v["date_start"], "%Y-%m-%d"
-                            )
-                            date_bo_social = datetime.strptime(end_date_bo_social, "%Y-%m-%d")
-                            if data_desde_plv > date_bo_social:
-                                continue
-
-                            data_desde_inv = datetime.strptime(fact.data_inici, "%Y-%m-%d")
-
-                            data_fins_plv = datetime.max
-                            if pricelist_version_v["date_end"]:
-                                data_fins_plv = datetime.strptime(
-                                    pricelist_version_v["date_end"], "%Y-%m-%d"
-                                )
-
-                            data_fins_inv = datetime.strptime(fact.data_final, "%Y-%m-%d")
-
-                            data_desde = max(data_desde_plv, data_desde_inv)
-                            data_final = min(data_fins_plv, data_fins_inv)
-
-                            vals = {
-                                "data_desde": data_desde.strftime("%Y-%m-%d"),
-                                "data_fins": data_final.strftime("%Y-%m-%d"),
-                                "uos_id": p_br.uom_id.id,
-                                "quantity": (data_final - data_desde).days + 1,
-                                "multi": 1,
-                                "product_id": pbosocial_id,
-                                "tipus": "altres",
-                                "name": p_br.description,
-                            }
-                            self.crear_linia(cursor, uid, fact.id, vals, ctx)
 
         return factures_creades
 

--- a/som_polissa_soci/tests/tests_facturacio.py
+++ b/som_polissa_soci/tests/tests_facturacio.py
@@ -1,155 +1,44 @@
 # -*- coding: utf-8 -*-
 from destral import testing
-from destral.transaction import Transaction
 import json
 
 
-class TestsFacturacioBoSocial(testing.OOTestCase):
-    def setUp(self):
-        self.txn = Transaction().start(self.database)
-
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        pl_item_o = pool.get("product.pricelist.item")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-        pl_version15_id = self.get_object_id("giscedata_tarifas_peajes_20150101", "boe_312_2014")
-        pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
-        pl_version17_id = self.get_object_id("giscedata_tarifas_peajes_20170101", "boe_314_2016")
-        pl_version18_id = self.get_object_id("giscedata_tarifas_peajes_20180101", "boe_314_2017")
-
-        self.preu15 = 0.02
-        self.preu16 = 0.01
-        self.preu17 = 0.04
-        self.preu18 = 0.03
-
-        # Afegim una regla a la llista de preus base (versió del 2015): la del
-        # producte de BS.
-        pl_item_cv = {
-            "product_id": product_bs_id,
-            "price_version_id": pl_version15_id,
-            "base_price": self.preu15,
-            "base": -3,  # Pricelist item price
-        }
-        pl_item_o.create(cursor, uid, pl_item_cv)
-        # El mateix d'abans pero per la versió del 2016
-        pl_item_cv["price_version_id"] = pl_version16_id
-        pl_item_cv["base_price"] = self.preu16
-        pl_item_o.create(cursor, uid, pl_item_cv)
-        # I per la del 2017
-        pl_item_cv["price_version_id"] = pl_version17_id
-        pl_item_cv["base_price"] = self.preu17
-        pl_item_o.create(cursor, uid, pl_item_cv)
-        # I per la del 2018
-        pl_item_cv["price_version_id"] = pl_version18_id
-        pl_item_cv["base_price"] = self.preu18
-        pl_item_o.create(cursor, uid, pl_item_cv)
-
-    def tearDown(self):
-        self.txn.stop()
-
+class TestsFacturacioDonatiu(testing.OOTestCaseWithCursor):
     def get_object_id(self, module, obj_ref):
         cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
         irmd_o = pool.get("ir.model.data")
         object_id = irmd_o.get_object_reference(cursor, uid, module, obj_ref)[1]
         return object_id
 
-    def test_add_bono_social_lines_case_a(self):
+    def test_add_donatiu_line(self):
         """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas A: la factura està integrament "dins" de la llista de preus::
-
-            factura:       |-------------|
-            l.preus:   |---------------------|
+        Comprova que s'afegeix una línia de donatiu (DN01) a la factura
+        quan la pòlissa té el donatiu activat.
 
         @return:
         """
         cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
         polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
         wiz_o = pool.get("wizard.manual.invoice")
         linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
 
         polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
+        product_dn01_id = self.get_object_id("som_polissa_soci", "dona_DN01")
 
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2016-03-03"
 
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
-        polissa_wv = {"soci": partner_id, "data_ultima_lectura": data_lectura_inici}
-        polissa_o.write(cursor, uid, polissa_id, polissa_wv)
-
-        # Activem la pòlissa
-        polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
-
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2016-01-01")
-
-        # Facturem
-        wiz_cv = {
-            "polissa_id": polissa_id,
-            "journal_id": journal_id,
-            "date_start": data_lectura_inici,
-            "date_end": data_lectura_final,
-        }
-        wiz_id = wiz_o.create(cursor, uid, wiz_cv)
-        wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
-        wiz_o = wiz_o.browse(cursor, uid, wiz_id)
-
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
-        invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
-
-        # Ha de tenir només una línia de BS
-        self.assertEqual(len(linia_bs_ids), 1)
-
-        # Comprovem que el preu és l'adequat
-        linia_factura_v = linia_factura_o.read(cursor, uid, linia_bs_ids[0], ["price_subtotal"])
-        self.assertEqual(linia_factura_v["price_subtotal"], (30 + 1) * self.preu16)
-
-    def test_add_bono_social_lines_case_b(self):
-        """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas B: hi ha un canvi de preus en mig del periode de facturació::
-
-            factura:       |-------------|
-            l.preus:   |----------|----------|
-
-        @return:
-        """
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
-        wiz_o = pool.get("wizard.manual.invoice")
-        linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
-
-        polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
-        journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
-        partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-
-        data_lectura_inici = "2016-02-02"
-        data_lectura_final = "2017-01-31"
-
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
         polissa_wv = {
-            "data_ultima_lectura": data_lectura_inici,
             "soci": partner_id,
-            "data_baixa": data_lectura_final,
+            "data_ultima_lectura": data_lectura_inici,
+            "donatiu": True,
         }
         polissa_o.write(cursor, uid, polissa_id, polissa_wv)
 
-        # Activem la pòlissa
         polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
 
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2016-01-01")
-
-        # Facturem
         wiz_cv = {
             "polissa_id": polissa_id,
             "journal_id": journal_id,
@@ -160,368 +49,12 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
         wiz_o = wiz_o.browse(cursor, uid, wiz_id)
 
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
         invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
+        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_dn01_id)]
+        linia_dn01_ids = linia_factura_o.search(cursor, uid, dmn)
 
-        # Ha de tenir exactament 2 línies de BS
-        self.assertEqual(len(linia_bs_ids), 2)
+        self.assertEqual(len(linia_dn01_ids), 1)
 
-        # Comprovem que el preu és l'adequat
-        import_linies = {"2016": (333 + 1) * self.preu16, "2017": (30 + 1) * self.preu17}
-        linia_factura_f = ["price_subtotal", "data_desde"]
-        linia_factura_vs = linia_factura_o.read(cursor, uid, linia_bs_ids, linia_factura_f)
-        for linia_factura_v in linia_factura_vs:
-            year = linia_factura_v["data_desde"][:4]
-            self.assertEqual(linia_factura_v["price_subtotal"], import_linies[year])
-
-    def test_add_bono_social_lines_case_c(self):
-        """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas C: hi ha n canvis de preus en mig del periode de facturació::
-
-            factura:       |-------------|
-            l.preus:   |------|-------|------|
-
-        En aquest cas 2 canvis de preus.
-        @return:
-        """
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
-        lectura_o = pool.get("giscedata.lectures.lectura")
-        wiz_o = pool.get("wizard.manual.invoice")
-        linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
-
-        polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
-        journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
-        partner_id = self.get_object_id("base", "res_partner_agrolait")
-        lectura_id = self.get_object_id("giscedata_facturacio", "lectura_0006")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-
-        data_lectura_inici = "2016-02-02"
-        data_lectura_final = "2018-01-31"
-
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
-        polissa_wv = {
-            "data_ultima_lectura": data_lectura_inici,
-            "soci": partner_id,
-            "data_baixa": data_lectura_final,
-        }
-        polissa_o.write(cursor, uid, polissa_id, polissa_wv)
-
-        # Activem la pòlissa
-        polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
-
-        # Afegim una lectura per forçar la facturació a tres versions de la
-        # llista de preus
-        lectura_wv = {"name": data_lectura_final, "lectura": 20}
-        lectura_o.copy(cursor, uid, lectura_id, lectura_wv)
-
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2016-01-01")
-
-        # Facturem
-        wiz_cv = {
-            "polissa_id": polissa_id,
-            "journal_id": journal_id,
-            "date_start": data_lectura_inici,
-            "date_end": data_lectura_final,
-        }
-        wiz_id = wiz_o.create(cursor, uid, wiz_cv)
-        wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
-        wiz_o = wiz_o.browse(cursor, uid, wiz_id)
-
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
-        invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
-
-        # Ha de tenir exactament 3 línies de BS
-        self.assertEqual(len(linia_bs_ids), 3)
-
-        # Comprovem que el preu és l'adequat
-        import_linies = {
-            "2016": (333 + 1) * self.preu16,
-            "2017": (364 + 1) * self.preu17,
-            "2018": (30 + 1) * self.preu18,
-        }
-        linia_factura_f = ["price_subtotal", "data_desde"]
-        linia_factura_vs = linia_factura_o.read(cursor, uid, linia_bs_ids, linia_factura_f)
-        for linia_factura_v in linia_factura_vs:
-            year = linia_factura_v["data_desde"][:4]
-            self.assertAlmostEqual(linia_factura_v["price_subtotal"], import_linies[year])
-
-    def test_add_bono_social_lines_case_d(self):
-        """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas D: com el cas A però la versió no té data final::
-
-            factura:       |-------------|
-            l.preus:   |-------------------...
-
-        @return:
-        """
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
-        wiz_o = pool.get("wizard.manual.invoice")
-        linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
-        pl_version_o = pool.get("product.pricelist.version")
-
-        polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
-        journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
-        partner_id = self.get_object_id("base", "res_partner_agrolait")
-        pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
-        pl_version17_id = self.get_object_id("giscedata_tarifas_peajes_20170101", "boe_314_2016")
-        pl_version18_id = self.get_object_id("giscedata_tarifas_peajes_20180101", "boe_314_2017")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-
-        data_lectura_inici = "2016-02-02"
-        data_lectura_final = "2016-03-03"
-
-        # Desactivem les versions posteriors a la del 2016
-        pl_version_wv = {"active": False}
-        pl_version_post16_ids = [pl_version17_id, pl_version18_id]
-        pl_version_o.write(cursor, uid, pl_version_post16_ids, pl_version_wv)
-        # I forcem que la versión de preus del 2016 no tingui final
-        pl_version_wv = {"date_end": False}
-        pl_version_o.write(cursor, uid, pl_version16_id, pl_version_wv)
-
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
-        polissa_wv = {
-            "data_ultima_lectura": data_lectura_inici,
-            "soci": partner_id,
-        }
-        polissa_o.write(cursor, uid, polissa_id, polissa_wv)
-
-        # Activem la pòlissa
-        polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
-
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2016-01-01")
-
-        # Facturem
-        wiz_cv = {
-            "polissa_id": polissa_id,
-            "journal_id": journal_id,
-            "date_start": data_lectura_inici,
-            "date_end": data_lectura_final,
-        }
-        wiz_id = wiz_o.create(cursor, uid, wiz_cv)
-        wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
-        wiz_o = wiz_o.browse(cursor, uid, wiz_id)
-
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
-        invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
-
-        # Ha de tenir exactament 3 línies de BS
-        self.assertEqual(len(linia_bs_ids), 1)
-
-        # No cal testejar l'import de la linia ja que ja ho fa el cas A
-
-    def test_add_bono_social_lines_case_e(self):
-        """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas B: hi ha un canvi de preus en mig del periode de facturació::
-
-            factura:       |-------------|
-            l.preus:   |----------|----------...
-
-        @return:
-        """
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
-        wiz_o = pool.get("wizard.manual.invoice")
-        pl_version_o = pool.get("product.pricelist.version")
-        linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
-
-        polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
-        journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
-        partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-        pl_version17_id = self.get_object_id("giscedata_tarifas_peajes_20170101", "boe_314_2016")
-        pl_version18_id = self.get_object_id("giscedata_tarifas_peajes_20180101", "boe_314_2017")
-
-        data_lectura_inici = "2016-02-02"
-        data_lectura_final = "2017-01-31"
-
-        # Desactivem la versió del 2018
-        pl_version_wv = {"active": False}
-        pl_version_o.write(cursor, uid, pl_version18_id, pl_version_wv)
-        # I forcem que la versión de preus del 2017 no tingui final
-        pl_version_wv = {"date_end": False}
-        pl_version_o.write(cursor, uid, pl_version17_id, pl_version_wv)
-
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
-        polissa_wv = {
-            "data_ultima_lectura": data_lectura_inici,
-            "soci": partner_id,
-            "data_baixa": data_lectura_final,
-        }
-        polissa_o.write(cursor, uid, polissa_id, polissa_wv)
-
-        # Activem la pòlissa
-        polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
-
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2016-01-01")
-
-        # Facturem
-        wiz_cv = {
-            "polissa_id": polissa_id,
-            "journal_id": journal_id,
-            "date_start": data_lectura_inici,
-            "date_end": data_lectura_final,
-        }
-        wiz_id = wiz_o.create(cursor, uid, wiz_cv)
-        wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
-        wiz_o = wiz_o.browse(cursor, uid, wiz_id)
-
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
-        invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
-
-        # Ha de tenir exactament 2 línies de BS
-        self.assertEqual(len(linia_bs_ids), 2)
-
-        # No cal testejar l'import de la linia ja que ja ho fa el cas B
-
-    def test_add_bono_social_lines_case_f(self):
-        """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas F: el bo social deixa de ser d'aplicació amb la segona llista de preus
-
-            factura:       |--------------|
-            l.preus:   |----------Fi BS|
-
-        @return:
-        """
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
-        wiz_o = pool.get("wizard.manual.invoice")
-        pl_version_o = pool.get("product.pricelist.version")
-        linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
-
-        polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
-        journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
-        partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-        pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
-        data_lectura_inici = "2016-02-02"
-        data_lectura_final = "2017-01-31"
-
-        end_plv_16 = pl_version_o.read(cursor, uid, pl_version16_id, ["date_end"])["date_end"]
-
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
-        polissa_wv = {
-            "data_ultima_lectura": data_lectura_inici,
-            "soci": partner_id,
-            "data_baixa": data_lectura_final,
-        }
-        polissa_o.write(cursor, uid, polissa_id, polissa_wv)
-
-        # Activem la pòlissa
-        polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
-
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2016-01-01")
-        varconf_o.set(cursor, uid, "som_invoice_end_date_bo_social", end_plv_16)
-
-        # Facturem
-        wiz_cv = {
-            "polissa_id": polissa_id,
-            "journal_id": journal_id,
-            "date_start": data_lectura_inici,
-            "date_end": data_lectura_final,
-        }
-        wiz_id = wiz_o.create(cursor, uid, wiz_cv)
-        wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
-        wiz_o = wiz_o.browse(cursor, uid, wiz_id)
-
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
-        invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
-
-        # Ha de tenir exactament 2 línies de BS
-        self.assertEqual(len(linia_bs_ids), 1)
-
-        # No cal testejar l'import de la linia ja que ja ho fa el cas B
-        # Comprovem que el preu és l'adequat
-        import_linia = (333 + 1) * self.preu16
-        linia_factura_f = ["price_subtotal", "data_desde"]
-        linia_factura_v = linia_factura_o.read(cursor, uid, linia_bs_ids[0], linia_factura_f)
-        self.assertEqual(linia_factura_v["price_subtotal"], import_linia)
-
-    def test_add_bono_social_lines_case_g(self):
-        """
-        Comprova que s'afegeix una línia de bono social (BS01) a la factura.
-        Cas F: el bo social deixa de ser d'aplicació amb la segona llista de preus
-
-            factura:                 |--------------|
-            l.preus:   |-----Fi BS|
-
-        @return:
-        """
-        cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
-        polissa_o = pool.get("giscedata.polissa")
-        varconf_o = pool.get("res.config")
-        wiz_o = pool.get("wizard.manual.invoice")
-        pl_version_o = pool.get("product.pricelist.version")
-        linia_factura_o = pool.get("giscedata.facturacio.factura.linia")
-
-        polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
-        journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
-        partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
-        pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
-        data_lectura_inici = "2016-02-02"
-        data_lectura_final = "2017-01-31"
-
-        pl_version_o.read(cursor, uid, pl_version16_id, ["date_end"])["date_end"]
-
-        # Configurem la pòlissa per tal de poder activar-la i facturar-la.
-        polissa_wv = {
-            "data_ultima_lectura": data_lectura_inici,
-            "soci": partner_id,
-            "data_baixa": data_lectura_final,
-        }
-        polissa_o.write(cursor, uid, polissa_id, polissa_wv)
-
-        # Activem la pòlissa
-        polissa_o.send_signal(cursor, uid, [polissa_id], ["validar", "contracte"])
-
-        # Configurem algunes variables abans de facturar
-        varconf_o.set(cursor, uid, "som_invoice_active_bo_social", 1)
-        varconf_o.set(cursor, uid, "som_invoice_start_date_bo_social", "2014-01-01")
-        varconf_o.set(cursor, uid, "som_invoice_end_date_bo_social", "2015-01-01")
-
-        # Facturem
-        wiz_cv = {
-            "polissa_id": polissa_id,
-            "journal_id": journal_id,
-            "date_start": data_lectura_inici,
-            "date_end": data_lectura_final,
-        }
-        wiz_id = wiz_o.create(cursor, uid, wiz_cv)
-        wiz_o.action_manual_invoice(cursor, uid, [wiz_id])
-        wiz_o = wiz_o.browse(cursor, uid, wiz_id)
-
-        # Busquem a les linies de la factura alguna que correspongui a la del BS
-        invoice_id = json.loads(wiz_o.invoice_ids)[0]
-        dmn = [("factura_id", "=", invoice_id), ("product_id", "=", product_bs_id)]
-        linia_bs_ids = linia_factura_o.search(cursor, uid, dmn)
-
-        # Ha de tenir exactament 2 línies de BS
-        self.assertEqual(len(linia_bs_ids), 0)
+        linia_factura_v = linia_factura_o.read(
+            cursor, uid, linia_dn01_ids[0], ["price_unit", "quantity"])
+        self.assertEqual(linia_factura_v["price_unit"], 0.01)

--- a/som_polissa_soci/tests/tests_facturacio.py
+++ b/som_polissa_soci/tests/tests_facturacio.py
@@ -10,7 +10,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
 
         cursor, uid, pool = (self.txn.cursor, self.txn.user, self.openerp.pool)
         pl_item_o = pool.get("product.pricelist.item")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
         pl_version15_id = self.get_object_id("giscedata_tarifas_peajes_20150101", "boe_312_2014")
         pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
         pl_version17_id = self.get_object_id("giscedata_tarifas_peajes_20170101", "boe_314_2016")
@@ -71,7 +71,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
 
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2016-03-03"
@@ -129,7 +129,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
 
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2017-01-31"
@@ -198,7 +198,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
         lectura_id = self.get_object_id("giscedata_facturacio", "lectura_0006")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
 
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2018-01-31"
@@ -277,7 +277,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
         pl_version17_id = self.get_object_id("giscedata_tarifas_peajes_20170101", "boe_314_2016")
         pl_version18_id = self.get_object_id("giscedata_tarifas_peajes_20180101", "boe_314_2017")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
 
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2016-03-03"
@@ -345,7 +345,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
         pl_version17_id = self.get_object_id("giscedata_tarifas_peajes_20170101", "boe_314_2016")
         pl_version18_id = self.get_object_id("giscedata_tarifas_peajes_20180101", "boe_314_2017")
 
@@ -415,7 +415,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
         pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2017-01-31"
@@ -484,7 +484,7 @@ class TestsFacturacioBoSocial(testing.OOTestCase):
         polissa_id = self.get_object_id("giscedata_polissa", "polissa_0001")
         journal_id = self.get_object_id("giscedata_facturacio", "facturacio_journal_energia")
         partner_id = self.get_object_id("base", "res_partner_agrolait")
-        product_bs_id = self.get_object_id("som_polissa_soci", "bosocial_BS01")
+        product_bs_id = self.get_object_id("giscedata_repercusio_bo_social", "bosocial_BS01")
         pl_version16_id = self.get_object_id("giscedata_tarifas_peajes_20160101", "boe_302_2015")
         data_lectura_inici = "2016-02-02"
         data_lectura_final = "2017-01-31"

--- a/som_webforms_helpers/__terp__.py
+++ b/som_webforms_helpers/__terp__.py
@@ -12,6 +12,7 @@
         "som_facturacio_switching",
         "som_generationkwh",
         "som_polissa_condicions_generals",
+        "giscedata_repercusio_bo_social",
     ],
     "init_xml": [],
     "demo_xml": [

--- a/som_webforms_helpers/giscedata_polissa_tarifa.py
+++ b/som_webforms_helpers/giscedata_polissa_tarifa.py
@@ -89,7 +89,8 @@ class GiscedataPolissaTarifa(osv.osv):
         imd_obj = self.pool.get("ir.model.data")
         prod_obj = self.pool.get("product.product")
 
-        bs_id = imd_obj.get_object_reference(cursor, uid, "som_polissa_soci", "bosocial_BS01")[1]
+        bs_id = imd_obj.get_object_reference(
+            cursor, uid, "giscedata_repercusio_bo_social", "bosocial_BS01")[1]
         prod = prod_obj.browse(cursor, uid, bs_id)
 
         price = pricelist.price_get(bs_id, 1, 1, context)[pricelist.id]

--- a/som_webforms_helpers/giscedata_polissa_tarifa.py
+++ b/som_webforms_helpers/giscedata_polissa_tarifa.py
@@ -207,20 +207,25 @@ class GiscedataPolissaTarifa(osv.osv):
 
         fiscal_position_data = []
 
-        start_date_iva_reduit = conf_obj.get(
-            cursor, uid, "charge_iva_10_percent_when_start_date", "2021-06-01"
-        )
-        end_date_iva_reduit = conf_obj.get(
-            cursor, uid, "charge_iva_10_percent_end_date", "2024-12-31"
-        )
+        iva_10_active = eval(conf_obj.get(
+            cursor, uid, 'charge_iva_10_percent_when_available', '0'
+        ))
 
-        try:
-            has_to_charge_iva_10 = omie_obj.has_to_charge_10_percent_requeriments_oficials(
-                cursor, uid, datetime.strftime(datetime.today(), '%Y-%m-%d'), max_power / 1000)
-        except Exception:
-            has_to_charge_iva_10 = False
+        has_to_charge_iva_10 = False
+        if iva_10_active:
+            try:
+                has_to_charge_iva_10 = omie_obj.has_to_charge_10_percent_requeriments_oficials(
+                    cursor, uid, datetime.strftime(datetime.today(), '%Y-%m-%d'), max_power / 1000)
+            except Exception:
+                pass
 
         if has_to_charge_iva_10:
+            start_date_iva_reduit = conf_obj.get(
+                cursor, uid, "charge_iva_10_percent_when_start_date", "2021-06-01"
+            )
+            end_date_iva_reduit = conf_obj.get(
+                cursor, uid, "charge_iva_10_percent_end_date", "2024-12-31"
+            )
             fiscal_position_id = imd_obj.get_object_reference(
                 cursor, uid, "som_polissa_condicions_generals", "fp_iva_reduit"
             )[1]

--- a/som_webforms_helpers/tests/test_tarifes.py
+++ b/som_webforms_helpers/tests/test_tarifes.py
@@ -131,7 +131,7 @@ class tarifes_tests(testing.OOTestCase):
             # Assert
             prices = {
                 "current": {
-                    "bo_social": {"unit": "\xe2\x82\xac/dia", "value": 0.0},
+                    "bo_social": {"unit": "\xe2\x82\xac/Dia", "value": 0.0},
                     "comptador": {"unit": "\xe2\x82\xac/mes", "value": 0.0},
                     "end_date": False,
                     "energia": {
@@ -183,7 +183,7 @@ class tarifes_tests(testing.OOTestCase):
             )
             prices = {
                 "current": {
-                    "bo_social": {"unit": "\xe2\x82\xac/dia", "value": 0.0},
+                    "bo_social": {"unit": "\xe2\x82\xac/Dia", "value": 0.0},
                     "comptador": {"unit": "\xe2\x82\xac/mes", "value": 0.0},
                     "end_date": False,
                     "energia": {
@@ -207,7 +207,7 @@ class tarifes_tests(testing.OOTestCase):
                 },
                 "history": [
                     {
-                        "bo_social": {"unit": "\xe2\x82\xac/dia", "value": 0.0},
+                        "bo_social": {"unit": "\xe2\x82\xac/Dia", "value": 0.0},
                         "comptador": {"unit": "\xe2\x82\xac/mes", "value": 0.0},
                         "end_date": "2022-12-31",
                         "energia": {
@@ -403,7 +403,7 @@ class tarifes_tests(testing.OOTestCase):
             )
             # Assert
             prices = {
-                "bo_social": {"uom": "\xe2\x82\xac/dia", "value": 0.0},
+                "bo_social": {"uom": "\xe2\x82\xac/Dia", "value": 0.0},
                 "comptador": {"uom": "\xe2\x82\xac/mes", "value": 0.0},
                 "end_date": "2022-12-31",
                 "gkwh": {


### PR DESCRIPTION
## Objectiu
Millores en el backend del mail d'enviament de preus, es treuen coses hardcodejades per evitar deixar-nos coses en cada canvi.

A més a més, millora les CCPP amb petits refactors i agafar també el IVA i IE dinàmicament.

També arregla el modul som_polissa_soci que crea repetit el bo social, que ja està a un modul de gisce, i feia que la funcio get_bo_social_price no funciones.

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1605
https://somenergia.openproject.com/wp/1604

## Atenció
Després d'actualitzar (scripts migració), cal omplir les variables de configuració:
- default_iva_21_tax_id
- default_iese_tax_id
- serveis_ajust_estimated_kwh_price _(aquesta ja te valor per defecte, no és imprescindible)_

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions
