### PR TITLE
Reduir l'impacte a la base de dades del procés diari d'autoreclama

### DIFF
--- a/som_autoreclama/models/giscedata_atc.py
+++ b/som_autoreclama/models/giscedata_atc.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from osv import osv, fields
 from tools.translate import _
 from datetime import date

--- a/som_autoreclama/models/giscedata_atc.py
+++ b/som_autoreclama/models/giscedata_atc.py
@@ -557,7 +557,7 @@ class GiscedataAtc(osv.osv):
         fields_to_read = ["state_id", "change_date", "atc_id"]
         for id in ids:
             res = history_obj.search(
-                cursor, uid, [("atc_id", "=", id)], limit=1, order="id desc"
+                cursor, uid, [("atc_id", "=", id), ("end_date", "=", False)], limit=1
             )
             if res:
                 # We consider the last record the first one due to order

--- a/som_autoreclama/models/giscedata_atc.py
+++ b/som_autoreclama/models/giscedata_atc.py
@@ -556,7 +556,9 @@ class GiscedataAtc(osv.osv):
         result = dict.fromkeys(ids, False)
         fields_to_read = ["state_id", "change_date", "atc_id"]
         for id in ids:
-            res = history_obj.search(cursor, uid, [("atc_id", "=", id)])
+            res = history_obj.search(
+                cursor, uid, [("atc_id", "=", id)], limit=1, order="id desc"
+            )
             if res:
                 # We consider the last record the first one due to order
                 # statement in the model definition.

--- a/som_autoreclama/models/giscedata_polissa.py
+++ b/som_autoreclama/models/giscedata_polissa.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from osv import osv, fields
 from tools.translate import _
 from datetime import datetime, date, timedelta

--- a/som_autoreclama/models/giscedata_polissa.py
+++ b/som_autoreclama/models/giscedata_polissa.py
@@ -80,7 +80,9 @@ class GiscedataPolissa(osv.osv):
             days_since_last_f1 = 0
 
         history_obj = self.pool.get("som.autoreclama.state.history.polissa")
-        h_ids = history_obj.search(cursor, uid, [("polissa_id", "=", id)])
+        h_ids = history_obj.search(
+            cursor, uid, [("polissa_id", "=", id)], limit=1, order="id desc"
+        )
 
         days_since_current_cacr1006 = 0
         if h_ids:
@@ -119,10 +121,16 @@ class GiscedataPolissa(osv.osv):
             review_state_id = data_obj.get_object_reference(
                 cursor, uid, "som_autoreclama", "review_state_workflow_polissa"
             )[1]
-            h_ids = history_obj.search(cursor, uid, [
-                ("polissa_id", "=", id),
-                ("state_id", "=", review_state_id),
-            ])
+            h_ids = history_obj.search(
+                cursor,
+                uid,
+                [
+                    ("polissa_id", "=", id),
+                    ("state_id", "=", review_state_id),
+                ],
+                limit=1,
+                order="id desc",
+            )
             if h_ids:
                 last_date_review = history_obj.read(
                     cursor, uid, h_ids[0], ['change_date']
@@ -178,7 +186,9 @@ class GiscedataPolissa(osv.osv):
         invoicing_cyles_with_estimate_readings = len(reading_ids)
 
         history_obj = self.pool.get("som.autoreclama.state.history.polissa009")
-        h_ids = history_obj.search(cursor, uid, [("polissa_id", "=", id)])
+        h_ids = history_obj.search(
+            cursor, uid, [("polissa_id", "=", id)], limit=1, order="id desc"
+        )
 
         days_since_current_cacr1009 = 0
         if h_ids:
@@ -217,10 +227,16 @@ class GiscedataPolissa(osv.osv):
             review_state_id = data_obj.get_object_reference(
                 cursor, uid, "som_autoreclama", "review_state_workflow_polissa009"
             )[1]
-            h_ids = history_obj.search(cursor, uid, [
-                ("polissa_id", "=", id),
-                ("state_id", "=", review_state_id),
-            ])
+            h_ids = history_obj.search(
+                cursor,
+                uid,
+                [
+                    ("polissa_id", "=", id),
+                    ("state_id", "=", review_state_id),
+                ],
+                limit=1,
+                order="id desc",
+            )
             if h_ids:
                 last_date_review = history_obj.read(
                     cursor, uid, h_ids[0], ['change_date']
@@ -342,7 +358,9 @@ class GiscedataPolissa(osv.osv):
         result = dict.fromkeys(ids, False)
         fields_to_read = ["state_id", "change_date", "polissa_id"]
         for id in ids:
-            res = history_obj.search(cursor, uid, [("polissa_id", "=", id)])
+            res = history_obj.search(
+                cursor, uid, [("polissa_id", "=", id)], limit=1, order="id desc"
+            )
             if res:
                 # We consider the last record the first one due to order
                 # statement in the model definition.

--- a/som_autoreclama/models/giscedata_polissa.py
+++ b/som_autoreclama/models/giscedata_polissa.py
@@ -81,7 +81,7 @@ class GiscedataPolissa(osv.osv):
 
         history_obj = self.pool.get("som.autoreclama.state.history.polissa")
         h_ids = history_obj.search(
-            cursor, uid, [("polissa_id", "=", id)], limit=1, order="id desc"
+            cursor, uid, [("polissa_id", "=", id), ("end_date", "=", False)], limit=1
         )
 
         days_since_current_cacr1006 = 0
@@ -187,7 +187,7 @@ class GiscedataPolissa(osv.osv):
 
         history_obj = self.pool.get("som.autoreclama.state.history.polissa009")
         h_ids = history_obj.search(
-            cursor, uid, [("polissa_id", "=", id)], limit=1, order="id desc"
+            cursor, uid, [("polissa_id", "=", id), ("end_date", "=", False)], limit=1
         )
 
         days_since_current_cacr1009 = 0
@@ -359,7 +359,10 @@ class GiscedataPolissa(osv.osv):
         fields_to_read = ["state_id", "change_date", "polissa_id"]
         for id in ids:
             res = history_obj.search(
-                cursor, uid, [("polissa_id", "=", id)], limit=1, order="id desc"
+                cursor,
+                uid,
+                [("polissa_id", "=", id), ("end_date", "=", False)],
+                limit=1,
             )
             if res:
                 # We consider the last record the first one due to order

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -216,7 +216,7 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
                     msg += _(" - {}\n").format(message)
             else:
                 errors.append(item_id)
-                error_line = _(
+                msg += _(
                     "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
                 ).format(
                     _namespaces[namespace]['name'],
@@ -224,7 +224,6 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
                     actual_state,
                     cnd_obj.get_string(new_cursor, uid, condition_id),
                 )
-                msg += error_line
                 msg += _(" - {}\n").format(message)
 
             new_cursor.commit()

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -5,7 +5,7 @@ from tools.translate import _
 from tools import email_send
 import json
 import urllib
-
+import pooler
 
 _namespaces = {
     'atc': {
@@ -183,55 +183,52 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
         msg = _("Accions {}\n").format(block_name)
 
         for item_id in tqdm(ids):
-            try:
-                actual_state_id, actual_state = self.get_autoreclama_state_name(
-                    cursor, uid, item_id, namespace, context
-                )
-                result, condition_id, message = self.update_item_if_possible(
-                    cursor, uid, item_id, namespace, context
-                )
-                item_name = self.get_item_name(cursor, uid, item_id, namespace, context)
-                if result:
-                    updated.append(item_id)
-                    next_state_id, next_state = self.get_autoreclama_state_name(
-                        cursor, uid, item_id, namespace, context
-                    )
-                    msg += _("{} amb id {} ha canviat d'estat: {} --> {} => condició {}\n").format(
-                        _namespaces[namespace]['name'],
-                        item_name,
-                        actual_state,
-                        next_state,
-                        cnd_obj.get_string(cursor, uid, condition_id),
-                    )
-                    msg += _(" - {}\n").format(message)
-                    if next_state_id in review_states:
-                        reviews.append(item_id)
-                elif result is False:
-                    not_updated.append(item_id)
-                    if verbose:
-                        msg += _(
-                            "{} amb id {} no li toca canviar d'estat, estat actual: {}\n"
-                        ).format(_namespaces[namespace]['name'], item_name, actual_state)
-                        msg += _(" - {}\n").format(message)
-                else:
-                    errors.append(item_id)
-                    error_line = _(
-                        "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
-                    ).format(
-                        _namespaces[namespace]['name'],
-                        item_name,
-                        actual_state,
-                        cnd_obj.get_string(cursor, uid, condition_id),
-                    )
-                    msg += error_line
-                    msg += _(" - {}\n").format(message)
-                    cursor.rollback()
-                    raise Exception(error_line + message)
+            new_cursor = pooler.get_db(cursor.dbname).cursor()
 
-                cursor.commit()
-            except Exception as e:
-                cursor.rollback()
-                raise e
+            actual_state_id, actual_state = self.get_autoreclama_state_name(
+                new_cursor, uid, item_id, namespace, context
+            )
+            result, condition_id, message = self.update_item_if_possible(
+                new_cursor, uid, item_id, namespace, context
+            )
+            item_name = self.get_item_name(new_cursor, uid, item_id, namespace, context)
+            if result:
+                updated.append(item_id)
+                next_state_id, next_state = self.get_autoreclama_state_name(
+                    new_cursor, uid, item_id, namespace, context
+                )
+                msg += _("{} amb id {} ha canviat d'estat: {} --> {} => condició {}\n").format(
+                    _namespaces[namespace]['name'],
+                    item_name,
+                    actual_state,
+                    next_state,
+                    cnd_obj.get_string(new_cursor, uid, condition_id),
+                )
+                msg += _(" - {}\n").format(message)
+                if next_state_id in review_states:
+                    reviews.append(item_id)
+            elif result is False:
+                not_updated.append(item_id)
+                if verbose:
+                    msg += _(
+                        "{} amb id {} no li toca canviar d'estat, estat actual: {}\n"
+                    ).format(_namespaces[namespace]['name'], item_name, actual_state)
+                    msg += _(" - {}\n").format(message)
+            else:
+                errors.append(item_id)
+                error_line = _(
+                    "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
+                ).format(
+                    _namespaces[namespace]['name'],
+                    item_name,
+                    actual_state,
+                    cnd_obj.get_string(new_cursor, uid, condition_id),
+                )
+                msg += error_line
+                msg += _(" - {}\n").format(message)
+
+            new_cursor.commit()
+            new_cursor.close()
 
         summary = _("Sumari {}\n").format(block_name)
         summary += _("{} que han canviat d'estat: .................. {}\n".format(block_name, len(updated)))  # noqa: E501

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -183,51 +183,53 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
         msg = _("Accions {}\n").format(block_name)
 
         for item_id in tqdm(ids):
-            new_cursor = pooler.get_db(cursor.dbname).cursor()
+            try:
+                new_cursor = pooler.get_db(cursor.dbname).cursor()
 
-            actual_state_id, actual_state = self.get_autoreclama_state_name(
-                new_cursor, uid, item_id, namespace, context
-            )
-            result, condition_id, message = self.update_item_if_possible(
-                new_cursor, uid, item_id, namespace, context
-            )
-            item_name = self.get_item_name(new_cursor, uid, item_id, namespace, context)
-            if result:
-                updated.append(item_id)
-                next_state_id, next_state = self.get_autoreclama_state_name(
+                actual_state_id, actual_state = self.get_autoreclama_state_name(
                     new_cursor, uid, item_id, namespace, context
                 )
-                msg += _("{} amb id {} ha canviat d'estat: {} --> {} => condició {}\n").format(
-                    _namespaces[namespace]['name'],
-                    item_name,
-                    actual_state,
-                    next_state,
-                    cnd_obj.get_string(new_cursor, uid, condition_id),
+                result, condition_id, message = self.update_item_if_possible(
+                    new_cursor, uid, item_id, namespace, context
                 )
-                msg += _(" - {}\n").format(message)
-                if next_state_id in review_states:
-                    reviews.append(item_id)
-            elif result is False:
-                not_updated.append(item_id)
-                if verbose:
-                    msg += _(
-                        "{} amb id {} no li toca canviar d'estat, estat actual: {}\n"
-                    ).format(_namespaces[namespace]['name'], item_name, actual_state)
+                item_name = self.get_item_name(new_cursor, uid, item_id, namespace, context)
+                if result:
+                    updated.append(item_id)
+                    next_state_id, next_state = self.get_autoreclama_state_name(
+                        new_cursor, uid, item_id, namespace, context
+                    )
+                    msg += _("{} amb id {} ha canviat d'estat: {} --> {} => condició {}\n").format(
+                        _namespaces[namespace]['name'],
+                        item_name,
+                        actual_state,
+                        next_state,
+                        cnd_obj.get_string(new_cursor, uid, condition_id),
+                    )
                     msg += _(" - {}\n").format(message)
-            else:
-                errors.append(item_id)
-                msg += _(
-                    "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
-                ).format(
-                    _namespaces[namespace]['name'],
-                    item_name,
-                    actual_state,
-                    cnd_obj.get_string(new_cursor, uid, condition_id),
-                )
-                msg += _(" - {}\n").format(message)
+                    if next_state_id in review_states:
+                        reviews.append(item_id)
+                elif result is False:
+                    not_updated.append(item_id)
+                    if verbose:
+                        msg += _(
+                            "{} amb id {} no li toca canviar d'estat, estat actual: {}\n"
+                        ).format(_namespaces[namespace]['name'], item_name, actual_state)
+                        msg += _(" - {}\n").format(message)
+                else:
+                    errors.append(item_id)
+                    msg += _(
+                        "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
+                    ).format(
+                        _namespaces[namespace]['name'],
+                        item_name,
+                        actual_state,
+                        cnd_obj.get_string(new_cursor, uid, condition_id),
+                    )
+                    msg += _(" - {}\n").format(message)
 
-            new_cursor.commit()
-            new_cursor.close()
+                new_cursor.commit()
+            finally:
+                new_cursor.close()
 
         summary = _("Sumari {}\n").format(block_name)
         summary += _("{} que han canviat d'estat: .................. {}\n".format(block_name, len(updated)))  # noqa: E501

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -183,6 +183,7 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
         msg = _("Accions {}\n").format(block_name)
 
         for item_id in tqdm(ids):
+            new_cursor = None
             try:
                 new_cursor = pooler.get_db(cursor.dbname).cursor()
 
@@ -229,7 +230,8 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
 
                 new_cursor.commit()
             finally:
-                new_cursor.close()
+                if new_cursor:
+                    new_cursor.close()
 
         summary = _("Sumari {}\n").format(block_name)
         summary += _("{} que han canviat d'estat: .................. {}\n".format(block_name, len(updated)))  # noqa: E501

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -229,9 +229,9 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
                     raise Exception(error_line + message)
 
                 cursor.commit()
-            except Exception:
+            except Exception as e:
                 cursor.rollback()
-                raise
+                raise e
 
         summary = _("Sumari {}\n").format(block_name)
         summary += _("{} que han canviat d'estat: .................. {}\n".format(block_name, len(updated)))  # noqa: E501

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from osv import osv
 from tqdm import tqdm
 from tools.translate import _
 from tools import email_send
 import json
-import urllib
 import pooler
+
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
 
 _namespaces = {
     'atc': {
@@ -141,13 +147,13 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
         }
 
         actionj = {}
-        for action in actions.iteritems():
+        for action in actions.items():
             if isinstance(action[1], (list, dict)):
                 actionj[action[0]] = json.dumps(action[1])
             else:
                 actionj[action[0]] = action[1]
 
-        url_params = urllib.urlencode(actionj)
+        url_params = urlencode(actionj)
         base_url = cfg_obj.get(
             cursor, uid, "som_autoreclama_web_client_base_url", "https://somenergia.coop/")
         action = u'/action?'

--- a/som_autoreclama/models/som_autoreclama_state_updater.py
+++ b/som_autoreclama/models/som_autoreclama_state_updater.py
@@ -44,7 +44,7 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
             ("agent_actual", "=", "10"),  # Distri
             ("autoreclama_state.is_last", "=", False),
         ]
-        return atc_obj.search(cursor, uid, search_params)
+        return atc_obj.search(cursor, uid, search_params, order="id")
 
     def get_autoreclama_state_name(self, cursor, uid, item_id, namespace, context=None):
         item_obj = self.pool.get(_namespaces[namespace]['model'])
@@ -65,7 +65,9 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
             ("state", "in", ['activa', 'baixa', 'impagament', 'modcontractual']),
             (autoreclama_state + ".is_last", "=", False),
         ]
-        return pol_obj.search(cursor, uid, search_params, context={"active_test": False})
+        return pol_obj.search(
+            cursor, uid, search_params, order="id", context={"active_test": False}
+        )
 
     def get_item_name(self, cursor, uid, item_id, namespace, context=None):
         if namespace == 'atc':
@@ -181,38 +183,55 @@ class SomAutoreclamaStateUpdater(osv.osv_memory):
         msg = _("Accions {}\n").format(block_name)
 
         for item_id in tqdm(ids):
-            actual_state_id, actual_state = self.get_autoreclama_state_name(
-                cursor, uid, item_id, namespace, context)
-            result, condition_id, message = self.update_item_if_possible(
-                cursor, uid, item_id, namespace, context
-            )
-            item_name = self.get_item_name(cursor, uid, item_id, namespace, context)
-            if result:
-                updated.append(item_id)
-                next_state_id, next_state = self.get_autoreclama_state_name(
-                    cursor, uid, item_id, namespace, context)
-                msg += _("{} amb id {} ha canviat d'estat: {} --> {} => condició {}\n").format(
-                    _namespaces[namespace]['name'],
-                    item_name, actual_state, next_state,
-                    cnd_obj.get_string(cursor, uid, condition_id)
+            try:
+                actual_state_id, actual_state = self.get_autoreclama_state_name(
+                    cursor, uid, item_id, namespace, context
                 )
-                msg += _(" - {}\n").format(message)
-                if next_state_id in review_states:
-                    reviews.append(item_id)
-            elif result is False:
-                not_updated.append(item_id)
-                if verbose:
-                    msg += _("{} amb id {} no li toca canviar d'estat, estat actual: {}\n").format(
-                        _namespaces[namespace]['name'], item_name, actual_state
+                result, condition_id, message = self.update_item_if_possible(
+                    cursor, uid, item_id, namespace, context
+                )
+                item_name = self.get_item_name(cursor, uid, item_id, namespace, context)
+                if result:
+                    updated.append(item_id)
+                    next_state_id, next_state = self.get_autoreclama_state_name(
+                        cursor, uid, item_id, namespace, context
+                    )
+                    msg += _("{} amb id {} ha canviat d'estat: {} --> {} => condició {}\n").format(
+                        _namespaces[namespace]['name'],
+                        item_name,
+                        actual_state,
+                        next_state,
+                        cnd_obj.get_string(cursor, uid, condition_id),
                     )
                     msg += _(" - {}\n").format(message)
-            else:
-                errors.append(item_id)
-                msg += _(
-                    "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
-                ).format(_namespaces[namespace]['name'], item_name, actual_state,
-                         cnd_obj.get_string(cursor, uid, condition_id))
-                msg += _(" - {}\n").format(message)
+                    if next_state_id in review_states:
+                        reviews.append(item_id)
+                elif result is False:
+                    not_updated.append(item_id)
+                    if verbose:
+                        msg += _(
+                            "{} amb id {} no li toca canviar d'estat, estat actual: {}\n"
+                        ).format(_namespaces[namespace]['name'], item_name, actual_state)
+                        msg += _(" - {}\n").format(message)
+                else:
+                    errors.append(item_id)
+                    error_line = _(
+                        "{} amb id {} no ha canviat d'estat per error, estat actual: {} => condició {}\n"  # noqa: E501
+                    ).format(
+                        _namespaces[namespace]['name'],
+                        item_name,
+                        actual_state,
+                        cnd_obj.get_string(cursor, uid, condition_id),
+                    )
+                    msg += error_line
+                    msg += _(" - {}\n").format(message)
+                    cursor.rollback()
+                    raise Exception(error_line + message)
+
+                cursor.commit()
+            except Exception:
+                cursor.rollback()
+                raise
 
         summary = _("Sumari {}\n").format(block_name)
         summary += _("{} que han canviat d'estat: .................. {}\n".format(block_name, len(updated)))  # noqa: E501

--- a/som_autoreclama/tests/test_som_autoreclama_009.py
+++ b/som_autoreclama/tests/test_som_autoreclama_009.py
@@ -3,7 +3,7 @@
 import mock
 import unittest
 from ..models import giscedata_polissa
-from test_som_autoreclama_base import SomAutoreclamaBaseTests, today_str
+from .test_som_autoreclama_base import SomAutoreclamaBaseTests, today_str
 
 
 class SomAutoreclama009AutomationTest(SomAutoreclamaBaseTests):

--- a/som_autoreclama/tests/test_som_autoreclama_states.py
+++ b/som_autoreclama/tests/test_som_autoreclama_states.py
@@ -241,6 +241,54 @@ class SomAutoreclamaStatesTest(SomAutoreclamaBaseTests):
         self.assertEqual(atc.autoreclama_history_ids[2].atc_id.id, new_atc_id)
         self.assertEqual(atc.autoreclama_history_ids[2].generated_atc_id.id, False)
 
+    def test_atc_current_state_ignores_newer_closed_history_row(self):
+        atc_obj = self.get_model("giscedata.atc")
+        history_obj = self.get_model("som.autoreclama.state.history.atc")
+
+        atc_id = self.build_atc(r1=True)
+        _, disabled_state_id = self.get_object_reference(
+            "som_autoreclama", "disabled_state_workflow_atc"
+        )
+
+        history_obj.create(
+            self.cursor,
+            self.uid,
+            {
+                "atc_id": atc_id,
+                "state_id": disabled_state_id,
+                "change_date": "2020-01-01",
+                "end_date": "2020-01-02",
+            },
+        )
+
+        atc = atc_obj.browse(self.cursor, self.uid, atc_id)
+        self.assertEqual(atc.autoreclama_state.name, "Correcte")
+        self.assertEqual(atc.autoreclama_state_date, today_str())
+
+    def test_polissa_current_state_ignores_newer_closed_history_row(self):
+        pol_obj = self.get_model("giscedata.polissa")
+        history_obj = self.get_model("som.autoreclama.state.history.polissa")
+
+        pol_id = self.build_polissa(initial_state='correct', data_baixa=False)
+        _, loop_state_id = self.get_object_reference(
+            "som_autoreclama", "loop_state_workflow_polissa"
+        )
+
+        history_obj.create(
+            self.cursor,
+            self.uid,
+            {
+                "polissa_id": pol_id,
+                "state_id": loop_state_id,
+                "change_date": "2020-01-01",
+                "end_date": "2020-01-02",
+            },
+        )
+
+        pol = pol_obj.browse(self.cursor, self.uid, pol_id)
+        self.assertEqual(pol.autoreclama_state.name, "Correcte")
+        self.assertEqual(pol.autoreclama_state_date, today_str())
+
 
 class SomAutoreclamaCreationWizardTest(SomAutoreclamaBaseTests):
     def test_create_general_atc_r1_case_via_wizard__atr_wihtout_r1_type_a(self):

--- a/som_autoreclama/tests/test_som_autoreclama_states.py
+++ b/som_autoreclama/tests/test_som_autoreclama_states.py
@@ -5,7 +5,11 @@ from datetime import timedelta, datetime
 from addons import get_module_resource
 import mock
 from ..models import giscedata_atc, giscedata_polissa, som_autoreclama_state_history
-from test_som_autoreclama_base import SomAutoreclamaBaseTests, today_str, today_minus_str
+from .test_som_autoreclama_base import (
+    SomAutoreclamaBaseTests,
+    today_str,
+    today_minus_str,
+)
 from destral.patch import PatchNewCursors
 
 

--- a/som_autoreclama/tests/test_som_autoreclama_states.py
+++ b/som_autoreclama/tests/test_som_autoreclama_states.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from datetime import timedelta, datetime
 from addons import get_module_resource
 import mock
@@ -1071,7 +1073,7 @@ class SomAutoreclamaConditionsTest(SomAutoreclamaBaseTests):
         test_datas = [
             {
                 "subtype": "001",
-                "log_days": 30 / 2,
+                "log_days": 30 // 2,
                 "result": False,
                 "cond": "conditions_001_correct_state_workflow_atc",
             },
@@ -1083,7 +1085,7 @@ class SomAutoreclamaConditionsTest(SomAutoreclamaBaseTests):
             },
             {
                 "subtype": "038",
-                "log_days": 30 / 2,
+                "log_days": 30 // 2,
                 "result": False,
                 "cond": "conditions_038_correct_state_workflow_atc",
             },
@@ -1095,7 +1097,7 @@ class SomAutoreclamaConditionsTest(SomAutoreclamaBaseTests):
             },
             {
                 "subtype": "027",
-                "log_days": 10 / 2,
+                "log_days": 10 // 2,
                 "result": False,
                 "cond": "conditions_027_correct_state_workflow_atc",
             },
@@ -1107,7 +1109,7 @@ class SomAutoreclamaConditionsTest(SomAutoreclamaBaseTests):
             },
             {
                 "subtype": "039",
-                "log_days": 30 / 2,
+                "log_days": 30 // 2,
                 "result": False,
                 "cond": "conditions_039_correct_state_workflow_atc",
             },
@@ -1140,7 +1142,6 @@ class SomAutoreclamaConditionsTest(SomAutoreclamaBaseTests):
         for cond_id in cond_ids:
             cond = cond_obj.browse(self.cursor, self.uid, cond_id)
 
-            print(cond.subtype_id.name)
             if cond.subtype_id.name in ["006", "009", "036"]:  # unsuported
                 continue
 
@@ -1151,7 +1152,7 @@ class SomAutoreclamaConditionsTest(SomAutoreclamaBaseTests):
             self.assertEqual(ok, True, "Error on More than for condition id {}".format(cond_id))
 
             # test less
-            atc_id = self.build_atc(subtype=cond.subtype_id.name, log_days=cond.days / 2, r1=True)
+            atc_id = self.build_atc(subtype=cond.subtype_id.name, log_days=cond.days // 2, r1=True)
             atc_data = atc_obj.get_autoreclama_data(self.cursor, self.uid, atc_id, "atc", {})
             ok = cond_obj.fit_condition(self.cursor, self.uid, cond_id, atc_data, "atc", {})
             self.assertEqual(ok, False, "Error on Less than for condition id {}".format(cond_id))

--- a/som_autoreclama/tests/test_som_autoreclama_states.py
+++ b/som_autoreclama/tests/test_som_autoreclama_states.py
@@ -4,6 +4,7 @@ from addons import get_module_resource
 import mock
 from ..models import giscedata_atc, giscedata_polissa, som_autoreclama_state_history
 from test_som_autoreclama_base import SomAutoreclamaBaseTests, today_str, today_minus_str
+from destral.patch import PatchNewCursors
 
 
 class SomAutoreclamaStatesTest(SomAutoreclamaBaseTests):
@@ -1355,6 +1356,7 @@ class SomAutoreclamaUpdaterTest(SomAutoreclamaBaseTests):
         self.assertEqual(atc.autoreclama_state_date, today_str())
         self.assertGreaterEqual(len(atc.autoreclama_history_ids), 2)
 
+    @PatchNewCursors()
     def test_update_atcs_if_possible__some_consitions(self):
         atc_n_id = self.build_atc(r1=True)
         atc_y_id = self.build_atc(log_days=60, subtype="001", r1=True)
@@ -1825,6 +1827,7 @@ class SomAutoreclamaUpdaterTest(SomAutoreclamaBaseTests):
         second_006_id = pol.autoreclama_history_ids[0]['generated_atc_id'].id
         self.assertNotEqual(first_006.id, second_006_id)
 
+    @PatchNewCursors()
     def test_update_polisses_if_possible__some_conditions(self):
         pol_n_id = self.build_polissa(
             name="polissa_0003",


### PR DESCRIPTION
## Objectiu

Reduir l'impacte a la base de dades del procés diari d'autoreclama
Pr feta per IA

## Targeta on es demana o Incidència

incidència general

## Comportament antic

una mega-transacció

## Comportament nou

trenca la mega-transacció en petits commits


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reduces the database impact of the daily autoreclama cron job by replacing a single mega-transaction with per-item commits using independent `pooler` cursors, and adds `("end_date", "=", False)` filters with `limit=1` to history searches to cut the number of rows fetched.

- **Per-item cursor isolation** (`update_items_if_possible`): each item now gets its own `new_cursor` committed after processing; a `try/finally` ensures the cursor is closed even on exception. Python 2/3 compat fixes (`iteritems` → `items`, `urllib.urlencode` → conditional import) are included.
- **History query optimisation** (`giscedata_atc.py`, `giscedata_polissa.py`): all calls that previously fetched every history row for an entity now filter to `end_date = False` + `limit=1`, relying on the model's `_order = "end_date desc, id desc"` to return the one active row efficiently.
- **Test updates**: `@PatchNewCursors()` added to the two tests that call `update_items_if_possible`, and two new tests confirm that closed history rows are ignored when reading the current state.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the performance goal; the history-query and Python-compat changes are correct, but the error-handling path in the per-item loop has open concerns from prior review rounds that are not yet resolved.

The per-item cursor logic, end_date=False filters, and test additions are all correctly implemented. The one area that warrants a second look before shipping to production is the exception path in update_items_if_possible: an unhandled runtime error inside the loop still aborts all remaining items, and the result=None branch commits whatever partial writes do_action produced. Both of these were flagged in earlier review rounds and remain unchanged in this revision.

som_autoreclama/models/som_autoreclama_state_updater.py — specifically the per-item try/finally block and what happens when update_item_if_possible returns None.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_autoreclama/models/som_autoreclama_state_updater.py | Core change: per-item cursor with try/finally. Residual open concerns from earlier review threads (no except to continue past per-item exceptions; result=None path still calls commit) are unresolved in this revision. |
| som_autoreclama/models/giscedata_polissa.py | Adds end_date=False + limit=1 to all active-state history searches; review-state lookup now uses order="id desc" which correctly returns the most recently created review row. |
| som_autoreclama/models/giscedata_atc.py | Identical end_date=False + limit=1 optimisation for the ATC history lookup; semantically equivalent to the old query given the model's default ordering. |
| som_autoreclama/tests/test_som_autoreclama_states.py | Adds @PatchNewCursors to two updater tests; adds two new state-history tests; fixes integer division (30/2 → 30//2) for Python 3 compatibility. |
| som_autoreclama/tests/test_som_autoreclama_009.py | Single import fix: absolute import from .test_som_autoreclama_base instead of bare module name. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Cron as Cron job
    participant Updater as SomAutoreclamaStateUpdater
    participant Pool as pooler
    participant DB as PostgreSQL

    Cron->>Updater: _cronjob_state_updater_mail_text(cursor)
    Updater->>Updater: state_updater(cursor) — fetch all candidate IDs via cursor
    loop for each item_id
        Updater->>Pool: get_db(cursor.dbname).cursor()
        Pool-->>Updater: new_cursor
        Updater->>DB: get_autoreclama_state_name(new_cursor, item_id)
        Updater->>DB: update_item_if_possible(new_cursor, item_id)
        DB-->>Updater: result (True / False / None)
        alt "result == True (state changed)"
            Updater->>DB: historize then new_cursor.commit()
        else "result == False (no change needed)"
            Updater->>DB: new_cursor.commit() no-op
        else "result == None (do_change=False)"
            Updater->>DB: new_cursor.commit() partial writes persisted
        end
        Updater->>DB: new_cursor.close()
    end
    Updater->>Updater: get_names / get_names_as_link via original cursor
    Updater-->>Cron: summary text then send email
```
</details>

<sub>Reviews (5): Last reviewed commit: ["🤖✅ py3k"](https://github.com/som-energia/openerp_som_addons/commit/05aa118de089947250b84f4efc31448d0296a6da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34375039)</sub>

<!-- /greptile_comment -->