### PR TITLE
🐛 Error en el totalitzador de càrrecs i peatges de la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3202,7 +3202,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         data["header_multi"] = 4 if discount["is_visible"] else 2
         data["iva_column"] = has_iva_column(fact)
         data["is_visible"] = len(self.get_dates_desde(fact.linies_potencia)) == 1
-        data["total"] = sum([round(charges_lines_potencia[period]["preu_cargos"], 2) for period in periods if period in charges_lines_potencia])  # noqa: E501
+        data["total"] = sum([round(charges_lines_potencia[period]["atr_cargos"], 2) for period in periods if period in charges_lines_potencia])  # noqa: E501
         return data
 
     def get_component_invoice_details_info_td_data(self, fact, pol):


### PR DESCRIPTION
## Objectiu

En aplicar la pr https://github.com/Som-Energia/openerp_som_addons/pull/1182 es detecta que les "quesitos" de la tercera plana de peatges i càrrecs no estan be. 

## Targeta on es demana o Incidència

Error introduït el 30/04/2026 a la PR https://github.com/Som-Energia/openerp_som_addons/pull/1182

## Comportament antic

Error, informació incorrecta al gràfic de la tercera plana

## Comportament nou

Informació correcta al gràfic de la tercera plana

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
