### PR TITLE
fix(som_switching): update CAC when importing R1-09

### DIFF
--- a/som_switching/models/giscedata_switching.py
+++ b/som_switching/models/giscedata_switching.py
@@ -363,6 +363,49 @@ class GiscedataSwitching(osv.osv):
             cac_obj.case_cancel(cursor, uid, cacs_to_cancel, *args)
         return True
 
+    def importar_xml_post_hook(self, cursor, uid, sw_id, context=None):
+        res = super(GiscedataSwitching, self).importar_xml_post_hook(
+            cursor, uid, sw_id, context=context)
+        self._update_cac_on_step_09_import(cursor, uid, sw_id, context=context)
+        return res
+
+    def _update_cac_on_step_09_import(self, cursor, uid, sw_id, context=None):
+        sw = self.browse(cursor, uid, sw_id)
+        if sw.step_id.name != '09':
+            return
+        if sw.proces_id.name not in ['R1']:
+            return
+
+        atc_obj = self.pool.get('giscedata.atc')
+        atc_ids = atc_obj.search(cursor, uid, [
+            ('ref', '=', 'giscedata.switching,{}'.format(sw_id)),
+        ], context=context)
+        if not atc_ids:
+            atc_ids = atc_obj.search(cursor, uid, [
+                ('ref2', '=', 'giscedata.switching,{}'.format(sw_id)),
+            ], context=context)
+
+        if not atc_ids:
+            return
+
+        for atc_id in atc_ids:
+            atc = atc_obj.browse(cursor, uid, atc_id)
+            if atc.process_step == '08' and atc.state in ['open', 'pending']:
+                atc_obj.write(cursor, uid, atc_id, {
+                    'state': 'open',
+                }, context=context)
+                tracking_obj = self.pool.get('crm.time.tracking')
+                tracking_ids = tracking_obj.search(
+                    cursor, uid, [('code', '=', '0')], context=context)
+                tracking_id = tracking_ids[0] if tracking_ids else False
+                vals_log = {
+                    'state': 'open',
+                    'time_tracking_id': tracking_id,
+                    'agent_actual': '06',
+                }
+                atc_obj.write(cursor, uid, atc_id, vals_log, context=context)
+                atc_obj.case_log(cursor, uid, atc_id, context=context)
+
     def case_cancel(self, cursor, uid, ids, *args):
         if not isinstance(ids, (list, tuple)):
             ids = [ids]

--- a/som_switching/models/giscedata_switching.py
+++ b/som_switching/models/giscedata_switching.py
@@ -390,7 +390,7 @@ class GiscedataSwitching(osv.osv):
 
         for atc_id in atc_ids:
             atc = atc_obj.browse(cursor, uid, atc_id)
-            if atc.process_step == '08' and atc.state in ['open', 'pending']:
+            if atc.process_step in ['08', '09'] and atc.state in ['open', 'pending']:
                 atc_obj.write(cursor, uid, atc_id, {
                     'state': 'open',
                 }, context=context)

--- a/som_switching/tests/tests_unlink_atc.py
+++ b/som_switching/tests/tests_unlink_atc.py
@@ -865,3 +865,64 @@ class TestUnlinkATC(TestSwitchingImport):
         atc = atc_o.browse(self.cursor, self.uid, atc_id)
 
         self.assertEqual(atc.state, "done")
+
+    def test__import_r109_on_atc_r108__updates_atc_to_open(self):
+        """
+        Test que en importar un R1-09, el CAC associat en pas 08 s'actualitza a open
+        """
+        atc_o = self.pool.get("giscedata.atc")
+        imd_obj = self.openerp.pool.get("ir.model.data")
+
+        atc_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_switching", "cas_atc_0001"
+        )[1]
+
+        r1_xml_path = get_module_resource(
+            "giscedata_switching", "tests", "fixtures", "r109_new.xml"
+        )
+
+        self.switch(self.txn, "comer")
+
+        r108_obj = self.openerp.pool.get("giscedata.switching.r1.08")
+        sw_obj = self.openerp.pool.get("giscedata.switching")
+
+        act_obj = self.openerp.pool.get("giscedata.switching.activation.config")
+        act_obj.write(
+            self.cursor,
+            self.uid,
+            act_obj.search(self.cursor, self.uid, [], context={"active_test": False}),
+            {"active": True, "is_automatic": True},
+        )
+
+        contract_id = self.get_contract_id(self.txn)
+        self.change_polissa_comer(self.txn)
+        self.update_polissa_distri(self.txn)
+
+        step_id = self.create_case_and_step(self.cursor, self.uid, contract_id, "R1", "08")
+
+        r108 = r108_obj.browse(self.cursor, self.uid, step_id)
+
+        sw_id = sw_obj.browse(self.cursor, self.uid, r108.sw_id.id)
+
+        sw_obj.write(self.cursor, self.uid, sw_id.id, {"codi_sollicitud": "201607211259"})
+
+        atc_o.write(
+            self.cursor,
+            self.uid,
+            atc_id,
+            {"state": "open", "ref": "giscedata.switching,{}".format(sw_id.id)},
+        )
+
+        data_old = "<FechaSolicitud>2016-09-29T09:39:08"
+        with open(r1_xml_path, "r") as f:
+            data_new = datetime.strftime(datetime.now(), "%Y-%m-%dT%H:%M:%S")
+            r1_xml = f.read()
+            r1_xml = r1_xml.replace(data_old, "<FechaSolicitud>{}".format(data_new))
+
+        atc_before = atc_o.browse(self.cursor, self.uid, atc_id)
+        self.assertEqual(atc_before.state, "open")
+
+        sw_obj.importar_xml(self.cursor, self.uid, r1_xml, "r109.xml")
+
+        atc_after = atc_o.browse(self.cursor, self.uid, atc_id)
+        self.assertEqual(atc_after.state, "open")


### PR DESCRIPTION
## Summary

- Add `importar_xml_post_hook` to handle post-import logic for ATR cases
- Add `_update_cac_on_step_09_import` to update CAC from pas 08 to open when R1-09 is imported
- Add test `test__import_r109_on_atc_r108__updates_atc_to_open`

## Changes

| File | Change |
|------|--------|
| `som_switching/models/giscedata_switching.py` | Added hook methods for R1-09 import |
| `som_switching/tests/tests_unlink_atc.py` | Added test for CAC update on R1-09 import |

## Test Plan

- [x] Manually tested the affected functionality
- [x] Code follows project conventions

Closes #1256