### PR TITLE
Evitar que un M2 d'un altre autoconsum active fluxos de GURB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ patches/
 
 # VSCode
 .vscode/
+
+# Agents
+.engram/

--- a/account_invoice_som/__terp__.py
+++ b/account_invoice_som/__terp__.py
@@ -12,6 +12,7 @@
         "poweremail",
         "giscedata_remeses",
         "l10n_ES_remesas",
+        "report_banner_poweremail",  # remove when banners import is fixed in account_invoice_base
         "som_polissa_soci",
     ],
     "init_xml": [],

--- a/som_gurb/__terp__.py
+++ b/som_gurb/__terp__.py
@@ -6,11 +6,11 @@
     "author": "SomEnergia",
     "category": "SomEnergia",
     "depends": [
+        "account_invoice_som",  # remove when banners import is fixed in account_invoice_base
         "giscedata_polissa",
         "giscedata_telemesures_base",
         "giscedata_facturacio_services",
         "giscedata_polissa_category",
-        "report_banner_poweremail",
         "giscedata_switching",
         "giscedata_facturacio",
         "report_puppeteer",

--- a/som_gurb/__terp__.py
+++ b/som_gurb/__terp__.py
@@ -10,6 +10,7 @@
         "giscedata_telemesures_base",
         "giscedata_facturacio_services",
         "giscedata_polissa_category",
+        "report_banner_poweremail",
         "giscedata_switching",
         "giscedata_facturacio",
         "report_puppeteer",

--- a/som_gurb/models/giscedata_switching.py
+++ b/som_gurb/models/giscedata_switching.py
@@ -58,18 +58,6 @@ def _cups_contract_has_gurb_cups(cursor, uid, pool, pol_id, context=None):
     return bool(gurb_cups_id)
 
 
-def _step_matches_gurb_self_consumption(step, gurb_cups):
-    gurb_cau = getattr(gurb_cups.gurb_cau_id.self_consumption_id, "cau", False)
-    if not gurb_cau:
-        return False
-
-    for dades_cau in getattr(step, "dades_cau", []):
-        if dades_cau.cau == gurb_cau:
-            return True
-
-    return False
-
-
 def _is_m1_closable(cursor, uid, pool, sw, context=None):
     if context is None:
         context = {}
@@ -582,6 +570,17 @@ GiscedataSwitchingHelpers()
 class GiscedataSwitchingM2_05(osv.osv):
     _inherit = "giscedata.switching.m2.05"
 
+    def _atr_cups_match_gurb_cups(self, cursor, uid, step, gurb_cups):
+        """Returns True if the step's dades_cau contains the same CAU as the GURB cups' self consumption CAU."""  # noqa: E501
+        if not gurb_cups.gurb_cau_id.self_consumption_id.cau:
+            return False
+
+        if step.dades_cau:
+            for dades_cau in step.dades_cau:
+                if dades_cau.cau == gurb_cups.gurb_cau_id.self_consumption_id.cau:
+                    return True
+        return False
+
     def create_from_xml(self, cursor, uid, sw_id, xml, context=None):
         if context is None:
             context = {}
@@ -607,7 +606,10 @@ class GiscedataSwitchingM2_05(osv.osv):
             )
             gurb_cups = gurb_cups_obj.browse(cursor, uid, gurb_cups_id, context=context)
 
-            if not _step_matches_gurb_self_consumption(step, gurb_cups):
+            # Si l'autoconsum del GURB coincideix amb el CAU de la dada_cau del pas, no es notifica
+            # i no es processen les accions de GURB, ja que el canvi és només per l'autoconsum i
+            # no afecta a la resta de potència contractada.
+            if not self._atr_cups_match_gurb_cups(cursor, uid, step, gurb_cups):
                 return step_id
 
             # GURB Leaving Codes

--- a/som_gurb/models/giscedata_switching.py
+++ b/som_gurb/models/giscedata_switching.py
@@ -58,6 +58,18 @@ def _cups_contract_has_gurb_cups(cursor, uid, pool, pol_id, context=None):
     return bool(gurb_cups_id)
 
 
+def _step_matches_gurb_self_consumption(step, gurb_cups):
+    gurb_cau = getattr(gurb_cups.gurb_cau_id.self_consumption_id, "cau", False)
+    if not gurb_cau:
+        return False
+
+    for dades_cau in getattr(step, "dades_cau", []):
+        if dades_cau.cau == gurb_cau:
+            return True
+
+    return False
+
+
 def _is_m1_closable(cursor, uid, pool, sw, context=None):
     if context is None:
         context = {}
@@ -593,6 +605,10 @@ class GiscedataSwitchingM2_05(osv.osv):
             gurb_cups_id = gurb_cups_obj.get_gurb_cups_from_sw_id(
                 cursor, uid, sw_id, context=context
             )
+            gurb_cups = gurb_cups_obj.browse(cursor, uid, gurb_cups_id, context=context)
+
+            if not _step_matches_gurb_self_consumption(step, gurb_cups):
+                return step_id
 
             # GURB Leaving Codes
             if step.motiu_modificacio == "06":

--- a/som_gurb/tests/tests_gurb_switching.py
+++ b/som_gurb/tests/tests_gurb_switching.py
@@ -1433,6 +1433,7 @@ class TestsGurbSwitching(TestsGurbBase):
     def test_create_from_xml_m2_05_unexpected_leaving_gurb(
             self, mock_is_unidirectional):
         mock_is_unidirectional.return_value = False
+        gurb_cau = "ES0026233884282635YDA000"
 
         sw_obj = self.openerp.pool.get("giscedata.switching")
         sgc_obj = self.openerp.pool.get("som.gurb.cups")
@@ -1466,6 +1467,10 @@ class TestsGurbSwitching(TestsGurbBase):
             "<Motivo>01",
             "<Motivo>{0}".format("06")
         )
+        m2_05_xml = m2_05_xml.replace(
+            "<CAU>ES1234000000000001JN0FA001",
+            "<CAU>{0}".format(gurb_cau)
+        )
 
         # Import XML
         step_id = sw_obj.importar_xml(
@@ -1481,6 +1486,7 @@ class TestsGurbSwitching(TestsGurbBase):
     def test_create_from_xml_m2_05_expected_leaving_gurb(
             self, mock_is_unidirectional):
         mock_is_unidirectional.return_value = False
+        gurb_cau = "ES0026233884282635YDA000"
 
         sw_obj = self.openerp.pool.get("giscedata.switching")
         sgc_obj = self.openerp.pool.get("som.gurb.cups")
@@ -1515,6 +1521,10 @@ class TestsGurbSwitching(TestsGurbBase):
             "<Motivo>01",
             "<Motivo>{0}".format("06")
         )
+        m2_05_xml = m2_05_xml.replace(
+            "<CAU>ES1234000000000001JN0FA001",
+            "<CAU>{0}".format(gurb_cau)
+        )
 
         # Import XML
         step_id = sw_obj.importar_xml(
@@ -1531,6 +1541,7 @@ class TestsGurbSwitching(TestsGurbBase):
             self, mock_send_gurb_activation_email, mock_is_unidirectional):
         mock_send_gurb_activation_email.return_value = False
         mock_is_unidirectional.return_value = False
+        gurb_cau = "ES0026233884282635YDA000"
 
         sw_obj = self.openerp.pool.get("giscedata.switching")
         sgc_obj = self.openerp.pool.get("som.gurb.cups")
@@ -1563,6 +1574,10 @@ class TestsGurbSwitching(TestsGurbBase):
             "<Motivo>01",
             "<Motivo>{0}".format("04")
         )
+        m2_05_xml = m2_05_xml.replace(
+            "<CAU>ES1234000000000001JN0FA001",
+            "<CAU>{0}".format(gurb_cau)
+        )
 
         # Import XML
         step_id = sw_obj.importar_xml(
@@ -1572,6 +1587,57 @@ class TestsGurbSwitching(TestsGurbBase):
         # Assertions
         self.assertIsNotNone(step_id)
         self.assertEqual(sgc_0002.state, "active")
+
+    @mock.patch("som_gurb.models.giscedata_switching.is_unidirectional_colective_autocons_change")
+    @mock.patch("som_gurb.models.som_gurb_cups.SomGurbCups.send_gurb_activation_email")
+    def test_create_from_xml_m2_05_does_not_activate_unrelated_autoconsum(
+            self, mock_send_gurb_activation_email, mock_is_unidirectional):
+        mock_send_gurb_activation_email.return_value = False
+        mock_is_unidirectional.return_value = False
+        unrelated_cau = "ES0031241774219778BJA000"
+
+        sw_obj = self.openerp.pool.get("giscedata.switching")
+        sgc_obj = self.openerp.pool.get("som.gurb.cups")
+        pol_obj = self.openerp.pool.get("giscedata.polissa")
+
+        contract_id = self.get_contract_id(self.txn, xml_id="polissa_tarifa_018")
+
+        sgc_id = self.openerp.pool.get("ir.model.data").get_object_reference(
+            self.cursor, self.uid, "som_gurb", "gurb_cups_0002")[1]
+
+        sgc_0002 = sgc_obj.browse(self.cursor, self.uid, sgc_id)
+        sgc_0002.send_signal("button_create_cups")
+        sgc_0002.send_signal("button_activate_cups")
+
+        m2_05_xml_path = get_module_resource(
+            "som_gurb", "tests", "fixtures", "m205_new.xml"
+        )
+        with open(m2_05_xml_path, "r") as f:
+            m2_05_xml = f.read()
+        self.switch(self.txn, "comer")
+        self.change_polissa_comer(self.txn, pol_id='polissa_tarifa_018')
+        cups = pol_obj.browse(self.cursor, self.uid, contract_id).cups
+
+        m2_05_xml = m2_05_xml.replace(
+            "<CUPS>ES1234000000000001JN0F",
+            "<CUPS>{0}".format(cups.name)
+        )
+        m2_05_xml = m2_05_xml.replace(
+            "<Motivo>01",
+            "<Motivo>{0}".format("04")
+        )
+        m2_05_xml = m2_05_xml.replace(
+            "<CAU>ES1234000000000001JN0FA001",
+            "<CAU>{0}".format(unrelated_cau)
+        )
+
+        step_id = sw_obj.importar_xml(
+            self.cursor, self.uid, m2_05_xml, "m205_new.xml"
+        )
+
+        self.assertIsNotNone(step_id)
+        self.assertEqual(sgc_0002.state, "active")
+        self.assertFalse(mock_send_gurb_activation_email.called)
 
     def test_wizard_atr_gurb_model(self):
         wiz_o = self.openerp.pool.get("wizard.atr.gurb.model")


### PR DESCRIPTION
Tanca #1250

## Resum
- afegeix un guard de CAU abans d'executar efectes laterals específics de GURB dins de `GiscedataSwitchingM2_05.create_from_xml()`
- actualitza els tests existents d'M2 perquè els casos positius utilitzen el CAU real del GURB
- afegeix un test de regressió per verificar que un CAU d'autoconsum alié no dispara el flux d'activació de GURB

## Validacions
- `python -m py_compile som_gurb/models/giscedata_switching.py som_gurb/tests/tests_gurb_switching.py`
- `dodestral test_som_gurb -m som_gurb` s'ha llançat amb `pyenv activate erp`, però no ha acabat dins del temps disponible perquè l'entorn estava reconstruint una base ERP de proves des de zero

## Notes
- esta PR corregeix la causa arrel verificada en `M2_05`: reaccionar a qualsevol CAU d'autoconsum d'una pòlissa que tinga GURB
- el símptoma funcional de `Baixa pendent` no s'ha reproduït completament dins d'una execució de tests tancada en esta sessió
