### PR TITLE
FIX account test names

### DIFF
--- a/som_gurb/tests/tests_gurb_cups.py
+++ b/som_gurb/tests/tests_gurb_cups.py
@@ -7,6 +7,18 @@ from datetime import datetime, timedelta
 
 class TestsGurbCups(TestsGurbBase):
 
+    def _assert_account_code(self, many2one_value, expected_code):
+        self.assertEqual(many2one_value[1].split(' ', 1)[0], expected_code)
+
+    def _assert_partner_receivable_account(self, partner_id, many2one_value):
+        partner_o = self.openerp.pool.get("res.partner")
+        partner = partner_o.read(
+            self.cursor, self.uid, partner_id, ["property_account_receivable"]
+        )
+        self.assertEqual(
+            many2one_value[0], partner["property_account_receivable"][0]
+        )
+
     def test_gurb_cups_percentage(self):
         imd_o = self.openerp.pool.get("ir.model.data")
         gurb_cups_o = self.openerp.pool.get("som.gurb.cups")
@@ -185,7 +197,7 @@ class TestsGurbCups(TestsGurbBase):
         self.assertFalse(errs)
         self.assertTrue(invoice_id)
         inv = invoice_o.read(self.cursor, self.uid, invoice_id)
-        self.assertEqual(inv['account_id'][1], '430000000000 Clients')
+        self._assert_partner_receivable_account(inv['partner_id'][0], inv['account_id'])
         self.assertEqual(inv['partner_id'][1], 'GISCE')
         self.assertEqual(inv['origin'], 'GURBCUPSID2')
         self.assertEqual(inv['reference'], 'GURBCUPSID2')
@@ -205,7 +217,7 @@ class TestsGurbCups(TestsGurbBase):
         self.assertEqual(line['name'], u"Cost d'adhesió GURB GRUP 001")
         self.assertEqual(line['quantity'], 1.0)
         self.assertEqual(line['price_unit'], 3.75)
-        self.assertEqual(line['account_id'][1], '705000000104 Gurb')
+        self._assert_account_code(line['account_id'], '705000000104')
 
     @mock.patch("som_gurb.models.som_gurb_cups.SomGurbCups.generate_gurb_invoice_base64")
     def test_create_initial_invoice__invoice_tpv_payment(
@@ -233,7 +245,7 @@ class TestsGurbCups(TestsGurbBase):
         self.assertFalse(errs)
         self.assertTrue(invoice_id)
         inv = invoice_o.read(self.cursor, self.uid, invoice_id)
-        self.assertEqual(inv['account_id'][1], '430000000000 Clients')
+        self._assert_partner_receivable_account(inv['partner_id'][0], inv['account_id'])
         self.assertEqual(inv['partner_id'][1], 'GISCE')
         self.assertEqual(inv['origin'], 'GURBCUPSID2')
         self.assertEqual(inv['reference'], 'GURBCUPSID2')
@@ -253,7 +265,7 @@ class TestsGurbCups(TestsGurbBase):
         self.assertEqual(line['name'], u"Cost d'adhesió GURB GRUP 001")
         self.assertEqual(line['quantity'], 1.0)
         self.assertEqual(line['price_unit'], 3.75)
-        self.assertEqual(line['account_id'][1], '705000000104 Gurb')
+        self._assert_account_code(line['account_id'], '705000000104')
 
     def test_pay_invoice_gurb(self):
         gurb_cups_o = self.openerp.pool.get("som.gurb.cups")


### PR DESCRIPTION
## Objectiu

Corregir els tests de `som_gurb` que fallaven per comparar noms complets de comptes comptables massa rígids en lloc d'una referència estable.

## Targeta on es demana o Incidència

- https://github.com/Som-Energia/openerp_som_addons/issues/1252

## Comportament antic

Els tests de la factura inicial de `som_gurb` assumien que el compte cobrable del partner sempre tindria el codi `430000000000` i també comparaven labels complets de many2one. En la base `som_gurb`, el compte real és `430000`, així que els tests fallaven encara que la lògica funcional fora correcta.

## Comportament nou

Els tests validen el compte cobrable real configurat al partner per a la factura i continuen comprovant el codi comptable estable a la línia de factura de GURB.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions