### PR TITLE
🐛Linies de servei d'ajust fan duplicar el donatiu voluntari

### DIFF
--- a/som_polissa_soci/models/giscedata_facturacio.py
+++ b/som_polissa_soci/models/giscedata_facturacio.py
@@ -51,7 +51,7 @@ class GiscedataFacturacioFacturador(osv.osv):
                             [
                                 x.quantity if x.price_unit >= 0 else -x.quantity
                                 for x in fact.linia_ids
-                                if x.tipus == "energia" and x.product_id.code != "RMAG"
+                                if x.tipus == "energia" and x.product_id.code not in ("RMAG", "SAJU", "DSAJU")  # noqa: E501
                             ]
                         )
                         vals = {


### PR DESCRIPTION
## Objectiu

Error no detectat en les fases de testeig dels Serveis d'ajust, les linies de servei d'ajust son d'energia, es compten pel càlcul del donatiu voluntari, duplicant-ho. Caldrà refacturar.

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/8164830?folder_id=87

## Comportament antic

Duplica el valor del donatiu voluntari

## Comportament nou

No ducplica

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
