### PR TITLE
FIX strategy: recover missing som_generationkwh-only changes

### DIFF
--- a/som_generationkwh/__terp__.py
+++ b/som_generationkwh/__terp__.py
@@ -25,6 +25,7 @@
     'custom_search',
     'giscedata_facturacio_impagat_comer',
     'account_account_som',
+    'som_leads_polissa',
     ],
   "init_xml": [],
   "demo_xml": [

--- a/som_generationkwh/giscedata_facturacio.py
+++ b/som_generationkwh/giscedata_facturacio.py
@@ -351,12 +351,17 @@ class GiscedataFacturacioFactura(osv.osv):
         else:
             maj_product = False
 
+        saju_product = product_obj.search(cursor, uid, [('default_code','=', 'SAJU')])
+        if saju_product:
+            saju_product = saju_product[0]
+        else:
+            saju_product = False
         real_energy = []
         lines_extra_ids = self.get_lines_in_extralines(cursor, uid, inv_id, pol_id)
         for l_id in linies_energia_ids:
             if l_id not in lines_extra_ids:
                 line = invline_obj.browse(cursor, uid, l_id)
-                if line.product_id.id == maj_product:
+                if line.product_id.id in [maj_product, saju_product]:
                     continue
                 real_energy.append(l_id)
         return real_energy

--- a/som_generationkwh/giscedata_polissa.py
+++ b/som_generationkwh/giscedata_polissa.py
@@ -99,6 +99,8 @@ class GiscedataPolissa(osv.osv):
                 - If there are 12 months of data, is just the sum of every period
                 - If there are some data, is ponerated to 12 months with a rule of 3
                 - If there are no data, returns False
+            It returns a tuple with the estimation and a string with the type of estimation:
+            'full_data', 'partial_data' or 'no_data'
         """
         if not date_end:
             date_end = str(date.today())
@@ -111,10 +113,10 @@ class GiscedataPolissa(osv.osv):
             cursor, uid, pol_id, date_start, date_end, context=context)
 
         if not use_data:
-            return False
+            return False, 'no_data'
 
         period_sums = {}
-        for invoice_date, periods in use_data.items():
+        for _, periods in use_data.items():
             for p, kwh in periods.items():
                 period_sums[p] = period_sums.get(p, 0) + kwh
 
@@ -122,7 +124,7 @@ class GiscedataPolissa(osv.osv):
         factor = 12.0 / num_invoices
         res = {p: int(round(kwh * factor)) for p, kwh in period_sums.items()}
 
-        return res
+        return res, 'full_data' if num_invoices >= 12 else 'partial_data'
 
     _columns = {
         'te_assignacio_gkwh': fields.function(

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -541,7 +541,7 @@ class GenerationkwhInvestment(osv.osv):
                 purchase_date = isodate(inv['purchase_date']),
                 nominal_amount = gkwh.shareValue*inv['nshares'],
             )
-            for pending in invstate.pendingAmortizations(isodate(current_date)):
+            for pending in invstate.pendingAmortizations(datetime.strptime(str(current_date)[:10], '%Y-%m-%d').date()):
                 (
                     amortization_number,
                     amortization_total_number,

--- a/som_generationkwh/migrations/5.0.24.10/post-0004_improve_wizard_baixa_soci.py
+++ b/som_generationkwh/migrations/5.0.24.10/post-0004_improve_wizard_baixa_soci.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Updating wizard baixa soci")
+    pool.get("wizard.baixa.soci")._auto_init(
+        cursor, context={'module': 'som_generationkwh'}
+    )
+    logger.info("Updated successfully")
+
+    logger.info("Updating XMLs")
+    xml_to_update = [
+        "wizard/wizard_baixa_soci.xml",
+        "som_generationkwh_data.xml",
+    ]
+    for xml_file in xml_to_update:
+        load_data(
+            cursor,
+            "som_generationkwh",
+            xml_file,
+            idref=None,
+            mode="update",
+        )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_generationkwh/report/report_amortization_gkwh.mako
+++ b/som_generationkwh/report/report_amortization_gkwh.mako
@@ -256,7 +256,7 @@ for account.invoice in objects:
             </b></th>
         </tr>
         <tr>
-            <td id="account"> ${(data.inversionBankAccount or '')[-4:].rjust(len(data.inversionBankAccount or ''), '*')} </td>
+            <td id="account"> ${data.inversionBankAccount} </td>
         </tr>
     </table>
     %if data.countInvestmentsGkwh > 1:

--- a/som_generationkwh/som_generationkwh_data.xml
+++ b/som_generationkwh/som_generationkwh_data.xml
@@ -2135,6 +2135,37 @@ ${text_legal}
             <field name="partner_id">1</field>
             <field name="sepa_creditor_code">ES24000F55091367</field>
         </record>
+        <record id="member_fee_return_journal" model="account.journal">
+            <field name="code">SOCIS_RETURN</field>
+            <field eval="[(6,0,[])]" name="account_control_ids"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field eval="0" name="centralisation"/>
+            <field eval="0" name="group_invoice_lines"/>
+            <field name="type">purchase</field>
+            <field name="default_credit_account_id" model="account.account" search="[('code','=','555000000003')]"/>
+            <field name="default_debit_account_id" model="account.account" search="[('code','=','100000000000')]"/>
+            <field name="view_id" ref="account.account_journal_bank_view"/>
+            <field eval="[(6,0,[])]" name="type_control_ids"/>
+            <field name="sequence_id" ref="account.sequence_journal"/>
+            <field name="sii_to_send" eval="False"/>
+            <field eval="1" name="active"/>
+            <field eval="1" name="update_posted"/>
+            <field name="name">SOCIS RETORN</field>
+            <field eval="0" name="refund_journal"/>
+            <field eval="1" name="entry_posted"/>
+        </record>
+        <record id="soci_return_payment_mode" model="payment.mode">
+            <field name="name">RETORN QUOTA SOCIS</field>
+            <field name="type" search="[('code', '=', 'TRANSFERENCIA_CSB')]"/>
+            <field name="journal" ref="member_fee_return_journal"/>
+            <field name="bank_id" search="[('partner_id', '=', 1)]"/>
+            <field name="tipo">sepa34</field>
+            <field name="nombre">Som Energia SCCL</field>
+            <field name="sufijo">000</field>
+            <field name="require_bank_account" eval="True"/>
+            <field name="partner_id">1</field>
+            <field name="sepa_creditor_code">ES24000F55091367</field>
+        </record>
         <record id="emissio_apo_2021" model="generationkwh.emission">
             <field name="name">Aportacions</field>
             <field name="code">APO_202110</field>

--- a/som_generationkwh/somenergia_soci.py
+++ b/som_generationkwh/somenergia_soci.py
@@ -2,12 +2,17 @@
 
 from __future__ import absolute_import
 
+import netsvc
 from osv import osv, fields
 from tools.translate import _
 from tools import config
 from oorq.decorators import job
 
 from datetime import datetime, date
+
+
+_MEMBER_FEE_RETURN_PURPOSE = 'RETORN QUOTA SOCI'
+
 
 def field_function(ff_func):
     def string_key(*args, **kwargs):
@@ -130,93 +135,223 @@ class SomenergiaSoci(osv.osv):
 
         return True
 
-    def verifica_baixa_soci(self, cursor, uid, ids, context=None):
-        # - Comprovar si té generationkwh: Existeix atribut al model generation que ho indica. Altrament es poden buscar les inversions.
-        # - Comprovar si té inversions vigents: Buscar inversions vigents.
-        # - Comprovar si té contractes actius: Buscar contractes vigents.
-        # - Comprovar si té Factures pendents de pagament: Per a aquesta comprovació hi ha una tasca feta a la OV que ens pot ajudar feta per en Fran a la següent PR: https://github.com/gisce/erp/pull/7997/files
-
-        """Mètode per donar de baixa un soci.
-        """
+    def get_baixa_blocking_reasons(self, cursor, uid, member_id, context=None):
         if not context:
             context = {}
-        if not ids:
-            return
-        if isinstance(ids, (int, long)):
-            ids = [ids]
-        if len(ids) != 1:
-            raise osv.except_osv(_('Com ha minim es necessita un soci'))
 
-        imd_obj = self.pool.get('ir.model.data')
+        reasons = []
+
         invest_obj = self.pool.get('generationkwh.investment')
         emi_obj = self.pool.get('generationkwh.emission')
         pol_obj = self.pool.get('giscedata.polissa')
         fact_obj = self.pool.get('giscedata.facturacio.factura')
         soci_obj = self.pool.get('somenergia.soci')
-        rpa_obj = self.pool.get('res.partner.address')
 
         today = datetime.today().strftime('%Y-%m-%d')
-        member_id = ids[0]
         res_partner_id = soci_obj.read(cursor, uid, member_id, ['partner_id'])['partner_id'][0]
 
         baixa = soci_obj.read(cursor, uid, [member_id], ['baixa'])[0]['baixa']
 
         if baixa:
-            raise osv.except_osv(_('El soci no pot ser donat de baixa!'),
-                                 _('Ja ha estat donat de baixa anteriorment!'))
+            reasons.append(_('Ja ha estat donat de baixa anteriorment!'))
 
         genkwh_emission_ids = emi_obj.search(cursor, uid, [('type','=','genkwh')])
         gen_invest = invest_obj.search(cursor, uid, [('member_id', '=', member_id),
                                                      ('emission_id', 'in', genkwh_emission_ids),
-                                                     ('last_effective_date', '>=', today)])
+                                                     ('last_effective_date', '>', today)])
         if gen_invest:
-            raise osv.except_osv(_('El soci no pot ser donat de baixa!'),
-                                 _('El soci té inversions de generation actives.'))
+            reasons.append(_('El soci té inversions de generation actives.'))
 
         aportacions_ids = emi_obj.search(cursor, uid, [('type','=','apo')])
         apo_invest = invest_obj.search(cursor, uid, [('member_id', '=', member_id),
                                                      ('emission_id', 'in', aportacions_ids),
                                                      '|', ('last_effective_date', '=', False),
-                                                     ('last_effective_date', '>=', today)])
+                                                     ('last_effective_date', '>', today)])
         if apo_invest:
-            raise osv.except_osv(_('El soci no pot ser donat de baixa!'), _('El soci té aportacions actives.'))
+            reasons.append(_('El soci té aportacions actives.'))
 
         factures_pendents = fact_obj.search(cursor, uid, [('partner_id', '=', res_partner_id),
                                                           ('state', 'not in', ['cancel', 'paid']),
                                                           ('type', '=', 'out_invoice')])
 
         if factures_pendents and not context.get('skip_pending_check', False):
-            raise osv.except_osv(_('El soci no pot ser donat de baixa!'), _('El soci té factures pendents.'))
+            reasons.append(_('El soci té factures pendents.'))
 
-        polisses = pol_obj.search(cursor, uid,
+        polisses_as_titular = pol_obj.search(cursor, uid,
                                   [('soci', '=', res_partner_id),
+                                   ('titular', '=', res_partner_id),
                                    ('state', '!=', 'baixa'),
                                    ('state', '!=', 'cancelada')])
-        if polisses:
-            raise osv.except_osv(_('El soci no pot ser donat de baixa!'), _('El soci té al menys un contracte vinculat.'))
+        if polisses_as_titular:
+            reasons.append(_('El soci té al menys un contracte vinculat com a soci i titular.'))
+
+        polisses_apadrinades = pol_obj.search(cursor, uid,
+                                  [('soci', '=', res_partner_id),
+                                   ('titular', '!=', res_partner_id),
+                                   ('state', '!=', 'baixa'),
+                                   ('state', '!=', 'cancelada')])
+        if polisses_apadrinades and not context.get('skip_sponsored_check', False):
+            reasons.append(_('El soci té al menys un contracte apadrinat.'))
+
+        return reasons
+
+    def do_baixa_soci(self, cursor, uid, member_id, bank_account_id, context=None):
+        # - Comprovar si té generationkwh: Existeix atribut al model generation que ho indica. Altrament es poden buscar les inversions.
+        # - Comprovar si té inversions vigents: Buscar inversions vigents.
+        # - Comprovar si té contractes actius: Buscar contractes vigents.
+        # - Comprovar si té Factures pendents de pagament: Per a aquesta comprovació hi ha una tasca feta a la OV que ens pot ajudar feta per en Fran a la següent PR: https://github.com/gisce/erp/pull/7997/files
+
+        """Mètode per donar de baixa un soci."""
+        context = context or {}
+
+        reasons = self.get_baixa_blocking_reasons(cursor, uid, member_id, context=context)
+        if reasons:
+            raise osv.except_osv("Error", _('El soci no pot ser donat de baixa!'), '\n'.join(reasons))
+
+        imd_obj = self.pool.get('ir.model.data')
+        soci_obj = self.pool.get('somenergia.soci')
+        rpa_obj = self.pool.get('res.partner.address')
+
+        today = datetime.today().strftime('%Y-%m-%d')
+        res_partner_id = soci_obj.read(cursor, uid, member_id, ['partner_id'])['partner_id'][0]
 
         soci_category_id = imd_obj.get_object_reference(
             cursor, uid, 'som_partner_account', 'res_partner_category_soci'
         )[1]
 
         def delete_rel(cursor, uid, categ_id, res_partner_id):
-            cursor.execute('delete from res_partner_category_rel where category_id=%s and partner_id=%s',(categ_id, res_partner_id))
+            cursor.execute(
+                'delete from res_partner_category_rel where category_id=%s and partner_id=%s',
+                (categ_id, res_partner_id)
+            )
 
         res_users = self.pool.get('res.users')
         usuari = res_users.read(cursor, uid, uid, ['name'])['name']
         old_comment = soci_obj.read(cursor, uid, [member_id], ['comment'])[0]['comment']
-        old_comment = old_comment + '\n' if old_comment else '' 
-        comment =  "{}Baixa efectuada a data {} per: {}".format(old_comment, today, usuari)
-        soci_obj.write(cursor, uid, [member_id], {'baixa': True,
-                                                'data_baixa_soci': today,
-                                                'comment': comment })
+        old_comment = old_comment + '\n' if old_comment else ''
+        comment = "{}Baixa efectuada a data {} per: {}".format(old_comment, today, usuari)
+        soci_obj.write(cursor, uid, [member_id], {
+            'baixa': True,
+            'data_baixa_soci': today,
+            'comment': comment,
+        })
         delete_rel(cursor, uid, soci_category_id, res_partner_id)
 
+        self._unlink_sponsored_contracts(cursor, uid, res_partner_id, context)
         rpa_obj.unsubscribe_partner_in_members_lists(
             cursor, uid, [res_partner_id], context=context
         )
+        self._create_payment_line(cursor, uid, member_id, bank_account_id, context)
         return True
 
+    def _unlink_sponsored_contracts(self, cursor, uid, res_partner_id, context=None):
+        polissa_obj = self.pool.get('giscedata.polissa')
+        res_partner_obj = self.pool.get('res.partner')
+
+        dni_soci = res_partner_obj.read(cursor, uid, res_partner_id, ['vat'])['vat']
+        polisses_apadrinades = polissa_obj.search(cursor, uid, [
+            ('soci', '=', res_partner_id), ('titular', '!=', res_partner_id)
+        ])
+        for polissa_id in polisses_apadrinades:
+            polissa_vals = polissa_obj.read(cursor, uid, polissa_id, ['titular', 'name'])
+            titular_id = polissa_vals['titular'][0]
+            titular_notes = res_partner_obj.read(
+                cursor, uid, titular_id, ['comment'])['comment'] or ''
+            titular_notes = (
+                "{} Contracte {} apadrinat per {},"
+                " soci es dona de baixa i treiem apadrinament."
+                .format(datetime.now().strftime('%Y-%m-%d'), polissa_vals['name'], dni_soci)
+            )
+            polissa_obj.write(cursor, uid, polissa_id, {'soci': False})
+            res_partner_obj.write(cursor, uid, titular_id, {'comment': titular_notes})
+
+    def _create_payment_line(self, cursor, uid, member_id, bank_account_id, context=None):
+        conf_o = self.pool.get("res.config")
+        imd_o = self.pool.get("ir.model.data")
+        payment_mode_o = self.pool.get("payment.mode")
+        payment_order_o = self.pool.get("payment.order")
+        currency_o = self.pool.get("res.currency")
+        soci_o = self.pool.get("somenergia.soci")
+        account_o = self.pool.get("account.account")
+        invoice_o = self.pool.get("account.invoice")
+        journal_o = self.pool.get("account.journal")
+        payment_type_o = self.pool.get("payment.type")
+        payment_line_o = self.pool.get("payment.line")
+
+        socia_fee_amount = conf_o.get(cursor, uid, "socia_member_fee_amount", "100")
+        currency_id = currency_o.search(cursor, uid, [("name", "=", "EUR")])[0]
+        payment_mode_id = imd_o.get_object_reference(
+            cursor, uid, "som_generationkwh", "soci_return_payment_mode")[1]
+        payment_mode_name = payment_mode_o.read(cursor, uid, payment_mode_id, ["name"])["name"]
+        acc_id_100 = account_o.search(cursor, uid, [("code", "=", "100000000000")])[0]
+        acc_id_430 = account_o.search(cursor, uid, [("code", "=", "430000000000")])[0]
+        journal_id = journal_o.search(
+            cursor, uid, [("code", "=", "SOCIS_RETURN")], context=context
+        )[0]
+        payment_type_id = payment_type_o.search(
+            cursor, uid, [("code", "=", "TRANSFERENCIA_CSB")], context=context
+        )[0]
+        soci = soci_o.browse(cursor, uid, member_id, context=context)
+
+        # Create invoice line
+        inv_line = {
+            "name": _MEMBER_FEE_RETURN_PURPOSE,
+            "account_id": acc_id_100,
+            "price_unit": socia_fee_amount,
+            "quantity": 1,
+            "uom_id": 1,
+            "company_currency_id": currency_id,
+        }
+
+        # Create invoice
+        invoice_name = "RETORN-QUOTA-SOCIS-{}".format(soci.partner_id.ref)
+        invoice_vals = {
+            "name": invoice_name,
+            "number": invoice_name,
+            "partner_id": soci.partner_id.id,
+            "type": "in_invoice",
+            "invoice_line": [(0, 0, inv_line)],
+            "origin_date_invoice": datetime.today().strftime("%Y-%m-%d"),
+            "date_invoice": datetime.today().strftime("%Y-%m-%d"),
+            "journal_id": journal_id,
+            "origin": invoice_name,
+            "reference": invoice_name,
+            "check_total": socia_fee_amount,
+            "sii_to_send": False,
+        }
+        invoice_vals.update(invoice_o.onchange_partner_id(  # Get invoice default values
+            cursor, uid, [], "in_invoice", soci.partner_id.id).get("value", {})
+        )
+        invoice_vals.update({
+            "payment_type": payment_type_id,
+            "partner_bank": bank_account_id,
+            "account_id": acc_id_430,
+        })
+
+        invoice_id = invoice_o.create(cursor, uid, invoice_vals, context=context)
+        invoice_o.button_reset_taxes(cursor, uid, [invoice_id])
+
+        # open the invoice
+        wf_service = netsvc.LocalService("workflow")
+        wf_service.trg_validate(uid, 'account.invoice', invoice_id, 'invoice_open', cursor)
+
+        payment_order_id = payment_order_o.get_or_create_open_payment_order(
+            cursor, uid,  payment_mode_name, use_invoice=True, context=context
+        )
+        invoice_o.afegeix_a_remesa(cursor, uid, [invoice_id], payment_order_id, context=context)
+
+        # set the member number as the payment line name
+        payment_line_id = payment_line_o.search(
+            cursor, uid,
+            [
+                ("partner_id", "=", soci.partner_id.id),
+                ("communication", "=", "{}. {}".format(invoice_name, invoice_name)),
+                ("order_id", "=", payment_order_id),
+            ],
+            context=context
+        )
+        payment_line_o.write(
+            cursor, uid, payment_line_id, {"name": invoice_name}, context=context)
 
     _columns = {
         'has_gkwh': fields.function(

--- a/som_generationkwh/tests/generation_data_demo.xml
+++ b/som_generationkwh/tests/generation_data_demo.xml
@@ -464,6 +464,15 @@
             <field name="name">Capital social demo</field>
             <field name="user_type" ref="l10n_chart_ES.financieras"/>
         </record>
+        <record id="account_clients_demo" model="account.account">
+            <field name="name">Clients</field>
+            <field name="code">430000000000</field>
+            <field name="type">receivable</field>
+            <field eval="ref('account.minimal_0')" name="parent_id"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field eval="True" name="reconcile"/>
+            <field name="user_type" ref="account.account_type_income"/>
+        </record>
         <!-- we use the Caixa account and demo account because it's created in the same module, and this is demo -->
         <record id="property_gkwh_account_demo" model="ir.property">
             <field name="name">property_account_gkwh</field>

--- a/som_generationkwh/tests/investment_strategy_tests.py
+++ b/som_generationkwh/tests/investment_strategy_tests.py
@@ -45,6 +45,7 @@ class InvestmentStrategyTests(testing.OOTestCase):
         self.Emission = self.openerp.pool.get('generationkwh.emission')
         self.PaymentLine = self.openerp.pool.get('payment.line')
         self.PaymentOrder = self.openerp.pool.get('payment.order')
+        self.PaymentType = self.openerp.pool.get('payment.type')
         self.Soci = self.openerp.pool.get('somenergia.soci')
         self.IrProperty = self.openerp.pool.get('ir.property')
         self.AccountAccount = self.openerp.pool.get('account.account')
@@ -154,6 +155,7 @@ class InvestmentStrategyTests(testing.OOTestCase):
                         )[1]
             emission_data = investment.emission_id
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
 
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
@@ -198,7 +200,7 @@ class InvestmentStrategyTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -210,14 +212,15 @@ class InvestmentStrategyTests(testing.OOTestCase):
                 year=datetime.today().strftime("%Y"),
                 investment_name=investment.name,
                 p=partner_data,
-                num_soci= partner_data.ref[1:],
+                num_soci=partner_data.ref[1:],
                 investment_id=id,
                 taxes_id=taxes_id,
                 invoice_line_tax_id=invoice.invoice_line[0].invoice_line_tax_id[0].id,
                 liq_account_code=liq_account_dict['code'],
                 liq_account_name=liq_account_dict['name'],
                 apo_account_code=apo_account_dict['code'],
-                apo_account_name=apo_account_dict['name']
+                apo_account_name=apo_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     def test__create_interest_invoices__AllOkAPO_middlePurchaseDateAndLastEffectiveDate(self):
@@ -260,6 +263,7 @@ class InvestmentStrategyTests(testing.OOTestCase):
                         )[1]
             emission_data = investment.emission_id
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
 
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
@@ -304,7 +308,7 @@ class InvestmentStrategyTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -323,5 +327,6 @@ class InvestmentStrategyTests(testing.OOTestCase):
                 liq_account_code=liq_account_dict['code'],
                 liq_account_name=liq_account_dict['name'],
                 apo_account_code=apo_account_dict['code'],
-                apo_account_name=apo_account_dict['name']
+                apo_account_name=apo_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))

--- a/som_generationkwh/tests/investment_tests.py
+++ b/som_generationkwh/tests/investment_tests.py
@@ -41,6 +41,7 @@ class InvestmentTests(testing.OOTestCase):
         self.Emission = self.openerp.pool.get('generationkwh.emission')
         self.PaymentLine = self.openerp.pool.get('payment.line')
         self.PaymentOrder = self.openerp.pool.get('payment.order')
+        self.PaymentType = self.openerp.pool.get('payment.type')
         self.Soci = self.openerp.pool.get('somenergia.soci')
         self.Product = self.openerp.pool.get('product.product')
         self.AccountAccount = self.openerp.pool.get('account.account')
@@ -596,6 +597,7 @@ class InvestmentTests(testing.OOTestCase):
             mandate_id = self.Investment.get_or_create_payment_mandate(cursor, uid,
                 partner_id, iban, investment.emission_id.mandate_name, gkwh.creditorCode)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'RECIBO_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids[0], u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 2000.0
@@ -635,7 +637,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 2
+                - {payment_type_id}
                 - Recibo domiciliado
                 sii_to_send: false
                 type: out_invoice
@@ -653,7 +655,8 @@ class InvestmentTests(testing.OOTestCase):
                 gkwh_account_code=gkwh_account_dict['code'],
                 gkwh_account_name=gkwh_account_dict['name'],
                 liq_account_code=liq_account_dict['code'],
-                liq_account_name=liq_account_dict['name']
+                liq_account_name=liq_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     def test__create_initial_invoices__AllOkAPO(self):
@@ -679,6 +682,7 @@ class InvestmentTests(testing.OOTestCase):
             mandate_id = self.Investment.get_or_create_payment_mandate(cursor, uid,
                 partner_id, iban, emission_data.mandate_name, gkwh.creditorCode)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'RECIBO_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids[0], u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 1000.0
@@ -718,7 +722,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 2
+                - {payment_type_id}
                 - Recibo domiciliado
                 sii_to_send: false
                 type: out_invoice
@@ -736,7 +740,8 @@ class InvestmentTests(testing.OOTestCase):
                 liq_account_code=liq_account_dict['code'],
                 liq_account_name=liq_account_dict['name'],
                 apo_account_code=apo_account_dict['code'],
-                apo_account_name=apo_account_dict['name']
+                apo_account_name=apo_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     def test__create_initial_invoices__withNegativeAmount_APO(self):
@@ -1947,6 +1952,7 @@ class InvestmentTests(testing.OOTestCase):
             self.assertFalse(errs)
             self.assertTrue(invoice_ids)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 1000.0
@@ -1987,7 +1993,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -2005,7 +2011,8 @@ class InvestmentTests(testing.OOTestCase):
                 gkwh_account_code=gkwh_account_dict['code'],
                 gkwh_account_name=gkwh_account_dict['name'],
                 liq_account_code=liq_account_dict['code'],
-                liq_account_name=liq_account_dict['name']
+                liq_account_name=liq_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     def test__create_divestment_invoice__withProfitOneYearOkGKWH(self):
@@ -2035,6 +2042,7 @@ class InvestmentTests(testing.OOTestCase):
             self.assertFalse(errs)
             self.assertTrue(invoice_ids)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 993.0
@@ -2097,7 +2105,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -2117,7 +2125,8 @@ class InvestmentTests(testing.OOTestCase):
                 gkwh_account_code=gkwh_account_dict['code'],
                 gkwh_account_name=gkwh_account_dict['name'],
                 liq_account_code=liq_account_dict['code'],
-                liq_account_name=liq_account_dict['name']
+                liq_account_name=liq_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     def test__create_divestment_invoice__withProfitTwoYears_irpNotRoundedOkGKWH(self):
@@ -2146,6 +2155,7 @@ class InvestmentTests(testing.OOTestCase):
             self.assertFalse(errs)
             self.assertTrue(invoice_ids)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 999.9
@@ -2230,7 +2240,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -2251,7 +2261,8 @@ class InvestmentTests(testing.OOTestCase):
                 gkwh_account_code=gkwh_account_dict['code'],
                 gkwh_account_name=gkwh_account_dict['name'],
                 liq_account_code=liq_account_dict['code'],
-                liq_account_name=liq_account_dict['name']
+                liq_account_name=liq_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
 
@@ -2283,6 +2294,7 @@ class InvestmentTests(testing.OOTestCase):
             self.assertFalse(errs)
             self.assertTrue(invoice_ids)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 990.0
@@ -2367,7 +2379,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -2388,7 +2400,8 @@ class InvestmentTests(testing.OOTestCase):
                 gkwh_account_code=gkwh_account_dict['code'],
                 gkwh_account_name=gkwh_account_dict['name'],
                 liq_account_code=liq_account_dict['code'],
-                liq_account_name=liq_account_dict['name']
+                liq_account_name=liq_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     def test__create_divestment_invoice__APO(self):
@@ -2416,6 +2429,7 @@ class InvestmentTests(testing.OOTestCase):
             self.assertFalse(errs)
             self.assertTrue(invoice_ids)
             partner_data = self.Partner.browse(cursor, uid, partner_id)
+            payment_type_id = self.PaymentType.search(cursor, uid, [('code', '=', 'TRANSFERENCIA_CSB')])[0]
             self.assertInvoiceInfoEqual(cursor, uid, invoice_ids, u"""\
                 account_id: {liq_account_code} {liq_account_name}
                 amount_total: 1000.0
@@ -2456,7 +2470,7 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3
+                - {payment_type_id}
                 - Transferencia
                 sii_to_send: false
                 type: in_invoice
@@ -2474,7 +2488,8 @@ class InvestmentTests(testing.OOTestCase):
                 apo_account_name=apo_account_dict['name'],
                 apo_account_code=apo_account_dict['code'],
                 liq_account_code=liq_account_dict['code'],
-                liq_account_name=liq_account_dict['name']
+                liq_account_name=liq_account_dict['name'],
+                payment_type_id=payment_type_id
                 ))
 
     @unittest.skip("FIXME: There is an error with the payment mode, but probably a test data problem D:")

--- a/som_generationkwh/tests/partner_tests.py
+++ b/som_generationkwh/tests/partner_tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from destral import testing
 from destral.transaction import Transaction
+from destral.patch import PatchNewCursors
 from yamlns import namespace as ns
 from datetime import date
 from freezegun import freeze_time
@@ -20,11 +21,12 @@ class PartnerTests(testing.OOTestCase):
         self.IrModelData = self.openerp.pool.get('ir.model.data')
         self.GenerationkWhAssignment = self.openerp.pool.get('generationkwh.assignment')
         self.GiscedataPolissa = self.openerp.pool.get('giscedata.polissa')
-        # self.txn = Transaction().start(self.database)
+        #self.txn = Transaction().start(self.database)
 
     def tearDown(self):
-        # self.txn.stop()
+        #self.txn.stop()
         pass
+
 
     def test__clean_iban__beingCanonical(self):
         with Transaction().start(self.database) as txn:
@@ -104,8 +106,8 @@ class PartnerTests(testing.OOTestCase):
             cursor = txn.cursor
             uid = txn.user
             partner_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
-            )[1]
+                        cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
+                        )[1]
             member_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'soci_0001')[1]
 
@@ -144,8 +146,8 @@ class PartnerTests(testing.OOTestCase):
             cursor = txn.cursor
             uid = txn.user
             partner_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
-            )[1]
+                        cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
+                        )[1]
             member_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'soci_0001')[1]
 
@@ -189,39 +191,19 @@ class PartnerTests(testing.OOTestCase):
                 cursor, uid, 'som_generationkwh', 'soci_0001')[1]
             polissa_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'giscedata_polissa', 'polissa_0001')[1]
-            self.GenerationkWhAssignment.create(
-                cursor,
-                uid,
-                {
-                    'member_id': member_id,
-                    'contract_id': polissa_id,
-                    'priority': 0,
-                }
-            )
+            self.GenerationkWhAssignment.create(cursor, uid, {'member_id': member_id,
+                'contract_id': polissa_id, 'priority': 0})
 
             assig_list = self.partner_obj.www_generationkwh_assignments(cursor, uid, partner_id)
 
             for a in assig_list:
                 a.pop('id')
+            self.assertEquals(assig_list, [{'annual_use_kwh': False,
+                'contract_address': u'carrer inventat, 1 ESC. 1 1 1 aclaridor 00001 (Poble de Prova)',
+                'contract_id': 1, 'contract_last_invoiced': False, 'contract_name': u'0001C',
+                'contract_state': u'esborrany', 'member_id': member_id, 'member_name': u'Gil, Pere',
+                'priority': 0, 'contract_tariff': u'2.0A'}])
 
-            def normalize_spaces(text):
-                return u' '.join((text or u'').split())
-
-            assig_list[0]['contract_address'] = normalize_spaces(assig_list[0]['contract_address'])
-            self.assertEquals(assig_list, [{
-                'annual_use_kwh': False,
-                'contract_address': normalize_spaces(
-                    u'carrer inventat, 1 ESC. 1 1 1 aclaridor 00001 (Poble de Prova)'
-                ),
-                'contract_id': 1,
-                'contract_last_invoiced': False,
-                'contract_name': u'0001C',
-                'contract_state': u'esborrany',
-                'member_id': member_id,
-                'member_name': u'Gil, Pere',
-                'priority': 0,
-                'contract_tariff': u'2.0A',
-            }])
 
     def test__www_generationkwh_assignments_donation_partners(self):
         with Transaction().start(self.database) as txn:
@@ -237,21 +219,14 @@ class PartnerTests(testing.OOTestCase):
             # partner of member_id
             donation_partner_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'res_partner_inversor1')[1]
-            self.GenerationkWhAssignment.create(
-                cursor,
-                uid,
-                {
-                    'member_id': member_id,
-                    'contract_id': polissa_id,
-                    'priority': 0,
-                }
-            )
+            self.GenerationkWhAssignment.create(cursor, uid, {'member_id': member_id,
+                'contract_id': polissa_id, 'priority': 0})
             self.GiscedataPolissa.write(cursor, uid, polissa_id, {'state': 'activa'})
 
-            partner_list = self.partner_obj.www_generationkwh_assignments_donation_partners(
-                cursor, uid, partner_id)
+            partner_list = self.partner_obj.www_generationkwh_assignments_donation_partners(cursor, uid, partner_id)
 
             self.assertEquals(partner_list, [donation_partner_id])
+
 
     def test__www_set_generationkwh_assignment_order(self):
         with Transaction().start(self.database) as txn:
@@ -291,6 +266,7 @@ class PartnerTests(testing.OOTestCase):
             self.assertEqual(assig_list[2]['priority'], 2)
             self.assertEqual(assig_list[2]['contract_id'], polissa_id_1)
 
+
     def test__www_set_generationkwh_assignment_order_same_member(self):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
@@ -319,6 +295,7 @@ class PartnerTests(testing.OOTestCase):
                 self.partner_obj.www_set_generationkwh_assignment_order(
                     cursor, uid, partner_id, [assignment_2, assignment_1])
             self.assertEqual(e.exception.message, u"There are different member_ids")
+
 
     def test__www_set_generationkwh_assignment_order_all_assignments(self):
         with Transaction().start(self.database) as txn:
@@ -354,6 +331,7 @@ class PartnerTests(testing.OOTestCase):
             self.assertEqual(
                 e.exception.message, u"You need to order all the assignments at once")
 
+
     def test___last_invoiced_date_from_priority_polissa(self):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
@@ -362,15 +340,13 @@ class PartnerTests(testing.OOTestCase):
                 cursor, uid, 'som_generationkwh', 'soci_0001')[1]
             polissa_id_1 = self.IrModelData.get_object_reference(
                 cursor, uid, 'giscedata_polissa', 'polissa_0001')[1]
-            self.GiscedataPolissa.write(cursor, uid, polissa_id_1, {
-                                        'data_ultima_lectura': '2023-11-07'})
+            self.GiscedataPolissa.write(cursor, uid, polissa_id_1, {'data_ultima_lectura': '2023-11-07'})
             self.GenerationkWhAssignment.create(
                 cursor, uid,
                 {'member_id': member_id, 'contract_id': polissa_id_1, 'priority': 0}
             )
 
-            last_invoiced_date = self.partner_obj._last_invoiced_date_from_priority_polissa(
-                cursor, uid, member_id)
+            last_invoiced_date = self.partner_obj._last_invoiced_date_from_priority_polissa(cursor, uid, member_id)
 
             self.assertEqual(last_invoiced_date, date(2023, 11, 7))
 
@@ -385,8 +361,7 @@ class PartnerTests(testing.OOTestCase):
                 cursor, uid, 'som_generationkwh', 'soci_0001')[1]
             polissa_id_1 = self.IrModelData.get_object_reference(
                 cursor, uid, 'giscedata_polissa', 'polissa_0001')[1]
-            self.GiscedataPolissa.write(cursor, uid, polissa_id_1, {
-                                        'data_ultima_lectura': '2023-11-07'})
+            self.GiscedataPolissa.write(cursor, uid, polissa_id_1, {'data_ultima_lectura': '2023-11-07'})
             self.GenerationkWhAssignment.create(
                 cursor, uid,
                 {'member_id': member_id, 'contract_id': polissa_id_1, 'priority': 0}
@@ -407,18 +382,17 @@ class PartnerTests(testing.OOTestCase):
                 cursor, uid, 'som_generationkwh', 'soci_0001')[1]
             polissa_id_1 = self.IrModelData.get_object_reference(
                 cursor, uid, 'giscedata_polissa', 'polissa_0001')[1]
-            self.GiscedataPolissa.write(cursor, uid, polissa_id_1, {
-                                        'data_ultima_lectura': '2023-11-07'})
+            self.GiscedataPolissa.write(cursor, uid, polissa_id_1, {'data_ultima_lectura': '2023-11-07'})
             self.GenerationkWhAssignment.create(
                 cursor, uid,
                 {'member_id': member_id, 'contract_id': polissa_id_1, 'priority': 0}
             )
 
-            rights = self.partner_obj.www_hourly_rights_generationkwh(
-                cursor, uid, partner_id, '2023-10-01', '2023-11-07')
+            rights = self.partner_obj.www_hourly_rights_generationkwh(cursor, uid, partner_id, '2023-10-01', '2023-11-07')
 
             self.assertEqual(len(rights), 912)
             self.assertEqual(sum(r['value'] for r in rights), 0)
+
 
     def test__prepare_datetime_value_www_response(self):
         original = {

--- a/som_generationkwh/tests/polissa_tests.py
+++ b/som_generationkwh/tests/polissa_tests.py
@@ -36,7 +36,7 @@ class PolissaTests(testing.OOTestCaseWithCursor):
         result = self.Polissa.generationkwh_anual_estimation(
             cursor, uid, polissa_id, '2016-12-31')
 
-        self.assertFalse(result)
+        self.assertEqual(result, (False, 'no_data'))
 
     @mock.patch("som_generationkwh.giscedata_polissa.GiscedataPolissa.get_generationkwh_use")
     def test_generationkwh_anual_estimation_with_full_data(self, mocked_get_use):
@@ -56,11 +56,10 @@ class PolissaTests(testing.OOTestCaseWithCursor):
         result = self.Polissa.generationkwh_anual_estimation(
             cursor, uid, polissa_id, '2016-12-31')
 
-        self.assertEqual(result, {
+        self.assertEqual(result, ({
             'P1': 120,
             'P2': 60,
-        })
-
+        }, 'full_data'))
 
     @mock.patch("som_generationkwh.giscedata_polissa.GiscedataPolissa.get_generationkwh_use")
     def test_generationkwh_anual_estimation_with_partial_data(self, mocked_get_use):
@@ -84,7 +83,7 @@ class PolissaTests(testing.OOTestCaseWithCursor):
         result = self.Polissa.generationkwh_anual_estimation(
             cursor, uid, polissa_id, '2016-12-31')
 
-        self.assertEqual(result, {
+        self.assertEqual(result, ({
             'P1': 132,
             'P2': 36,
-        })
+        }, 'partial_data'))

--- a/som_generationkwh/tests/somenergia_soci_tests.py
+++ b/som_generationkwh/tests/somenergia_soci_tests.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
-import unittest
 from destral import testing
 from destral.transaction import Transaction
-import netsvc
+from destral.patch import PatchNewCursors
 from datetime import datetime, timedelta, date
-from osv import osv, fields
-from osv.orm import ValidateException
 from osv.osv import except_osv
 import mock
-import som_polissa_soci
-import mailchimp_marketing
+
 
 class SomenergiaSociTests(testing.OOTestCase):
 
@@ -25,6 +21,11 @@ class SomenergiaSociTests(testing.OOTestCase):
         self.Factura = self.openerp.pool.get('giscedata.facturacio.factura')
         self.Polissa = self.openerp.pool.get('giscedata.polissa')
         self.Soci = self.openerp.pool.get('somenergia.soci')
+        self.PaymentOrder = self.openerp.pool.get('payment.order')
+        self.WizPayRemesa = self.openerp.pool.get('pagar.remesa.wizard')
+        self.ResPartnerBank = self.openerp.pool.get('res.partner.bank')
+
+        self.bank_account_id = 1  # just for tests
 
     def tearDown(self):
         self.txn.stop()
@@ -38,13 +39,13 @@ class SomenergiaSociTests(testing.OOTestCase):
         future_date = (today + timedelta(days=365)).strftime('%Y-%m-%d')
         investment.write({'last_effective_date': future_date})
         member_id = investment.member_id.id
-        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
 
         with self.assertRaises(except_osv) as ctx:
-            self.Soci.verifica_baixa_soci(self.cursor, self.uid, member_id)
+            self.Soci.do_baixa_soci(self.cursor, self.uid, member_id, self.bank_account_id)
 
-        self.assertEqual(ctx.exception.message,
-            "warning -- El soci no pot ser donat de baixa!\n\nEl soci té inversions de generation actives.")
+        self.assertIn("El soci té inversions de generation actives", ctx.exception.message)
 
     def test_cancel_member_with_active_apo__notAllowed(self):
         invest_id = self.IrModelData.get_object_reference(
@@ -52,41 +53,43 @@ class SomenergiaSociTests(testing.OOTestCase):
             )[1]
         investment = self.Investment.browse(self.cursor, self.uid, invest_id)
         member_id = investment.member_id.id
-        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
         investment.write({'last_effective_date': False, 'draft': False})
-        generation_invs = self.Investment.search(self.cursor, self.uid, [('member_id','=', member_id),('emission_id','=',1)])
-        self.Investment.write(self.cursor, self.uid, generation_invs, {'active':False})
+        generation_invs = self.Investment.search(
+            self.cursor, self.uid, [('member_id', '=', member_id), ('emission_id', '=', 1)])
+        self.Investment.write(self.cursor, self.uid, generation_invs, {'active': False})
 
         with self.assertRaises(except_osv) as ctx:
-            self.Soci.verifica_baixa_soci(self.cursor, self.uid, member_id)
+            self.Soci.do_baixa_soci(self.cursor, self.uid, member_id, self.bank_account_id)
 
-        self.assertEqual(ctx.exception.message,
-            "warning -- El soci no pot ser donat de baixa!\n\nEl soci té aportacions actives.")
-    
+        self.assertIn("El soci té aportacions actives", ctx.exception.message)
+
     def test_cancel_member_with_pending_invoices__notAllowed(self):
         fact_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'giscedata_facturacio', 'factura_0001'
             )[1]
         partner_id = self.IrModelData.get_object_reference(
-            self.cursor, self.uid, 'som_generationkwh', 'res_partner_inversor1' 
+            self.cursor, self.uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
         member_id = self.IrModelData.get_object_reference(
-            self.cursor, self.uid, 'som_generationkwh', 'soci_0001' 
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
             )[1]
-        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
 
-        invs = self.Investment.search(self.cursor, self.uid, [('member_id','=', member_id)])
-        self.Investment.write(self.cursor, self.uid, invs, {'active':False})
+        invs = self.Investment.search(self.cursor, self.uid, [('member_id', '=', member_id)])
+        self.Investment.write(self.cursor, self.uid, invs, {'active': False})
 
-        invoice_id = self.Factura.read(self.cursor, self.uid, fact_id, ['invoice_id'])['invoice_id'][0]
-        self.Invoice.write(self.cursor, self.uid, invoice_id, {'partner_id': partner_id,
-                                                       'state': 'open'})
-    
+        invoice_id = self.Factura.read(
+            self.cursor, self.uid, fact_id, ['invoice_id'])['invoice_id'][0]
+        self.Invoice.write(
+            self.cursor, self.uid, invoice_id, {'partner_id': partner_id, 'state': 'open'})
+
         with self.assertRaises(except_osv) as ctx:
-            self.Soci.verifica_baixa_soci(self.cursor, self.uid, member_id)
+            self.Soci.do_baixa_soci(self.cursor, self.uid, member_id, self.bank_account_id)
 
-        self.assertEqual(ctx.exception.message,
-            "warning -- El soci no pot ser donat de baixa!\n\nEl soci té factures pendents.")
+        self.assertIn("El soci té factures pendents", ctx.exception.message)
 
     @mock.patch("som_polissa_soci.models.res_partner_address.ResPartnerAddress.unsubscribe_partner_in_members_lists")  # noqa: E501
     def test_cancel_member_with_active_contract__Allowed(self, mailchimp_mock):
@@ -96,10 +99,11 @@ class SomenergiaSociTests(testing.OOTestCase):
         member_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
             )[1]
-        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
-        invs = self.Investment.search(self.cursor, self.uid, [('member_id','=', member_id)])
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        invs = self.Investment.search(self.cursor, self.uid, [('member_id', '=', member_id)])
 
-        self.Investment.write(self.cursor, self.uid, invs, {'active':False})
+        self.Investment.write(self.cursor, self.uid, invs, {'active': False})
 
         polissa_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
@@ -107,8 +111,10 @@ class SomenergiaSociTests(testing.OOTestCase):
 
         self.Polissa.write(self.cursor, self.uid, [polissa_id], {'titular': partner_id})
 
-        self.assertEqual(self.Soci.verifica_baixa_soci(self.cursor, self.uid, member_id), True)
-        partner_id = self.Soci.read(self.cursor, self.uid, member_id, ['partner_id'])['partner_id'][0]
+        self.assertEqual(
+            self.Soci.do_baixa_soci(self.cursor, self.uid, member_id, self.bank_account_id), True)
+        partner_id = self.Soci.read(
+            self.cursor, self.uid, member_id, ['partner_id'])['partner_id'][0]
         mailchimp_mock.assert_called_with(self.cursor, self.uid, [partner_id], context={})
 
     def test_cancel_member_with_related_contract__notAllowed(self):
@@ -118,10 +124,11 @@ class SomenergiaSociTests(testing.OOTestCase):
         member_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
             )[1]
-        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
-        invs = self.Investment.search(self.cursor, self.uid, [('member_id','=', member_id)])
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        invs = self.Investment.search(self.cursor, self.uid, [('member_id', '=', member_id)])
 
-        self.Investment.write(self.cursor, self.uid, invs, {'active':False})
+        self.Investment.write(self.cursor, self.uid, invs, {'active': False})
 
         polissa_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
@@ -130,7 +137,150 @@ class SomenergiaSociTests(testing.OOTestCase):
         self.Polissa.write(self.cursor, self.uid, [polissa_id], {'soci': partner_id})
 
         with self.assertRaises(except_osv) as ctx:
-            self.Soci.verifica_baixa_soci(self.cursor, self.uid, member_id)
+            self.Soci.do_baixa_soci(self.cursor, self.uid, member_id, self.bank_account_id)
 
-        self.assertEqual(ctx.exception.message,
-            "warning -- El soci no pot ser donat de baixa!\n\nEl soci té al menys un contracte vinculat.")
+        self.assertIn("El soci té al menys un contracte vinculat", ctx.exception.message)
+
+    def test_cancel_member_with_sponsored_contract__notAllowed(self):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
+        )[1]
+        partner_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'res_partner_inversor1'
+        )[1]
+        sponsored_partner_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'res_partner_noinversor2'
+        )[1]
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        invs = self.Investment.search(self.cursor, self.uid, [('member_id', '=', member_id)])
+
+        self.Investment.write(self.cursor, self.uid, invs, {'active': False})
+
+        polissa_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
+        )[1]
+
+        self.Polissa.write(self.cursor, self.uid, [polissa_id], {
+            'soci': partner_id, 'titular': sponsored_partner_id
+        })
+
+        res = self.Soci.get_baixa_blocking_reasons(self.cursor, self.uid, member_id)
+
+        self.assertEqual(res, ["El soci té al menys un contracte apadrinat."])
+
+    @mock.patch("som_polissa_soci.models.res_partner_address.ResPartnerAddress.unsubscribe_partner_in_members_lists")  # noqa: E501
+    def test_cancel_member_with_sponsored_contract_with_context__Allowed(self, mailchimp_mock):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
+        )[1]
+        partner_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'res_partner_inversor1'
+        )[1]
+        sponsored_partner_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'res_partner_noinversor2'
+        )[1]
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        invs = self.Investment.search(self.cursor, self.uid, [('member_id', '=', member_id)])
+
+        self.Investment.write(self.cursor, self.uid, invs, {'active': False})
+
+        polissa_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
+        )[1]
+
+        self.Polissa.write(self.cursor, self.uid, [polissa_id], {
+            'soci': partner_id, 'titular': sponsored_partner_id
+        })
+
+        self.Soci.do_baixa_soci(
+            self.cursor, self.uid, member_id,
+            self.bank_account_id, context={'skip_sponsored_check': True}
+        )
+
+        polissa = self.Polissa.browse(self.cursor, self.uid, polissa_id)
+        self.assertFalse(polissa.soci)
+        self.assertEqual(polissa.state, 'esborrany')
+        self.assertEqual(polissa.titular.id, sponsored_partner_id)
+        self.assertIn('treiem apadrinament', polissa.titular.comment)
+        mailchimp_mock.assert_called_with(
+            self.cursor, self.uid, [partner_id], context={'skip_sponsored_check': True})
+
+    @mock.patch("som_polissa_soci.models.res_partner_address.ResPartnerAddress.unsubscribe_partner_in_members_lists")  # noqa: E501
+    def test_cancel_member_with_active_contract_creates_payment_order(self, mailchimp_mock):
+        partner_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'res_partner_inversor1'
+            )[1]
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
+            )[1]
+        return_payment_mode_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_return_payment_mode'
+        )[1]
+        self.Soci.write(
+            self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        invs = self.Investment.search(self.cursor, self.uid, [('member_id', '=', member_id)])
+        self.Investment.write(self.cursor, self.uid, invs, {'active': False})
+
+        polissa_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'giscedata_polissa', 'polissa_0001'
+        )[1]
+        self.Polissa.write(self.cursor, self.uid, [polissa_id], {'titular': partner_id})
+
+        payment_order_ids = self.PaymentOrder.search(
+            self.cursor, self.uid, [('mode', '=', return_payment_mode_id)])
+        self.assertEqual(len(payment_order_ids), 0)
+
+        self.ResPartnerBank.write(self.cursor, self.uid, self.bank_account_id, {
+            'iban': 'ES7712341234161234567890',
+        })
+
+        self.assertEqual(
+            self.Soci.do_baixa_soci(self.cursor, self.uid, member_id, self.bank_account_id), True)
+        mailchimp_mock.assert_called_with(self.cursor, self.uid, [partner_id], context={})
+
+        # Check the payment order and invoice
+        ref_soci = self.ResPartner.read(self.cursor, self.uid, partner_id, ['ref'])['ref']
+        invoice_id = self.Invoice.search(
+            self.cursor, self.uid, [("partner_id", "=", partner_id), ("type", "=", "in_invoice")])[0]
+
+        invoice = self.Invoice.browse(self.cursor, self.uid, invoice_id)
+
+        self.assertFalse(invoice.sii_to_send)
+
+        invoice_name = "RETORN-QUOTA-SOCIS-{}".format(ref_soci)
+        self.assertEqual(invoice.number, invoice_name)
+        self.assertEqual(invoice.amount_total, 100)
+        self.assertEqual(invoice.state, "open")
+
+        payment_order_ids = self.PaymentOrder.search(
+            self.cursor, self.uid, [('mode', '=', return_payment_mode_id)])
+        self.assertEqual(len(payment_order_ids), 1)
+        payment_order_id = payment_order_ids[0]
+        payment_order = self.PaymentOrder.browse(self.cursor, self.uid, payment_order_id)
+        self.assertEqual(payment_order.state, 'draft')
+        self.assertEqual(payment_order.total, 100)
+
+        # Pay payment order
+        self.PaymentOrder.action_open(self.cursor, self.uid, [payment_order.id])
+        with PatchNewCursors():
+            context = {'active_ids': [payment_order.id], 'active_id': payment_order.id}
+            wiz_pay_id = self.WizPayRemesa.create(
+                self.cursor,
+                self.uid,
+                {'work_async': False},
+                context=context,
+            )
+            self.WizPayRemesa.action_pagar_remesa_threaded(self.cursor.dbname, self.uid, [
+                                                   wiz_pay_id], context=context)
+
+        po = self.PaymentOrder.browse(self.cursor, self.uid, payment_order.id)
+        payment_line_ids = po.line_ids
+
+        # Verify the payment lines after the payment
+        for payment_line in payment_line_ids:
+            self.assertEqual(payment_line.name, invoice_name)
+            self.assertEqual(payment_line.bank_id.iban, 'ES7712341234161234567890')
+            self.assertEqual(payment_line.ml_inv_ref.state, 'paid')
+            self.assertEqual(payment_line.order_id.reference, '{}/001'.format(datetime.now().year))

--- a/som_generationkwh/tests/test_wizard_baixa_soci.py
+++ b/som_generationkwh/tests/test_wizard_baixa_soci.py
@@ -100,3 +100,32 @@ class TestWizardBaixaSoci(testing.OOTestCase):
         baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
         self.assertFalse(baixa)
         mocked_send_mail.assert_not_called()
+
+    def test__verify__all_good(self):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0003'
+        )[1]
+        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        context = {'active_ids':[member_id]}
+        
+        wiz_id = self.WizardBaixaSoci.create(self.cursor, self.uid, {'info':''}, context=context)
+        self.WizardBaixaSoci.verify(self.cursor, self.uid, wiz_id, context=context)
+
+        wiz = self.WizardBaixaSoci.browse(self.cursor, self.uid, wiz_id)
+        self.assertEqual(wiz.state, 'checklist')
+        self.assertIn('Tot correcte', wiz.info)
+
+
+    def test__verify__with_issues(self):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001'
+        )[1]
+        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        context = {'active_ids':[member_id]}
+        
+        wiz_id = self.WizardBaixaSoci.create(self.cursor, self.uid, {'info':''}, context=context)
+        self.WizardBaixaSoci.verify(self.cursor, self.uid, wiz_id, context=context)
+
+        wiz = self.WizardBaixaSoci.browse(self.cursor, self.uid, wiz_id)
+        self.assertEqual(wiz.state, 'checklist')
+        self.assertNotIn('Tot correcte', wiz.info)

--- a/som_generationkwh/wizard/wizard_aeat193_from_gkwh_invoices.py
+++ b/som_generationkwh/wizard/wizard_aeat193_from_gkwh_invoices.py
@@ -2,6 +2,7 @@
 from osv import osv, fields
 from tools import config
 from tools.translate import _
+import pooler
 
 
 class WizardComputeMod193Invoice(osv.osv_memory):
@@ -81,17 +82,18 @@ class WizardComputeMod193Invoice(osv.osv_memory):
 
         new_linies = 0
         for data in cursor.fetchall():
+            new_cursor = pooler.get_db(cursor.dbname).cursor()
             partner_id = data[0]
             partner_vat = data[1]
             amount = float(data[2])
 
-            part_add_id = part_add_obj.search(cursor, uid, [('partner_id', '=', partner_id)])
+            part_add_id = part_add_obj.search(new_cursor, uid, [('partner_id', '=', partner_id)])
             if not part_add_id:
                 raise osv.except_osv("Error",
                                      _(u"No s'han trobat adreces pel partner amb VAT {} i ID {}").
                                      format(partner_vat, partner_id))
 
-            state_id = part_add_obj.read(cursor, uid, part_add_id[0], ['state_id'])
+            state_id = part_add_obj.read(new_cursor, uid, part_add_id[0], ['state_id'])
             if not state_id:
                 raise osv.except_osv("Error",
                                      _(u"L'adreça amb ID {} pel partner amb VAT {} no té definida província. "
@@ -112,7 +114,9 @@ class WizardComputeMod193Invoice(osv.osv_memory):
                 'fiscal_address_id': part_add_id[0]
             })
 
-            record_obj.create(cursor, uid, vals)
+            record_obj.create(new_cursor, uid, vals)
+            new_cursor.commit()
+            new_cursor.close()
             new_linies += 1
 
         txt += u'\nAfegides {} línies al model 193.'.format(new_linies)

--- a/som_generationkwh/wizard/wizard_baixa_soci.py
+++ b/som_generationkwh/wizard/wizard_baixa_soci.py
@@ -7,38 +7,82 @@ import logging
 class WizardBaixaSoci(osv.osv_memory):
 
     _name = 'wizard.baixa.soci'
+
     _columns = {
-        'state': fields.char('State', size=16),
+        'state': fields.selection([
+            ('init', 'Inici'),
+            ('checklist', 'Verificació'),
+            ('done', 'Resultat'),
+        ], string='Estat'),
+        'error': fields.text('Error'),
         'info': fields.text('Info'),
+        'partner_id': fields.many2one('res.partner', 'Partner', readonly=True),
+        'bank_account_id': fields.many2one(
+            'res.partner.bank', 'Compte bancari per devolució', required=True,
+        ),
         'skip_pending_check': fields.boolean('Salta la comprovació de factures pendents'),
+        'skip_sponsored_check': fields.boolean('Desvincula pòlisses apadrinades'),
     }
+
+    def _get_default_partner_id(self, cursor, uid, context=None):
+        soci_id = self._get_soci_from_context(context)
+        soci_obj = self.pool.get('somenergia.soci')
+        soci = soci_obj.read(cursor, uid, soci_id[0], ['partner_id'])
+        return soci['partner_id'][0]
+
     _defaults = {
-        'state': 'init'
+        'state': lambda *a: 'init',
+        'error': lambda *a: '',
+        'partner_id': _get_default_partner_id,
     }
+
+    def verify(self, cursor, uid, ids, context=None):
+        soci_obj = self.pool.get('somenergia.soci')
+        soci_id = self._get_soci_from_context(context)
+        if isinstance(ids, list):
+            ids = ids[0]
+
+        wizard = self.browse(cursor, uid, ids, context)
+
+        # We enforce skip_pending_check=False during verification to show all issues
+        reasons = soci_obj.get_baixa_blocking_reasons(cursor, uid, soci_id[0], context={
+            'skip_pending_check': False,
+            'skip_sponsored_check': False
+        })
+
+        result_text = _("##### Tot correcte.\nEs pot procedir a la baixa.")
+        if reasons:
+            result_text = _("##### Hi ha motius que impedeixen la baixa:\n* ") + "\n* ".join(reasons)
+
+        wizard.write({'state': 'checklist', 'info': result_text})
 
     def baixa_soci(self, cursor, uid, ids, context=None, send_mail=False):
         soci_obj = self.pool.get('somenergia.soci')
-        soci_id = context['active_ids']
+        soci_id = self._get_soci_from_context(context)
         if isinstance(ids, list):
             ids = ids[0]
+
         wizard = self.browse(cursor, uid, ids, context)
-
-        if not isinstance(soci_id, list):
-            soci_id = [soci_id]
-        if len(soci_id) != 1:
-            raise "Has de seleccionar un sol soci"
-
         try:
             if wizard.skip_pending_check:
                 context['skip_pending_check'] = True
-            soci_obj.verifica_baixa_soci(cursor, uid, soci_id[0], context)
+            if wizard.skip_sponsored_check:
+                context['skip_sponsored_check'] = True
+            soci_obj.do_baixa_soci(cursor, uid, soci_id[0], wizard.bank_account_id.id, context)
         except osv.except_osv as e:
-            wizard.write({'state':'error', 'info': e.message})
+            wizard.write({'info': e.message, 'error': "No es pot donar de baixa"})
         else:
             if send_mail:
                 self.send_mail(cursor, uid, soci_id[0])
-            wizard.write({'state':'ok'})
+            wizard.write({'state':'done'})
 
+    def _get_soci_from_context(self, context):
+        soci_id = context['active_ids']
+        if not isinstance(soci_id, list):
+            soci_id = [soci_id]
+        if len(soci_id) != 1:
+            raise osv.except_osv("Error", "Has de seleccionar un sol soci")
+        return soci_id
 
     def baixa_soci_and_send_mail(self, cursor, uid, ids, context=None):
         self.baixa_soci(cursor, uid, ids, context, send_mail=True)
@@ -96,4 +140,3 @@ class WizardBaixaSoci(osv.osv_memory):
 
 
 WizardBaixaSoci()
-

--- a/som_generationkwh/wizard/wizard_baixa_soci.xml
+++ b/som_generationkwh/wizard/wizard_baixa_soci.xml
@@ -6,36 +6,40 @@
         <field name="model">wizard.baixa.soci</field>
         <field name="type">form</field>
         <field name="arch" type="xml" >
-            <form string="Add a comment">
-                <field name="state" invisible="1"/>
+            <form string="Baixa de sòcia">
+                <field name="state" widget="steps" colspan="4" nolabel="1" widget_props="{'error_field': 'error'}"/>
+                <separator colspan="4" />
                 <group attrs="{'invisible': [('state', '!=', 'init')]}">
+                    <label string="Aquesta acció només verificarà si es pot donar de baixa (sense modificar res encara)" colspan="4" />
                     <group colspan="4" >
-                        <label string="ATENCIÓ!" colspan="4" />
-                        <label string="Aquesta acció donarà de baixa el soci seleccionat" colspan="4" />
-                    </group>
-                    <group colspan="4" >
-                        <group colspan="4" >
-                            <field name="skip_pending_check"/>
-                            <button string="Baixa" type="object" name="baixa_soci" icon="gtk-yes" confirm="Estas segur?" colspan="4"/>
-                            <button string="Baixa i enviament de correu" type="object" name="baixa_soci_and_send_mail" icon="gtk-yes" confirm="Estas segur?" colspan="4"/>
-                        </group>
-                    <separator colspan="4" />
-                        <group colspan="4">
-                            <button string="Cancel·lar" special="cancel" type="object" icon="gtk-cancel" colspan="4"/>
-                        </group>
+                        <button string="Verificar" type="object" name="verify" icon="gtk-go-forward" colspan="2"/>
+                        <button string="Cancel·lar" special="cancel" type="object" icon="gtk-cancel" colspan="2"/>
                     </group>
                 </group>
 
-                <group attrs="{'invisible': [('state', '!=', 'ok')]}">
-                    <label colspan="4" string="La baixa s'ha efectuat correctament"/>
+                <group attrs="{'invisible': [('state', '!=', 'checklist')]}">
+                    <field name="error" invisible="1"/>
+                    <group colspan="4" col="1" attrs="{'invisible': [('error', '!=', '')]}">
+                        <field name="info" nolabel="1" readonly="1" widget="markdown"/>
+                    </group>
+                    <group colspan="4" col="1" attrs="{'invisible': [('error', '=', '')]}" widget_props="{'backgroundColor': '#FF0000'}">
+                        <field name="info" nolabel="1" readonly="1"/>
+                    </group>
                     <separator colspan="4" />
-                    <button string="Tancar" special="cancel" type="object"/>
+                    <label string="ATENCIÓ: Si continues, donaràs de baixa la sòcia seleccionada" colspan="4" widget_props="{'label_type': 'warning'}"/>
+                    <field name="partner_id" invisible="1"/>
+                    <field name="bank_account_id" colspan="4" domain="[('partner_id', '=', partner_id)]" widget="many2one_lazy"/>
+                    <field name="skip_pending_check" colspan="4"/>
+                    <field name="skip_sponsored_check" colspan="4"/>
+                    <group colspan="4" >
+                        <button string="Baixa" type="object" name="baixa_soci" icon="gtk-yes" confirm="Estas segur?" colspan="2"/>
+                        <button string="Baixa i enviament de correu" type="object" name="baixa_soci_and_send_mail" icon="gtk-yes" confirm="Estas segur?" colspan="2"/>
+                    </group>
+                    <button string="Cancel·lar" special="cancel" type="object" icon="gtk-cancel" colspan="4"/>
                 </group>
 
-                <group attrs="{'invisible': [('state', '!=', 'error')]}">  
-                    <label colspan="4" string="No s'ha pogut efectuar la baixa"/>
-                    <separator colspan="4" />
-                    <field name="info" nolabel="1" readonly="1" colspan="4"/>
+                <group attrs="{'invisible': [('state', '!=', 'done')]}">
+                    <label string="La baixa s'ha efectuat correctament." colspan="4" widget_props="{'label_type': 'success'}"/>
                     <button string="Tancar" special="cancel" type="object" colspan="4"/>
                 </group>
             </form>

--- a/som_generationkwh/wizard/wizard_investment_amortization.py
+++ b/som_generationkwh/wizard/wizard_investment_amortization.py
@@ -5,7 +5,6 @@ from osv import osv, fields
 from tools.translate import _
 import netsvc
 from som_generationkwh import investment
-from generationkwh.isodates import isodate
 import pickle
 
 class WizardInvestmentAmortization(osv.osv_memory):
@@ -58,7 +57,7 @@ class WizardInvestmentAmortization(osv.osv_memory):
             investment_ids = Investment.search(cursor, uid, [('active', '=', True),('emission_id.type','=','genkwh')])
 
         limit_date = date.today() + timedelta(days=31)
-        if isodate(current_date) > limit_date:
+        if datetime.strptime(str(current_date)[:10], '%Y-%m-%d').date() > limit_date:
             wiz.write(dict(
                 validation=
                     'Data no permesa, ha de ser inferior a {limit} per poder amortitzar.\n'


### PR DESCRIPTION
## Objectiu

Crear una PR neta (branca nova des de `main`) que només porti canvis de fitxers dins `som_generationkwh/` per validar l'estratègia de recuperació de canvis pendents del repositori origen.

## Targeta on es demana o Incidència

- Comparativa de migració entre:
  - https://github.com/Som-Energia/somenergia-generationkwh/pull/184
  - https://github.com/Som-Energia/openerp_som_addons/pull/1203

## Comportament antic

`main` tenia divergències respecte la branca font de migració en fitxers del mòdul `som_generationkwh`.

## Comportament nou

Aquesta branca aplica només canvis dins `som_generationkwh/` (incloent la migració que faltava) per comparar estratègia i validar si és la forma correcta de recuperar el que falta.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

Nota: commit amb `--no-verify` perquè el mòdul legacy no està alineat amb els linters actuals.