### PR TITLE
Add PostgreSQL command options in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,12 @@ services:
     environment:
      - POSTGRES_USER=erp
      - POSTGRES_PASSWORD=erp
+    command: >
+      postgres
+        -c max_worker_processes=16
+        -c max_parallel_workers=8
+        -c max_parallel_workers_per_gather=4
+        -c timescaledb.max_background_workers=8
     volumes:
       - ./db:/var/lib/postgresql/data
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
      - POSTGRES_PASSWORD=erp
     command: >
       postgres
-        -c max_worker_processes=16
+        -c max_worker_processes=20
         -c max_parallel_workers=8
         -c max_parallel_workers_per_gather=4
         -c timescaledb.max_background_workers=8


### PR DESCRIPTION
Configure PostgreSQL command options for performance tuning: PostgreSQL ran out of background worker slots to launch the Telemetry Reporter process.

## Objectiu
Docker compose without warnings.

## Targeta on es demana o Incidència


## Comportament antic
db_1     | 2026-05-19 13:12:36.593 UTC [32] WARNING:  failed to launch job 1 "Telemetry Reporter [1]": out of background workers

## Comportament nou
No warnings

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
