### PR TITLE
💄 Fer visibles 3 decimals a les lectures de la factura en pdf per l'ATR3.1

### DIFF
--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
@@ -17,7 +17,7 @@
         <td class="detall_td">${_(u"Lectura inicial (%s) (%s)") % (meter.initial_date, _(meter.initial_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["initial"], digits=2))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["initial"], digits=3))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -28,7 +28,7 @@
         <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["final"], digits=2))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["final"], digits=3))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -47,7 +47,7 @@
         </td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["total"], digits=2))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["total"], digits=3))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
@@ -17,7 +17,7 @@
         <td class="detall_td">${_(u"Lectura inicial (%s) (%s)") % (meter.initial_date, _(meter.initial_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(int(meter[p]["initial"]))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["initial"], digits=2))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -28,7 +28,7 @@
         <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(int(meter[p]["final"]))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["final"], digits=2))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -47,7 +47,7 @@
         </td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(int(round(meter[p]["total"])))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["total"], digits=2))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
@@ -7,7 +7,7 @@
         <td class="detall_td">${_(u"Lectura inicial (%s) (%s)") % (meter.initial_date, _(meter.initial_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(int(meter[p]["initial"]))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["initial"], digits=3))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -22,7 +22,7 @@
         <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["final"], digits=2))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["final"], digits=3))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -42,7 +42,7 @@
             </td>
             % for p in meter.showing_periods:
                 % if p in meter:
-                    <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["total"], digits=2))}</td>
+                    <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["total"], digits=3))}</td>
                 % else:
                     <td class="periods_td"></td>
                 % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
@@ -22,7 +22,7 @@
         <td class="detall_td">${_(u"Lectura final (%s) (%s)") % (meter.final_date, _(meter.final_type))}</td>
         % for p in meter.showing_periods:
             % if p in meter:
-                <td class="periods_td">${_(u"%s") %(int(meter[p]["final"]))}</td>
+                <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["final"], digits=2))}</td>
             % else:
                 <td class="periods_td"></td>
             % endif
@@ -42,7 +42,7 @@
             </td>
             % for p in meter.showing_periods:
                 % if p in meter:
-                    <td class="periods_td">${_(u"%s") %(int(round(meter[p]["total"])))}</td>
+                    <td class="periods_td">${_(u"%s") %(formatLang(meter[p]["total"], digits=2))}</td>
                 % else:
                     <td class="periods_td"></td>
                 % endif


### PR DESCRIPTION
## Objectiu

Que es mostrin els decimals de les lectures al pdf de la factura on no es mostrava abans, lectures base i lectures d'autogeneració, ara disponibles per l'entrada del ATR3.1.
3 decimals

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/work_packages/1667/activity

## Comportament antic

no es mostraven

## Comportament nou

es mostren 

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
