### PR TITLE
🐛 fix: handle boolean lang_partner across all report usages

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -38,6 +38,13 @@ compl_cat = "Facturació Complementaria imputada per part de la Distribuïdora"
 compl_cas = "Facturación Complementaria imputada por parte de la Distribuidora"
 
 
+def get_lang_partner(fact):
+    lang = fact.lang_partner
+    if isinstance(lang, basestring):
+        return lang
+    return 'es_ES'
+
+
 # -----------------------------------
 # helper functions
 # -----------------------------------
@@ -1235,7 +1242,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         """
         return a dictionary with all GdO clock data needs, data from 2020
         """
-        lang = fact.lang_partner.lower()[0:2]
+        lang = get_lang_partner(fact).lower()[0:2]
 
         example_data_2020 = """{{
                 'wind_power': 359390,
@@ -1279,7 +1286,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         """
         returns a dictionary with all the flags data needed for the flag component
         """
-        lang = fact.lang_partner.lower()[0:2]
+        lang = get_lang_partner(fact).lower()[0:2]
         data = {
             "is_autoconsum": te_autoconsum(fact, pol),  # fact.te_autoconsum
             "autoconsum_flag": "flag_auto_little_{}.png".format(lang),
@@ -1407,7 +1414,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         diari_factura_actual_eur = fact.total_energia / (dies_factura or 1.0)
         diari_factura_actual_kwh = (fact.energia_kwh * 1.0) / (dies_factura or 1.0)
 
-        fact.lang_partner
+        get_lang_partner(fact)
 
         data = {
             "periodes_a": periodes_a,
@@ -1505,7 +1512,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "periodes_a": periodes_a,
             "is_visible": has_adjust_a
             or (te_autoconsum(fact, pol) and has_readings_g and has_adjust_g),
-            "lang": fact.lang_partner,
+            "lang": get_lang_partner(fact),
             "has_autoconsum": te_autoconsum(fact, pol),
         }
 
@@ -1714,8 +1721,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         for h_js in historic_js:
             periode = h_js["mes"].split("/")
             if (int(periode[0]) >= 6 and int(periode[1]) == 21) or (int(periode[1]) > 21):
-                h_js["labels"] = labels[fact.lang_partner]
-            h_js["mes"] = shortMonths[fact.lang_partner][periode[0]] + "/" + periode[1]
+                h_js["labels"] = labels[get_lang_partner(fact)]
+            h_js["mes"] = shortMonths[get_lang_partner(fact)][periode[0]] + "/" + periode[1]
 
         mes_any_inicial = (
             datetime.strptime(fact.data_inici, "%Y-%m-%d") - timedelta(days=365)
@@ -1771,7 +1778,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "show_mean_zipcode_consumption": show_mean_zipcode_consumption,
             "zipcode": fact.cups_id.dp,
             "mean_zipcode_consumption": mean_zipcode_consumption,
-            "average_text": average_text[fact.lang_partner],
+            "average_text": average_text[get_lang_partner(fact)],
         }
 
         return data
@@ -1871,7 +1878,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "comer_phone": ".".join([cphone[i: i + 3] for i in range(0, len(cphone), 3)])
             if "." not in cphone
             else cphone,
-            "lang": fact.lang_partner,
+            "lang": get_lang_partner(fact),
         }
         return data
 
@@ -2237,7 +2244,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "invoice_comment": invoice_comment,
             "has_web": bool(pol.distribuidora.website),
             "web_distri": pol.distribuidora.website,
-            "language": fact.lang_partner,
+            "language": get_lang_partner(fact),
             "distri_name": pol.distribuidora.name,
         }
         return data
@@ -2422,7 +2429,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             self.cursor, self.uid, "gdo_and_impact_yearly_switch_date", "2099-05-01"
         )
 
-        lang_partner = fact.lang_partner if isinstance(fact.lang_partner, basestring) else 'es_ES'
+        lang = get_lang_partner(fact)
         data = {
             "is_visible": fact.date_invoice < swich_date,
             "year_graph": 2020,
@@ -2430,7 +2437,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             "inport_export_value": 1.3,
             "mix_image_som_energia": "electricity_information_mix_som.png",
             "mix_image_rest": "electricity_information_mix_rest_"
-            + lang_partner.lower()
+            + lang.lower()
             + "_2021.png",
             "renovable": {
                 "som_energia": "100%",
@@ -4146,7 +4153,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         ).days + 1
         diari_factura_actual_eur = fact.total_energia / (dies_factura or 1.0)
         diari_factura_actual_kwh = (fact.energia_kwh * 1.0) / (dies_factura or 1.0)
-        lang = fact.lang_partner.lower()
+        lang = get_lang_partner(fact).lower()
 
         data = {
             "diari_factura_actual_eur": diari_factura_actual_eur,
@@ -4273,12 +4280,12 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         if not required_max_requested_powers:
             return {
                 "is_visible": False,
-                "lang": fact.lang_partner.lower(),
+                "lang": get_lang_partner(fact).lower(),
             }
         qr_data = self.get_codi_qr(fact)
         data = {
             "is_visible": True,
-            "lang": fact.lang_partner.lower(),
+            "lang": get_lang_partner(fact).lower(),
             "link_qr": qr_data["url"] if qr_data["url"] else "https://comparador.cnmc.gob.es/",
             "has_gkwh": te_gkwh(fact),
             "qr_image": qr_data["qr"],
@@ -4381,7 +4388,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             if l.tipus in ("altres", "cobrament") and l.invoice_line_id.product_id.code == "PBV"
         ]
 
-        lang = fact.lang_partner.lower()
+        lang = get_lang_partner(fact).lower()
         if lang == 'ca_es':
             link_help = 'https://ca.support.somenergia.coop/article/1371-que-es-el-flux-solar'
             link_ov_suns = 'https://oficinavirtual.somenergia.coop/ca/flux-solar/'

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -1815,7 +1815,7 @@ class Tests_FacturacioFacturaReport_invoice_details_comments(Tests_FacturacioFac
                 "invoice_comment": None,
                 "has_web": False,
                 "web_distri": False,
-                "language": False,
+                "language": 'es_ES',
                 "distri_name": u"Agrolait",
             },
         )
@@ -1853,7 +1853,7 @@ class Tests_FacturacioFacturaReport_invoice_details_comments(Tests_FacturacioFac
                 "invoice_comment": u"comment",
                 "has_web": False,
                 "web_distri": False,
-                "language": False,
+                "language": 'es_ES',
                 "distri_name": u"Agrolait",
             },
         )


### PR DESCRIPTION
## Objectiu

Arreglar el bug `AttributeError: 'bool' object has no attribute 'lower'` a tots els llocs on s'utilitza `lang_partner` al report de facturació, no només a un.

## Targeta on es demana o Incidència

Error detectat a producció (erp01): el mateix error que #1211 però en altres llocs del report.

## Comportament antic

Quan `lang_partner` és un boolean (False/True), cridar `.lower()` falla.

## Comportament nou

Nova funció `get_lang_partner(fact)` que retorna `lang_partner` si és string, sinó `'es_ES'`. Tots els usos de `fact.lang_partner` ara usen aquesta funció.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions