### PR TITLE
📝 docs: add sentry triage workflow guide

### DIFF
--- a/.agents/skill-registry.md
+++ b/.agents/skill-registry.md
@@ -21,6 +21,7 @@ See `_shared/skill-resolver.md` for the full resolution protocol.
 | Quan necessites executar tests d'un mòdul OpenERP amb destral | erp-test | .agents/skills/erp-test/SKILL.md |
 | Quan necessites arrencar el servei ERP, executar l'ERP, o obrir l'entorn de desenvolupament | erp-start | .agents/skills/erp-start/SKILL.md |
 | Quan necessites crear un script de migració, modificar el model, o actualitzar un mòdul a producció | erp-migration | .agents/skills/erp-migration/SKILL.md |
+| Quan necessites fer triage d'incidències de Sentry, "analitzar sentry", "triar incidents" | sentry-triage | .agents/skills/sentry-triage/SKILL.md |
 
 ## Compact Rules
 
@@ -61,6 +62,14 @@ See `_shared/skill-resolver.md` for the full resolution protocol.
 - Script automàtic: `python scripts/create_migration_script.py`
 - Estructura: `<modul>/migrations/5.0.25.5.0/post-0001_*.py`
 - Executar: `erpserver -d <db> --run-scripts=<module>` o `--update=<module>`
+
+### sentry-triage
+- MCP Sentry requerit: Configurar a OpenCode (self-hosted mode)
+- Workflow: 1) Llista incidents → 2) Identifica tipus (error vs slow) → 3) Determina repo (erp vs addons) → 4) Crea issue sense PII → 5) Obrir PR
+- Repo segons stack: `/home/erp/src/erp/...` → gisce/erp (branca developer), `openerp_som_addons/` → openerp_som_addons (branca main)
+- Labels obligatoris: bug + autotask
+- Prohibit: Noms, emails, telèfons, CUPS, dades personals
+- branca PR: developer (gisce/erp) o main (openerp_som_addons), MAI rolling_erp01
 
 ## Project Conventions
 

--- a/.agents/skills/sentry-triage/SKILL.md
+++ b/.agents/skills/sentry-triage/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: sentry-triage
+description: >
+  Executa el workflow complet de triage d'incidències de Sentry.
+  Automatitza: identificar repo objectiu, analitzar stack, crear issue/PR sense PII.
+  Trigger: Quan necessites fer triage d'incidències de Sentry, "analitzar sentry", "triar incidents".
+metadata:
+  author: oriol
+  version: "1.0"
+---
+
+## When to Use
+
+Utilitza aquesta skill quan:
+- Una incidència de Sentry arriba a producció
+- Necessites identificar on fer el fix (gisce/erp vs openerp_som_addons)
+- Vols crear una issue a partir d'un error de Sentry
+- Necessites obrir una PR contra la branca correcta
+
+## Prerequisits
+
+ MCP de Sentry configurat a OpenCode. Consulta la guia:
+ [docs/guides/sentry-triage-workflow.md](references/sentry-triage-workflow.md)
+
+## Workflow de Triage
+
+### Pas 1: Identificar el tipus d'incidència
+
+Executa per llistar incidències actives:
+
+```bash
+sentry_list_issues(organizationSlug="somenergia", query="is:unresolved", sort="date", limit=10)
+```
+
+**Decisió**:
+- Errors reals → Procedir amb triage
+- `slow request` → Deprioritzar (no és bug)
+
+### Pas 2: Determinar el repositori objectiu
+
+Per cada error, mira el stack trace:
+
+| Stack | Repositori | Branca |
+|-------|------------|--------|
+| `/home/erp/src/erp/...` o mòduls `erp/` | `gisce/erp` | `developer` |
+| `openerp_som_addons/` | `Som-Energia/openerp_som_addons` | `main` |
+
+Executa per veure detall de l'error:
+
+```bash
+sentry_get_sentry_resource(url="<URL_SENTRY_ISSUE>")
+```
+
+### Pas 3: Crear la Issue
+
+**Dades obligatòries**:
+- Link directe a Sentry
+- Labels: `bug` + `autotask`
+- Comportament antic vs esperat
+
+**Dades PROHIBIDES** (mai en issues):
+- Noms, cognoms, adreces, emails, telèfons
+- CUPS, identificadors personals
+- Valors operatius sensibles
+
+**Per anonimitzar**: Reemplaça valors reals per `<EXAMPLE>` o descripcions generals.
+
+### Pas 4: Obrir la PR
+
+1. Crear branca seguint convencions del repo objectiu
+2. Descriure seguint la plantilla del repo (a `gisce/erp`: castellà)
+3. Obrir contra branca de desenvolupament, NO contra `rolling_erp01`
+
+## Comandes Ràpides
+
+```bash
+# Llistar incidències Sense resoldre
+sentry_list_issues(organizationSlug="somenergia", query="is:unresolved level:error")
+
+# Veure detalls d'un error específic
+sentry_get_sentry_resource(url="<SENTRY_URL>")
+
+# Analitzar error amb Seer (opcional, si tens API key configurada)
+sentry_analyze_issue_with_seer(issueUrl="<SENTRY_URL>")
+
+# Actualitzar estat d'una issue
+sentry_update_issue(organizationSlug="somenergia", issueId="<ID>", status="resolved")
+```
+
+## Integració amb SDD
+
+Aquesta skill s'utilitza a les fases:
+- `sdd-explore`: Quan una incidència de Sentry arriba i cal investigar
+- `sdd-propose`: Per documentar el repo i branca on es farà el fix
+- `sdd-apply`: Per implementar el fix i crear PR
+
+## Referències
+
+- **Guia completa**: Veure [references/sentry-triage-workflow.md](references/sentry-triage-workflow.md)
+- **MCP Sentry**: Configuració a la guia (no versionar tokens reals)

--- a/.agents/skills/sentry-triage/references/sentry-triage-workflow.md
+++ b/.agents/skills/sentry-triage/references/sentry-triage-workflow.md
@@ -1,7 +1,5 @@
 # Sentry Triage Workflow
 
-> **Nota**: Per a execució automatitzada, consulta la skill `sentry-triage` a [.agents/skills/sentry-triage/SKILL.md](../.agents/skills/sentry-triage/SKILL.md)
-
 Guia curta per triar i documentar incidències de Sentry relacionades amb els repositoris ERP de Som Energia.
 
 ## Objectiu
@@ -64,7 +62,7 @@ Exemple de configuració per a OpenCode:
       "environment": {
         "SENTRY_HOST": "<SENTRY_HOST>",
         "SENTRY_ACCESS_TOKEN": "<TOKEN>",
-        "MCP_DISABLE_SKILLS": "seer"
+        "MCP_DISABLE_SKIPS": "seer"
       }
     }
   }

--- a/.engram/config.json
+++ b/.engram/config.json
@@ -1,0 +1,3 @@
+{
+  "project_name": "openerp_som_addons"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ patches/
 
 # VSCode
 .vscode/
+.atl/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ openerp_som_addons/
 |---------|-----------|
 | `docs/patterns/` | Receptes: com fer tasques concretes |
 | `docs/guides/` | Guies: conceptes i configuració |
+| `docs/guides/sentry-triage-workflow.md` | Workflow per triar repo, issue i PR quan una incidència ve de Sentry |
 | `.github/docs/` | Decisions d'arquitectura i estil |
 
 ## Skills Disponibles
@@ -99,11 +100,3 @@ Abans de crear PR, verificar:
 - [ ] Tests passen (`erp-test`)
 - [ ] Linting passen (`flake8 .`)
 - [ ] S'ha seguit l'estil de codi
-
-## Documentació
-
-| Carpeta | Contingut |
-|---------|-----------|
-| `docs/patterns/` | Receptes: com fer tasques concretes |
-| `docs/guides/` | Guies: conceptes i configuració |
-| `.github/docs/` | Decisions d'arquitectura i estil |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ Les skills següents estan disponibles al projecte i s'han d'utilitzar quan corr
 | `erp-start` | Arrencar servei ERP | Veure [.agents/skills/erp-start/SKILL.md](.agents/skills/erp-start/SKILL.md) |
 | `erp-migration` | Crear scripts de migració | Veure [.agents/skills/erp-migration/SKILL.md](.agents/skills/erp-migration/SKILL.md) |
 
+### Sentry
+
+| Skill | Quan usar | Com usar |
+|-------|-----------|----------|
+| `sentry-triage` | Fer triage d'incidències de Sentry | Veure [.agents/skills/sentry-triage/SKILL.md](.agents/skills/sentry-triage/SKILL.md) |
+
 **Requisits per executar tests:**
 1. Docker: PostgreSQL, MongoDB, Redis corrent
 2. Virtualenv activat — nom habitual: `erp` (`pyenv activate erp` o `workon erp`)

--- a/docs/guides/sentry-triage-workflow.md
+++ b/docs/guides/sentry-triage-workflow.md
@@ -1,0 +1,85 @@
+# Sentry Triage Workflow
+
+Guia curta per triar i documentar incidències de Sentry relacionades amb els repositoris ERP de Som Energia.
+
+## Objectiu
+
+Evitar dubtes quan una incidència es detecta a producció però el fix s'ha de preparar en un altre repositori o branca.
+
+## Regles bàsiques
+
+1. El Sentry consultat és el de producció.
+2. Moltes incidències vindran d'entorns basats en `Som-Energia/erp:rolling_erp01`.
+3. Els fixes i PRs s'han de preparar a `gisce/erp:developer` quan el codi afectat viu a `erp/`.
+4. El repositori de la issue depén del mòdul on peta l'error:
+   - si el stack apunta a `/home/erp/src/erp/...` o a mòduls del repo `erp/`, la issue va a `gisce/erp`
+   - si el stack apunta a mòduls d'aquest repo `openerp_som_addons/`, la issue ha d'anar al repo corresponent d'addons
+
+## Quan crear una issue a partir de Sentry
+
+1. Prioritzar errors reals abans que `slow request`, si l'objectiu és arreglar bugs.
+2. Triar una incidència amb stack clar i codi de primer nivell.
+3. Evitar copiar dades personals o valors operatius sensibles des de Sentry.
+4. Incloure sempre el link directe de Sentry dins de la issue.
+
+Dades que no s'han de publicar MAI en issues, comentaris o PRs:
+
+- noms i cognoms
+- adreces postals o poblacions
+- emails
+- telèfons
+- CUPS
+- qualsevol altre identificador personal o dada operativa sensible
+
+Si un cas real és útil per explicar el bug, cal anonimitzar-lo o generalitzar-lo abans de publicar-lo.
+
+## Convencions per a la issue
+
+1. Afegir labels `bug` i `autotask`.
+2. Descriure el comportament antic i el comportament esperat.
+3. Explicar la causa tècnica amb referències a fitxers i línies si són conegudes.
+4. Indicar explícitament si l'error es veu a producció però el fix s'ha de fer en una altra branca o repo.
+
+## Convencions per a la PR
+
+1. Seguir la plantilla descrita a `AGENTS.md` i la documentació de PR del repositori objectiu.
+2. En el cas de `gisce/erp`, la descripció ha d'estar en castellà i seguir la plantilla del repo.
+3. La PR ha d'eixir des de la branca de desenvolupament correcta, no des de `rolling_erp01`.
+
+## MCP de Sentry
+
+Per a entorns self-hosted, el MCP de Sentry es configura en mode local/STDIO.
+
+Exemple de configuració per a OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "sentry": {
+      "type": "local",
+      "command": ["npx", "@sentry/mcp-server@0.2.0"],
+      "environment": {
+        "SENTRY_HOST": "<SENTRY_HOST>",
+        "SENTRY_ACCESS_TOKEN": "<TOKEN>",
+        "MCP_DISABLE_SKILLS": "seer"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+1. `SENTRY_HOST` ha de ser el host del servidor Sentry, sense `https://`.
+2. No guardar el token real en documentació ni en fitxers versionats.
+3. Si es volen eines de cerca en llenguatge natural, cal configurar també el proveïdor LLM corresponent.
+
+## Checklist ràpid
+
+- error triat i no només problema de rendiment
+- repo correcte identificat segons el mòdul del stack
+- issue amb link directe a Sentry
+- sense dades personals ni secrets
+- labels `bug` i `autotask`
+- PR oberta contra la branca de desenvolupament correcta


### PR DESCRIPTION
## Objectiu

- Documentar el workflow per triatge d'incidències de Sentry relacionades amb ERP i `openerp_som_addons`.
- Deixar una referència explícita a `AGENTS.md` perquè futurs agents la puguen trobar fàcilment.
- Incloure una configuració base del MCP de Sentry per a entorn self-hosted, sense secrets ni valors d'infraestructura específics.

## Targeta on es demana o Incidència

- Petició interna de documentació i memòria de treball per al triatge de Sentry.

## Comportament antic

- No hi havia una guia concreta al repo per decidir repo objectiu, issue i PR quan una incidència venia de Sentry.
- Tampoc hi havia una referència des d'`AGENTS.md` a aquest workflow.

## Comportament nou

- S'afegeix `docs/guides/sentry-triage-workflow.md` amb el workflow de triatge.
- S'afegeix a la guia una configuració base del MCP de Sentry amb placeholders genèrics, sense token real ni referències explícites a infraestructura concreta.
- `AGENTS.md` passa a enllaçar explícitament aquesta guia dins la documentació del projecte.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions