### PR TITLE
💄Canvi de frase al pdf de la factura per boe de 7/2026 a 10/2026

### DIFF
--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Som Energia\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2026-04-29 11:27+0000\n"
-"PO-Revision-Date: 2026-04-29 09:30+0000\n"
+"POT-Creation-Date: 2026-05-05 17:06+0000\n"
+"PO-Revision-Date: 2026-05-05 15:08+0000\n"
 "Last-Translator: Som Energia <itcrowd@somenergia.coop>\n"
 "Language-Team: Spanish (Spain) (http://trad.gisce.net/projects/p/somenergia/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4263
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4293
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr "Energía Reactiva Capacitiva (kVArh)"
@@ -45,7 +45,7 @@ msgid "Reimprimir Pdf (no caché)"
 msgstr "Reimprimir Pdf (no caché)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3685
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3714
 msgid "Factura amb linies complementaries de tipus desconegut {}"
 msgstr "Factura con líneas complementarias de tipo desconocido {}"
 
@@ -55,8 +55,8 @@ msgid "Reimprimir factura en pdf"
 msgstr "Reimprimir factura en pdf"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2865
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2869
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2873
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2877
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr "calculada"
@@ -94,14 +94,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr "Reports Facturación SOM (Comercializadora)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4293
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4323
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2909
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2917
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr "sin lectura"
@@ -112,14 +112,14 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr "La lista de precio no es compatible con la tarifa de acceso."
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1054
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1061
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr "Variables que marcan el inicio y/o final de la aplicación del mecanismo del tope de gas no están configuradas"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2663
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2671
 msgid "(sense lectura)"
 msgstr "(sin lectura)"
 
@@ -129,15 +129,15 @@ msgid "Sortir"
 msgstr "Salir"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:229
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2861
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:236
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2869
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr "real"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4389
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4419
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4449
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
 msgid "Autoconsum compartit (kWh)"
 msgstr "Autoconsumo compartido (kWh)"
@@ -148,18 +148,18 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Invalid XML for View Architecture!"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4163
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4193
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr "Energía Activa (kWh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2859
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2867
 msgid "estimada"
 msgstr "estimada"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3628
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3636
 msgid ""
 "No s'han trobats F1's d'expedient de anomalia/frau al generar pdf per {}"
 msgstr "No se han encontrado F1's de expediente de anomalía/fraude al generar pdf por {}"
@@ -170,19 +170,19 @@ msgid "Reimpressió de pdf's de factura:"
 msgstr "Reimpresión de pdf's de factura:"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2594
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2602
 msgid " (Som Energia, SCCL)"
 msgstr "(Som Energia, SCCL)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:230
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:383
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:237
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:390
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr "estimada distribuidora"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4195
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4225
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr "Energía Excedentaria (kWh)"
@@ -193,7 +193,7 @@ msgid "wizard.reprint.invoice.som"
 msgstr "wizard.reprint.invoice.som"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2661
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2669
 msgid "(estimada)"
 msgstr "(estimada)"
 
@@ -208,18 +208,18 @@ msgid "State"
 msgstr "State"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4232
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4262
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr "Energía Reactiva Inductiva (kVArh)"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2595
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2603
 msgid "TRANSFERÈNCIA"
 msgstr "TRANSFERENCIA"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:231
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:238
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr "calculada por Som Energía"
@@ -235,7 +235,7 @@ msgid "E-Mail factura adjunta"
 msgstr "E-Mail factura adjunta"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2665
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2673
 msgid "(real)"
 msgstr "(real)"
 
@@ -2175,6 +2175,7 @@ msgid ""
 msgstr "%s kWh x 0,0005 €/kWh (aplicando Art 99.2 de la Ley 28/2014 sin bonificación del 85%%)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:187
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:224
 msgid ""
 "En virtut del Reial Decret-llei 7/2026, del 20 de març, l'Impost Especial "
 "sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al"
@@ -2202,13 +2203,6 @@ msgstr "%s kWh x 0,001 €/kWh (aplicando Art 99.2 de la Ley 28/2014)"
 msgid "%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014)"
 msgstr "%s kWh x 0,0005 €/kWh (aplicando Art 99.2 de la Ley 28/2014)"
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:224
-msgid ""
-"En virtut del Reial Decret-llei 7/2026, del 20 de març, l'impost Especial "
-"sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al"
-" 0,5%."
-msgstr "En virtud del Real Decreto-ley 7/2026, de 20 de marzo, el Impuesto Especial sobre la Electricidad aplicado a la factura se encuentra reducido del 5,11269632% al 0,5%."
-
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:249
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:265
 #, python-format
@@ -2223,9 +2217,9 @@ msgstr "En virtud del Real Decreto-ley 12/2021, de 24 de junio, el IVA aplicable
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:253
 msgid ""
-"En virtut del Reial Decret-llei 7/2026, del 20 de març, l’IVA aplicat a la "
+"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l’IVA aplicat a la "
 "factura es troba reduït del 21% al 10%."
-msgstr "En virtud del Real Decreto-ley 7/2026, de 20 de marzo, el IVA aplicado a la factura se encuentra reducido del 21% al 10%."
+msgstr "En virtud del Real Decreto-ley 10/2026, de 28 de abril, el IVA aplicado a la factura se encuentra reducido del 21% al 10%."
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_power/invoice_details_td_power.mako:10
 msgid "Facturació per potencia contractada"

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2026-04-29 11:27+0000\n"
-"PO-Revision-Date: 2026-04-29 11:27+0000\n"
+"POT-Creation-Date: 2026-05-05 17:06+0000\n"
+"PO-Revision-Date: 2026-05-05 17:06+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Generated-By: Babel 2.9.1\n"
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4263
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4293
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:7
 msgid "Energia Reactiva Capacitiva (kVArh)"
 msgstr ""
@@ -38,7 +38,7 @@ msgid "Reimprimir Pdf (no caché)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3685
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3714
 msgid "Factura amb linies complementaries de tipus desconegut {}"
 msgstr ""
 
@@ -48,8 +48,8 @@ msgid "Reimprimir factura en pdf"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2865
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2869
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2873
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2877
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:11
 msgid "calculada"
 msgstr ""
@@ -86,14 +86,14 @@ msgid "Reports Facturació SOM (Comercialitzadora)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4293
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4323
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:8
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:7
 msgid "Maxímetre (kW)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2909
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2917
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_energy/invoice_details_td_energy.mako:7
 msgid "sense lectura"
 msgstr ""
@@ -104,14 +104,14 @@ msgid "La llista de preu no és compatible amb la tarifa d'accés."
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1054
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:1061
 msgid ""
 "Variables que marquen l'inici i/o final de l'aplicació del mecanisme del "
 "topall de gas no estàn configurades"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2663
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2671
 msgid "(sense lectura)"
 msgstr ""
 
@@ -121,15 +121,15 @@ msgid "Sortir"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:229
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2861
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:236
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2869
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:9
 msgid "real"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4389
 #: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4419
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4449
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:11
 msgid "Autoconsum compartit (kWh)"
 msgstr ""
@@ -140,18 +140,18 @@ msgid "Invalid XML for View Architecture!"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4163
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4193
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:4
 msgid "Energia Activa (kWh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2859
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2867
 msgid "estimada"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3628
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:3636
 msgid "No s'han trobats F1's d'expedient de anomalia/frau al generar pdf per {}"
 msgstr ""
 
@@ -161,19 +161,19 @@ msgid "Reimpressió de pdf's de factura:"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2594
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2602
 msgid " (Som Energia, SCCL)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:230
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:383
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:237
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:390
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:12
 msgid "estimada distribuïdora"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4195
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4225
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:5
 msgid "Energia Excedentària (kWh)"
 msgstr ""
@@ -184,7 +184,7 @@ msgid "wizard.reprint.invoice.som"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2661
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2669
 msgid "(estimada)"
 msgstr ""
 
@@ -199,18 +199,18 @@ msgid "State"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4232
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:4262
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:6
 msgid "Energia Reactiva Inductiva (kVArh)"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2595
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2603
 msgid "TRANSFERÈNCIA"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:231
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:238
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:10
 msgid "calculada per Som Energia"
 msgstr ""
@@ -226,7 +226,7 @@ msgid "E-Mail factura adjunta"
 msgstr ""
 
 #. module: giscedata_facturacio_comer_som
-#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2665
+#: code:addons/giscedata_facturacio_comer_som/giscedata_facturacio_report.py:2673
 msgid "(real)"
 msgstr ""
 
@@ -2162,6 +2162,7 @@ msgid ""
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:187
+#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:224
 msgid ""
 "En virtut del Reial Decret-llei 7/2026, del 20 de març, l'Impost Especial"
 " sobre l'Electricitat aplicat a la factura es troba reduït del "
@@ -2189,13 +2190,6 @@ msgstr ""
 msgid "%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014)"
 msgstr ""
 
-#: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:224
-msgid ""
-"En virtut del Reial Decret-llei 7/2026, del 20 de març, l'impost Especial"
-" sobre l'Electricitat aplicat a la factura es troba reduït del "
-"5,11269632% al 0,5%."
-msgstr ""
-
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:249
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:265
 #, python-format
@@ -2210,7 +2204,7 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako:253
 msgid ""
-"En virtut del Reial Decret-llei 7/2026, del 20 de març, l’IVA aplicat a "
+"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l’IVA aplicat a "
 "la factura es troba reduït del 21% al 10%."
 msgstr ""
 

--- a/giscedata_facturacio_comer_som/migrations/5.0.25.5.0/post-0005_FIX_pdf_inv_the_boe_phrase_has_changed_from_7_2026_to_10_2026_migrate_translations.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.25.5.0/post-0005_FIX_pdf_inv_the_boe_phrase_has_changed_from_7_2026_to_10_2026_migrate_translations.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import logging
+from tools.translate import trans_load
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Updating translations")
+    trans_load(cursor, "{}/{}/i18n/es_ES.po".format(config['addons_path'], "giscedata_facturacio_comer_som"), 'es_ES')  # noqa: E501
+    logger.info("Translations succesfully updated.")
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
@@ -184,7 +184,7 @@ TABLA_101 = {
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_iese']))}
                 % elif l.tax_type == '0.5percent2026':
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_iese']))}
-                    ${_(u"En virtut del Reial Decret-llei 7/2026, del 20 de març, l'Impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
+                    ${_(u"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l'Impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
                 % else:
                     ${_(u"%s € x 5,11269%%") % (formatLang(l['base_iese']))}
                 % endif
@@ -221,7 +221,7 @@ TABLA_101 = {
                     ${_(u"%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014)") % (formatLang(l['base_amount']))}
                 % elif l.tax_type == '0.5percent2026':
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_amount']))}
-                    ${_(u"En virtut del Reial Decret-llei 7/2026, del 20 de març, l'impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
+                    ${_(u"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l'impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
                 % else:
                     ${_(u"%s € x 5,11269%%") % (formatLang(l['base_amount']))}
                 % endif
@@ -250,7 +250,7 @@ TABLA_101 = {
         %if l.disclaimer_21_to_5:
             ${_(u"En virtut del Reial Decret-llei 12/2021, del 24 de juny, l'IVA aplicable a la factura es troba reduït del 21% al 5%.")}
         %elif l.disclaimer_21_to_10:
-            ${_(u"En virtut del Reial Decret-llei 7/2026, del 20 de març, l’IVA aplicat a la factura es troba reduït del 21% al 10%.")}
+            ${_(u"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l’IVA aplicat a la factura es troba reduït del 21% al 10%.")}
         %endif
         </td>
         <td class="subtotal">${_(u"%s €") % formatLang(l['amount'])}</td>

--- a/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
+++ b/giscedata_facturacio_comer_som/report/components/invoice_details_td_other_concepts/invoice_details_td_other_concepts.mako
@@ -184,7 +184,7 @@ TABLA_101 = {
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_iese']))}
                 % elif l.tax_type == '0.5percent2026':
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_iese']))}
-                    ${_(u"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l'Impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
+                    ${_(u"En virtut del Reial Decret-llei 7/2026, del 20 de març, l'Impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
                 % else:
                     ${_(u"%s € x 5,11269%%") % (formatLang(l['base_iese']))}
                 % endif
@@ -221,7 +221,7 @@ TABLA_101 = {
                     ${_(u"%s kWh x 0,0005 €/kWh (aplicant Art 99.2 de la Llei 28/2014)") % (formatLang(l['base_amount']))}
                 % elif l.tax_type == '0.5percent2026':
                     ${_(u"%s € x 0,5%%") % (formatLang(l['base_amount']))}
-                    ${_(u"En virtut del Reial Decret-llei 10/2026, del 28 d'abril, l'impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
+                    ${_(u"En virtut del Reial Decret-llei 7/2026, del 20 de març, l'Impost Especial sobre l'Electricitat aplicat a la factura es troba reduït del 5,11269632% al 0,5%.")}
                 % else:
                     ${_(u"%s € x 5,11269%%") % (formatLang(l['base_amount']))}
                 % endif


### PR DESCRIPTION
## Objectiu

Canvi de la frase a la factura en pdf per canvi de BOE del 7/2026 al 10/2026

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/1657/activity

## Comportament antic

frase del boe antic (fa 2 setmanes)

## Comportament nou

frase del boe nou (a aquest ritme ens quedarem sense numeros)

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [x] Modifica traduccions
