### PR TITLE
Afegir al wizard scheduler l'opció de obrir factures seqüencialment 

### DIFF
--- a/giscedata_facturacio_som/wizard/__init__.py
+++ b/giscedata_facturacio_som/wizard/__init__.py
@@ -2,3 +2,4 @@
 from __future__ import absolute_import
 from . import wizard_fraccionar_via_extralines
 from . import wizard_model_list_from_file
+from . import wizard_scheduler_facturacio_task

--- a/giscedata_facturacio_som/wizard/wizard_scheduler_facturacio_task.py
+++ b/giscedata_facturacio_som/wizard/wizard_scheduler_facturacio_task.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from osv import osv, fields
+
+
+class WizardScheduleTask(osv.osv_memory):
+    _name = 'wizard.schedule.facturacio.task'
+    _inherit = 'wizard.schedule.facturacio.task'
+
+    def _get_aviable_tasks(self, cursor, uid, context=None):
+        tasks = super(WizardScheduleTask, self)._get_aviable_tasks(
+            cursor, uid, context=context
+        )
+
+        found = False
+        for task in tasks:
+            if task[0] == 'obrir_factures_button_by_queue':
+                task[1] = 'Obrir Factures per workers'
+            elif task[0] == 'obrir_factures_button':
+                found = True
+        if not found:
+            tasks.append(('obrir_factures_button', 'Obrir Factures sequencial'))
+
+        return tasks
+
+    _columns = {
+        'tasks': fields.selection(_get_aviable_tasks, 'Tasca', required=True),
+    }
+
+
+WizardScheduleTask()

--- a/giscedata_facturacio_som/wizard/wizard_scheduler_facturacio_task.py
+++ b/giscedata_facturacio_som/wizard/wizard_scheduler_facturacio_task.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 from osv import osv, fields
 
 
@@ -14,13 +11,13 @@ class WizardScheduleTask(osv.osv_memory):
             cursor, uid, context=context
         )
 
-        found = False
-        for task in tasks:
-            if task[0] == 'obrir_factures_button_by_queue':
-                task[1] = 'Obrir Factures per workers'
-            elif task[0] == 'obrir_factures_button':
-                found = True
-        if not found:
+        tasks = [
+            (task_code, 'Obrir Factures per workers')
+            if task_code == 'obrir_factures_button_by_queue'
+            else (task_code, task_label)
+            for task_code, task_label in tasks
+        ]
+        if not any(task_code == 'obrir_factures_button' for task_code, _ in tasks):
             tasks.append(('obrir_factures_button', 'Obrir Factures sequencial'))
 
         return tasks


### PR DESCRIPTION
## Objectiu

Donar la opció de obrir factures al mètode seqüencial (antic) sense passar pels workers d'open_invoice

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/8166808?folder_id=87

## Comportament antic

No es podia des de l'actualització de fa 2 setmanes

## Comportament nou

Es pot programar la tasca d'obrir tant per seqüencial com per workers

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
