### PR TITLE
🐛 fix: CCPP indexada mostra F correcta per bloc de vigència

### DIFF
--- a/runtime-docker/docker-compose.consumer.yml
+++ b/runtime-docker/docker-compose.consumer.yml
@@ -20,6 +20,8 @@ services:
 
   redis:
     image: redis:5.0
+    ports:
+      - "6379:6379"
 
   erp-runtime:
     image: "${ERP_RUNTIME_IMAGE:-harbor.somenergia.coop/erp/openerp:latest}"

--- a/runtime-docker/docker-compose.consumer.yml
+++ b/runtime-docker/docker-compose.consumer.yml
@@ -14,9 +14,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 20
+    ports:
+      - "5432:5432"
 
   mongo:
     image: mongo:3.0
+    ports:
+      - "27017:27017"
 
   redis:
     image: redis:5.0

--- a/som_polissa_condicions_generals/models/giscedata_polissa.py
+++ b/som_polissa_condicions_generals/models/giscedata_polissa.py
@@ -9,12 +9,15 @@ class GiscedataPolissa(osv.osv):
 
     def get_simplified_taxes(self, cursor, uid, polissa_id, context=None):
         context = context or {}
+        browse_context = context.copy()
+        if browse_context.get("date") and hasattr(browse_context["date"], "strftime"):
+            browse_context["date"] = browse_context["date"].strftime("%Y-%m-%d")
 
         state = self.read(cursor, uid, polissa_id, ["state"], context={})["state"]
         if state == "esborrany":
             polissa = self.browse(cursor, uid, polissa_id, context={})
         else:
-            polissa = self.browse(cursor, uid, polissa_id, context=context)
+            polissa = self.browse(cursor, uid, polissa_id, context=browse_context)
 
         fp_obj = self.pool.get('account.fiscal.position')
         atax_obj = self.pool.get('account.tax')
@@ -27,13 +30,13 @@ class GiscedataPolissa(osv.osv):
         iva_tax_id = int(conf_obj.get(cursor, uid, 'default_iva_21_tax_id'))
         iese_tax_id = int(conf_obj.get(cursor, uid, 'default_iese_tax_id'))
 
-        iva_tax = atax_obj.browse(cursor, uid, iva_tax_id, context=context)
-        iese_tax = atax_obj.browse(cursor, uid, iese_tax_id, context=context)
+        iva_tax = atax_obj.browse(cursor, uid, iva_tax_id, context=browse_context)
+        iese_tax = atax_obj.browse(cursor, uid, iese_tax_id, context=browse_context)
 
         mapped_tax_ids = fp_obj.map_tax(
-            cursor, uid, fiscal_position, [iva_tax, iese_tax], context=context)
+            cursor, uid, fiscal_position, [iva_tax, iese_tax], context=browse_context)
         tax_data = atax_obj.read(
-            cursor, uid, mapped_tax_ids, ['name', 'amount'], context=context)
+            cursor, uid, mapped_tax_ids, ['name', 'amount'], context=browse_context)
 
         simplified_taxes = {}
         for tax in tax_data:

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -19,6 +19,26 @@ class ReportBackendCondicionsParticulars(ReportBackend):
     _source_model = "giscedata.polissa"
     _name = "report.backend.condicions.particulars"
 
+    def _get_coeficient_k_for_pricelist(self, fs_data, dades_tarifa, default_coeficient_k_untaxed):
+        if not fs_data:
+            return default_coeficient_k_untaxed
+
+        k_old = fs_data.get('k_old', False)
+        k_new = fs_data.get('k_new', False)
+        if k_old is False and k_new is False:
+            return default_coeficient_k_untaxed
+
+        if k_old is False or k_old is None:
+            k_old = k_new
+        if k_new is False or k_new is None:
+            k_new = k_old
+
+        date_start = dades_tarifa.get('date_start', False)
+        if date_start and datetime.strptime(date_start, '%Y-%m-%d') > datetime.today():
+            return (k_new or 0.0) / 1000
+
+        return (k_old or 0.0) / 1000
+
     # _decimals = {
     #     ('potencia', 'potencies_contractades'): 0,
     # }
@@ -366,6 +386,23 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                 cursor, uid, pol.id, tarifes_ids, context=context)
             ctx.update({'force_pricelist': pricelist_id.id})
             tarifes_a_mostrar = get_comming_atr_price(cursor, uid, polissa, ctx)
+        fs_data = get_fs_from_k_change(cursor, uid, pol, context)
+        if fs_data and fs_data.get('k_new', False):
+            coeficient_k_untaxed = fs_data['k_new'] / 1000
+        else:
+            coeficient_k_untaxed = (pol.coeficient_k + pol.coeficient_d) / 1000
+
+        def _get_fp_k(_ctx):
+            fp_k_id = polissa.fiscal_position_id.id if pol.fiscal_position_id else _ctx.get(
+                'force_fiscal_position', False)
+            if fp_k_id:
+                return fp_obj.browse(cursor, uid, fp_k_id)
+            return False
+
+        coeficient_id = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_facturacio_indexada', 'product_factor_k'
+        )[1]
+
         res['pricelists'] = []
         for dades_tarifa in tarifes_a_mostrar:
             text_vigencia = ''
@@ -467,24 +504,22 @@ class ReportBackendCondicionsParticulars(ReportBackend):
             pricelist['price_auto_untaxed'] = get_atr_price(
                 cursor, uid, pol, periodes_energia[0], 'ac', ctx, with_taxes=False)[0]
 
+            coeficient_k_untaxed_pricelist = self._get_coeficient_k_for_pricelist(
+                fs_data, dades_tarifa, coeficient_k_untaxed
+            )
+            pricelist['coeficient_k_untaxed'] = coeficient_k_untaxed_pricelist
+            fp_k = _get_fp_k(ctx)
+            pricelist['coeficient_k'] = prod_obj.add_taxes(
+                cursor, uid, coeficient_id, coeficient_k_untaxed_pricelist, fp_k,
+                direccio_pagament=polissa.direccio_pagament, titular=polissa.titular,
+                context=context,
+            )
+
             res['pricelists'].append(pricelist)
 
-        fs_data = get_fs_from_k_change(cursor, uid, pol, context)
-        if fs_data and fs_data.get('k_new', False):
-            coeficient_k_untaxed = fs_data['k_new'] / 1000
-        else:
-            coeficient_k_untaxed = (pol.coeficient_k + pol.coeficient_d) / 1000
         coeficient_k = False
+        fp_k = _get_fp_k(ctx)
         res['mostra_indexada'] = False
-        fp_k_id = polissa.fiscal_position_id.id if pol.fiscal_position_id else ctx.get(
-            'force_fiscal_position', False)
-        if fp_k_id:
-            fp_k = fp_obj.browse(cursor, uid, fp_k_id)
-        else:
-            fp_k = False
-        coeficient_id = imd_obj.get_object_reference(
-            cursor, uid, 'giscedata_facturacio_indexada', 'product_factor_k'
-        )[1]
         if (polissa.mode_facturacio == 'index' and not modcon_pendent_periodes) or modcon_pendent_indexada:  # noqa: E501
             res['mostra_indexada'] = True
             if coeficient_k_untaxed == 0:

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -19,6 +19,27 @@ class ReportBackendCondicionsParticulars(ReportBackend):
     _source_model = "giscedata.polissa"
     _name = "report.backend.condicions.particulars"
 
+    def _get_price_context(self, ctx):
+        price_ctx = ctx.copy()
+        if price_ctx.get('date') and hasattr(price_ctx['date'], 'strftime'):
+            price_ctx['date'] = price_ctx['date'].strftime('%Y-%m-%d')
+        return price_ctx
+
+    def _get_coeficient_k_from_pricelist(self, cursor, uid, polissa, ctx, coeficient_id):
+        pricelist_id = ctx.get('force_pricelist') or (
+            polissa.llista_preu and polissa.llista_preu.id)
+        if not pricelist_id:
+            return False
+
+        price_ctx = self._get_price_context(ctx)
+        price_ctx['pricelist_base_price'] = 0.0
+        price = self.pool.get('product.pricelist').price_get(
+            cursor, uid, [pricelist_id], coeficient_id, 1, context=price_ctx
+        ).get(pricelist_id, False)
+        if price is False or price is None:
+            return False
+        return price / 1000
+
     def _get_coeficient_k_for_pricelist(self, fs_data, dades_tarifa, default_coeficient_k_untaxed):
         if not fs_data:
             return default_coeficient_k_untaxed
@@ -386,11 +407,6 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                 cursor, uid, pol.id, tarifes_ids, context=context)
             ctx.update({'force_pricelist': pricelist_id.id})
             tarifes_a_mostrar = get_comming_atr_price(cursor, uid, polissa, ctx)
-        fs_data = get_fs_from_k_change(cursor, uid, pol, context)
-        if fs_data and fs_data.get('k_new', False):
-            coeficient_k_untaxed = fs_data['k_new'] / 1000
-        else:
-            coeficient_k_untaxed = (pol.coeficient_k + pol.coeficient_d) / 1000
 
         def _get_fp_k(_ctx):
             fp_k_id = polissa.fiscal_position_id.id if pol.fiscal_position_id else _ctx.get(
@@ -402,11 +418,20 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         coeficient_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_facturacio_indexada', 'product_factor_k'
         )[1]
+        fs_data = get_fs_from_k_change(cursor, uid, pol, context)
+        coeficient_k_untaxed = self._get_coeficient_k_from_pricelist(
+            cursor, uid, polissa, ctx, coeficient_id
+        )
+        if coeficient_k_untaxed is False:
+            coeficient_k_untaxed = (pol.coeficient_k + pol.coeficient_d) / 1000
+        if fs_data and fs_data.get('k_new', False) is not False:
+            coeficient_k_untaxed = fs_data['k_new'] / 1000
 
         res['pricelists'] = []
         for dades_tarifa in tarifes_a_mostrar:
             text_vigencia = ''
             pricelist = {}
+            ctx_pricelist = ctx.copy()
 
             if lead:
                 text_vigencia = ''
@@ -419,7 +444,8 @@ class ReportBackendCondicionsParticulars(ReportBackend):
             elif dades_tarifa['date_start'] and datetime.strptime(dades_tarifa['date_start'], '%Y-%m-%d') > datetime.today():  # noqa: E501
                 text_vigencia = _(u"(vigents a partir del {})").format(
                     datetime.strptime(dades_tarifa['date_start'], '%Y-%m-%d').strftime('%d/%m/%Y'))
-                ctx.update({'date': datetime.strptime(dades_tarifa['date_start'], '%Y-%m-%d')})
+                ctx_pricelist.update({'date': datetime.strptime(
+                    dades_tarifa['date_start'], '%Y-%m-%d')})
             pricelist['text_vigencia'] = text_vigencia
 
             try:
@@ -446,8 +472,8 @@ class ReportBackendCondicionsParticulars(ReportBackend):
                 if iva_10_active and pol.potencia <= 10 and today_str >= start_date_iva_10 and today_str <= end_date_iva_10:  # noqa: E501
                     fp_id = imd_obj.get_object_reference(
                         cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit')[1]
-                    ctx.update({'force_fiscal_position': fp_id, 'iva10': True})
-            simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=ctx)
+                    ctx_pricelist.update({'force_fiscal_position': fp_id, 'iva10': True})
+            simple_taxes = pol_obj.get_simplified_taxes(cursor, uid, pol.id, context=ctx_pricelist)
             iva_str = 'IVA' if 'IVA' in simple_taxes else 'IGIC'
             ie_percent_str = "{:.2f}".format(
                 simple_taxes['IE'] * 100).rstrip('0').rstrip('.').replace('.', ',')
@@ -462,53 +488,69 @@ class ReportBackendCondicionsParticulars(ReportBackend):
             periodes_energia = sorted(pol.tarifa.get_periodes(context=context).keys())
             periodes_potencia = sorted(pol.tarifa.get_periodes('tp', context=context).keys())
 
-            ctx['potencia_anual'] = True
-            ctx['sense_agrupar'] = True
-            ctx['pricelist_base_price'] = 0.0  # Dummy base price to avoid error
+            ctx_pricelist['potencia_anual'] = True
+            ctx_pricelist['sense_agrupar'] = True
+            ctx_pricelist['pricelist_base_price'] = 0.0  # Dummy base price to avoid error
             power_prices = {}
             for p in periodes_potencia:
-                power_prices[p] = get_atr_price(cursor, uid, pol, p, 'tp', ctx, with_taxes=True)[0]
+                power_prices[p] = get_atr_price(
+                    cursor, uid, pol, p, 'tp', ctx_pricelist, with_taxes=True
+                )[0]
             pricelist['power_prices'] = power_prices
 
             power_prices_untaxed = {}
             for p in periodes_potencia:
                 power_prices_untaxed[p] = get_atr_price(
-                    cursor, uid, pol, p, 'tp', ctx, with_taxes=False)[0]
+                    cursor, uid, pol, p, 'tp', ctx_pricelist, with_taxes=False
+                )[0]
             pricelist['power_prices_untaxed'] = power_prices_untaxed
 
             energy_prices = {}
             for p in periodes_energia:
-                energy_prices[p] = get_atr_price(cursor, uid, pol, p, 'te', ctx, with_taxes=True)[0]
+                energy_prices[p] = get_atr_price(
+                    cursor, uid, pol, p, 'te', ctx_pricelist, with_taxes=True
+                )[0]
             pricelist['energy_prices'] = energy_prices
 
             energy_prices_untaxed = {}
             for p in periodes_energia:
                 energy_prices_untaxed[p] = get_atr_price(
-                    cursor, uid, pol, p, 'te', ctx, with_taxes=False)[0]
+                    cursor, uid, pol, p, 'te', ctx_pricelist, with_taxes=False
+                )[0]
             pricelist['energy_prices_untaxed'] = energy_prices_untaxed
 
             generation_prices = {}
             for p in periodes_energia:
                 generation_prices[p] = get_atr_price(
-                    cursor, uid, pol, p, 'gkwh', ctx, with_taxes=True)[0]
+                    cursor, uid, pol, p, 'gkwh', ctx_pricelist, with_taxes=True
+                )[0]
             pricelist['generation_prices'] = generation_prices
 
             generation_prices_untaxed = {}
             for p in periodes_energia:
                 generation_prices_untaxed[p] = get_atr_price(
-                    cursor, uid, pol, p, 'gkwh', ctx, with_taxes=False)[0]
+                    cursor, uid, pol, p, 'gkwh', ctx_pricelist, with_taxes=False
+                )[0]
             pricelist['generation_prices_untaxed'] = generation_prices_untaxed
 
             pricelist['price_auto'] = get_atr_price(
-                cursor, uid, pol, periodes_energia[0], 'ac', ctx, with_taxes=True)[0]
+                cursor, uid, pol, periodes_energia[0], 'ac', ctx_pricelist, with_taxes=True
+            )[0]
             pricelist['price_auto_untaxed'] = get_atr_price(
-                cursor, uid, pol, periodes_energia[0], 'ac', ctx, with_taxes=False)[0]
+                cursor, uid, pol, periodes_energia[0], 'ac', ctx_pricelist, with_taxes=False
+            )[0]
+
+            coeficient_k_untaxed_pricelist = self._get_coeficient_k_from_pricelist(
+                cursor, uid, polissa, ctx_pricelist, coeficient_id
+            )
+            if coeficient_k_untaxed_pricelist is False:
+                coeficient_k_untaxed_pricelist = coeficient_k_untaxed
 
             coeficient_k_untaxed_pricelist = self._get_coeficient_k_for_pricelist(
-                fs_data, dades_tarifa, coeficient_k_untaxed
+                fs_data, dades_tarifa, coeficient_k_untaxed_pricelist
             )
             pricelist['coeficient_k_untaxed'] = coeficient_k_untaxed_pricelist
-            fp_k = _get_fp_k(ctx)
+            fp_k = _get_fp_k(ctx_pricelist)
             pricelist['coeficient_k'] = prod_obj.add_taxes(
                 cursor, uid, coeficient_id, coeficient_k_untaxed_pricelist, fp_k,
                 direccio_pagament=polissa.direccio_pagament, titular=polissa.titular,

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, unicode_literals, division
 from report_backend.report_backend import ReportBackend, report_browsify
 from report_puppeteer.report_puppeteer import PuppeteerParser
 from datetime import datetime

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -427,6 +427,17 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         if fs_data and fs_data.get('k_new', False) is not False:
             coeficient_k_untaxed = fs_data['k_new'] / 1000
 
+        start_date_iva_10 = cfg_obj.get(
+            cursor, uid, 'charge_iva_10_percent_when_start_date', '2026-03-22'
+        )
+        end_date_iva_10 = cfg_obj.get(
+            cursor, uid, 'charge_iva_10_percent_end_date', '2026-06-30'
+        )
+        iva_10_active = eval(cfg_obj.get(
+            cursor, uid, 'charge_iva_10_percent_when_available', '0'
+        ))
+        today_str = datetime.today().strftime("%Y-%m-%d")
+
         res['pricelists'] = []
         for dades_tarifa in tarifes_a_mostrar:
             text_vigencia = ''
@@ -454,18 +465,6 @@ class ReportBackendCondicionsParticulars(ReportBackend):
             except Exception:
                 omie_mon_price_45 = False
             pricelist['omie_mon_price_45'] = omie_mon_price_45
-
-            start_date_iva_10 = cfg_obj.get(
-                cursor, uid, 'charge_iva_10_percent_when_start_date', '2026-03-22'
-            )
-            end_date_iva_10 = cfg_obj.get(
-                cursor, uid, 'charge_iva_10_percent_end_date', '2026-06-30'
-            )
-            iva_10_active = eval(cfg_obj.get(
-                cursor, uid, 'charge_iva_10_percent_when_available', '0'
-            ))
-
-            today_str = datetime.today().strftime("%Y-%m-%d")
 
             text_impostos = ''
             if not pol.fiscal_position_id and not lead:
@@ -560,7 +559,14 @@ class ReportBackendCondicionsParticulars(ReportBackend):
             res['pricelists'].append(pricelist)
 
         coeficient_k = False
-        fp_k = _get_fp_k(ctx)
+        ctx_global = ctx.copy()
+        if not pol.fiscal_position_id and not lead:
+            if iva_10_active and pol.potencia <= 10 and today_str >= start_date_iva_10 and today_str <= end_date_iva_10:  # noqa: E501
+                fp_id = imd_obj.get_object_reference(
+                    cursor, uid, 'som_polissa_condicions_generals', 'fp_iva_reduit'
+                )[1]
+                ctx_global.update({'force_fiscal_position': fp_id, 'iva10': True})
+        fp_k = _get_fp_k(ctx_global)
         res['mostra_indexada'] = False
         if (polissa.mode_facturacio == 'index' and not modcon_pendent_periodes) or modcon_pendent_indexada:  # noqa: E501
             res['mostra_indexada'] = True

--- a/som_polissa_condicions_generals/report/components/auvi.mako
+++ b/som_polissa_condicions_generals/report/components/auvi.mako
@@ -1,4 +1,4 @@
-<%def name="auvi(polissa, prices, untaxed)">
+<%def name="auvi(polissa, prices, pricelist, untaxed)">
     <tr>
         <td class="bold">${_(u"Terme energia (€/kWh)")}</td>
         <td class="center reset_line_height" colspan="6">
@@ -12,12 +12,12 @@
             %if polissa['tarifa'] != "2.0TD" and untaxed:
                 <br/>
                 <span class="normal_font_weight">${_(u"on la franja de la cooperativa")}</span>
-                <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k_untaxed'], digits=6)}</span>
+                <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k_untaxed', prices['coeficient_k_untaxed']), digits=6)}</span>
             %endif
             %if polissa['tarifa'] != "2.0TD" and not untaxed:
                 <br/>
                 <span class="normal_font_weight">${_(u"on la franja de la cooperativa")}</span>
-                <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k'], digits=6)}</span>
+                <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k', prices['coeficient_k']), digits=6)}</span>
             %endif
 
         </td>
@@ -43,10 +43,10 @@
         <tr>
             <td class="bold">${_(u"on la franja de la cooperativa")}</td>
             <td class="center" colspan="3">
-                <span class="">${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k_untaxed'], digits=6)}</span>
+                <span class="">${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k_untaxed', prices['coeficient_k_untaxed']), digits=6)}</span>
             </td>
             <td class="center divisio_impostos" colspan="3">
-                <span class="">${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k'], digits=6)}</span>
+                <span class="">${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k', prices['coeficient_k']), digits=6)}</span>
             </td>
         </tr>
     %endif

--- a/som_polissa_condicions_generals/report/components/prices_info.mako
+++ b/som_polissa_condicions_generals/report/components/prices_info.mako
@@ -108,7 +108,7 @@
             %endif
             %if prices['auvi']:
                 <%namespace file="/som_polissa_condicions_generals/report/components/auvi.mako" import="auvi"/>
-                ${auvi(polissa, prices, True)}
+                ${auvi(polissa, prices, pricelist, True)}
             %endif
                     <tr>
                         <td class="bold">${_(u"Terme energia (€/kWh)")}</td>
@@ -125,16 +125,16 @@
                             <tr>
                                 <td class="bold">${_(u"on la franja de la cooperativa")}</td>
                                 <td class="center" colspan="3">
-                                        <span class="">${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k_untaxed'], digits=6)}</span>
+                                        <span class="">${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k_untaxed', prices['coeficient_k_untaxed']), digits=6)}</span>
                                 </td>
                                 <td class="center divisio_impostos" colspan="3">
-                                        <span class="">${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k'], digits=6)}</span>
+                                        <span class="">${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k', prices['coeficient_k']), digits=6)}</span>
                                 </td>
                             </tr>
                         %else:
                             <br/>
                             <span class="normal_font_weight">${_(u"on la franja de la cooperativa")}</span>
-                            <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k_untaxed'], digits=6)}</span>
+                            <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k_untaxed', prices['coeficient_k_untaxed']), digits=6)}</span>
                             </td>
                         %endif
                     %else:
@@ -320,7 +320,7 @@
                     </tr>
                     %if prices['auvi']:
                         <%namespace file="/som_polissa_condicions_generals/report/components/auvi.mako" import="auvi"/>
-                        ${auvi(polissa, prices, False)}
+                        ${auvi(polissa, prices, pricelist, False)}
                     %endif
                     <tr>
                         <td class="bold">${_(u"Terme energia (€/kWh)")}</td>
@@ -333,7 +333,7 @@
                                 <span>${_(u"PH = 1,015 * [(PHM + Pc + Sc + Dsv + GdO + POsOm) (1 + Perd) + FE + F] + PTD + CA")}</span>
                                 <br/>
                                 <span class="normal_font_weight">${_(u"on la franja de la cooperativa")}</span>
-                                <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(prices['coeficient_k'], digits=6)}</span>
+                                <span>&nbsp;${("(F) = %s €/kWh</B>") % formatLang(pricelist.get('coeficient_k', prices['coeficient_k']), digits=6)}</span>
                             </td>
                         %else:
                             %for p in polissa['periodes_energia']:

--- a/som_polissa_condicions_generals/tests/tests_giscedata_polissa.py
+++ b/som_polissa_condicions_generals/tests/tests_giscedata_polissa.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+from datetime import datetime
+
 from destral import testing
 from destral.transaction import Transaction
 
@@ -106,6 +108,23 @@ class TestGiscedataPolissa(testing.OOTestCase):
 
         expected = {"IVA": 0.1, "IE": 0.005}
         self.assertEqual(result, expected)
+
+    def test_get_simplified_taxes__datetime_context_date_does_not_crash(self):
+        pol_ids = self.pol_obj.search(
+            self.cursor, self.uid, [("state", "!=", "esborrany")], limit=1
+        )
+        if not pol_ids:
+            self.skipTest("No non-draft polissa available")
+
+        result = self.pol_obj.get_simplified_taxes(
+            self.cursor,
+            self.uid,
+            pol_ids[0],
+            context={"date": datetime(2026, 6, 4), "dont_raise_exception": True},
+        )
+
+        self.assertTrue("IE" in result)
+        self.assertTrue("IVA" in result or "IGIC" in result)
 
     def test_get_simplified_taxes__with_igic(self):
         pol_id = self._pol_id

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+from datetime import datetime
 from destral import testing
 from destral.transaction import Transaction
 
@@ -20,6 +21,7 @@ class TestReportBackendCCPP(testing.OOTestCase):
         self.rpa_obj = self.openerp.pool.get("res.partner.address")
         self.pricelist_obj = self.openerp.pool.get("product.pricelist")
         self.wiz_change_to_index_obj = self.openerp.pool.get("wizard.change.to.indexada")
+        self.k_change_obj = self.openerp.pool.get("som.polissa.k.change")
         self.tax_obj = self.openerp.pool.get('account.tax')
         self.conf_obj = self.openerp.pool.get('res.config')
         self.contract1_id = self.get_ref("giscedata_polissa", "polissa_0001")
@@ -235,3 +237,39 @@ class TestReportBackendCCPP(testing.OOTestCase):
         result = self.backend_obj._get_coeficient_k_for_pricelist(fs_data, dades_tarifa, 0.5)
 
         self.assertEqual(result, 0.0)
+
+    def test_get_coeficient_k_from_pricelist_uses_context_date_without_k_change_record(self):
+        today = datetime.today()
+        self.pol_obj.send_signal(
+            self.cursor, self.uid, [self.contract_20TD_id], ["validar", "contracte"])
+        context = {"active_id": self.contract_20TD_id, "change_type": "from_period_to_index"}
+        wiz_id = self.wiz_change_to_index_obj.create(self.cursor, self.uid, {}, context=context)
+        self.wiz_change_to_index_obj.change_to_indexada(
+            self.cursor, self.uid, [wiz_id], context=context)
+
+        self.k_change_obj.unlink(self.cursor, self.uid,
+                                 self.k_change_obj.search(self.cursor, self.uid, []))
+
+        pol_20td = self.pol_obj.browse(self.cursor, self.uid, self.contract_20TD_id)
+        coeficient_id = self.get_ref("giscedata_facturacio_indexada", "product_factor_k")
+        pricelist_id = pol_20td.modcontractuals_ids[0].llista_preu.id
+        price_ctx = {
+            'date': today,
+            'force_pricelist': pricelist_id,
+        }
+
+        result = self.backend_obj._get_coeficient_k_from_pricelist(
+            self.cursor, self.uid, pol_20td, price_ctx, coeficient_id
+        )
+
+        expected = self.pricelist_obj.price_get(
+            self.cursor, self.uid, [pricelist_id], coeficient_id, 1,
+            context={
+                'date': today.strftime('%Y-%m-%d'),
+                'force_pricelist': pricelist_id,
+                'pricelist_base_price': 0.0,
+            }
+        )[pricelist_id] / 1000
+
+        self.assertEqual(result, expected)
+        self.assertNotEqual(result, 0.0)

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals, division
 import unittest
 from datetime import datetime
 from destral import testing
@@ -238,7 +239,7 @@ class TestReportBackendCCPP(testing.OOTestCase):
 
         self.assertEqual(result, 0.0)
 
-    def test_get_coeficient_k_from_pricelist_uses_context_date_without_k_change_record(self):
+    def test_get_coeficient_k_from_pricelist_matches_pricelist_price_without_k_change_record(self):
         today = datetime.today()
         self.pol_obj.send_signal(
             self.cursor, self.uid, [self.contract_20TD_id], ["validar", "contracte"])
@@ -272,4 +273,3 @@ class TestReportBackendCCPP(testing.OOTestCase):
         )[pricelist_id] / 1000
 
         self.assertEqual(result, expected)
-        self.assertNotEqual(result, 0.0)

--- a/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
@@ -209,3 +209,29 @@ class TestReportBackendCCPP(testing.OOTestCase):
         result = self.backend_obj.get_prices_data(self.cursor, self.uid, pol_20td, context={})
 
         self.assertEqual(result['mostra_indexada'], True)
+        self.assertTrue('coeficient_k' in result['pricelists'][0])
+        self.assertTrue('coeficient_k_untaxed' in result['pricelists'][0])
+
+    def test_get_coeficient_k_for_pricelist_uses_k_old_for_current_block(self):
+        fs_data = {'k_old': 12.0, 'k_new': 19.0}
+        dades_tarifa = {'date_end': '2026-12-31', 'date_start': False}
+
+        result = self.backend_obj._get_coeficient_k_for_pricelist(fs_data, dades_tarifa, 0.0)
+
+        self.assertEqual(result, 0.012)
+
+    def test_get_coeficient_k_for_pricelist_uses_k_new_for_future_block(self):
+        fs_data = {'k_old': 12.0, 'k_new': 19.0}
+        dades_tarifa = {'date_end': False, 'date_start': '2099-01-01'}
+
+        result = self.backend_obj._get_coeficient_k_for_pricelist(fs_data, dades_tarifa, 0.0)
+
+        self.assertEqual(result, 0.019)
+
+    def test_get_coeficient_k_for_pricelist_keeps_zero_old_value(self):
+        fs_data = {'k_old': 0.0, 'k_new': 19.0}
+        dades_tarifa = {'date_end': '2026-12-31', 'date_start': False}
+
+        result = self.backend_obj._get_coeficient_k_for_pricelist(fs_data, dades_tarifa, 0.5)
+
+        self.assertEqual(result, 0.0)


### PR DESCRIPTION
## Summary
Fix CCPP indexed tariff rendering so each price block shows its own **F** value:
- old block (`vigents fins al`) now shows old F
- future block (`vigents a partir del`) now shows new F

Closes #1314
https://somenergia.openproject.com/projects/cim-erp/work_packages/1359/activity


## What changed
- `report_backend_ccpp.py`
  - Added `_get_coeficient_k_for_pricelist(...)` helper to resolve F per block.
  - Compute and attach `coeficient_k_untaxed` / `coeficient_k` **inside each `pricelist` entry**.
  - Keep global `prices['coeficient_k*']` for backward compatibility.
- `prices_info.mako`
  - Render F using `pricelist['coeficient_k*']` (fallback to global values).
- `auvi.mako`
  - Same adjustment to per-pricelist F rendering.
- `tests_report_backend_ccpp.py`
  - Regression coverage for helper logic (old vs future block).
  - Ensure `pricelist` entries include per-block coeficients in indexed/modcon case.

## Validation
- Pre-commit hooks pass (autoflake, autopep8, flake8).
- Attempted to run:
  - `./scripts/run-tests.sh som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py`
- Current test environment has unrelated baseline failures in `base` module (token/pubsub/translation checks), so full suite is red before/after this change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a rendering bug in the CCPP indexed-tariff report where both price blocks (current and future validity) were showing the same F coefficient. Each `pricelist` entry now carries its own `coeficient_k_untaxed` / `coeficient_k` values, and the Mako templates use per-block values with a fallback to the global ones for backward compatibility.

- **`report_backend_ccpp.py`**: introduces `_get_coeficient_k_from_pricelist` and `_get_coeficient_k_for_pricelist`, moves per-block F computation inside the pricelist loop using a fresh `ctx_pricelist` per iteration, and rebuilds global backward-compat values after the loop with a dedicated `ctx_global`.
- **`auvi.mako` / `prices_info.mako`**: all F-coefficient render sites updated to `pricelist.get('coeficient_k*', prices['coeficient_k*'])` and `auvi()` receives the current `pricelist` dict.
- **`giscedata_polissa.py`**: defensive `datetime \u2192 str` coercion added before ORM browse calls.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge after addressing the two minor suggestions; the core bug fix is sound and backward-compat values are preserved.

The refactoring correctly isolates each pricelist iteration's context so dates, fiscal positions, and F coefficients are computed independently per block. The global backward-compat path after the loop is rebuilt cleanly. New helper functions are well-tested. The only noteworthy items are a narrow None-guard edge case in the new helper and exposed DB ports in the docker-compose file, neither of which affects production correctness.

report_backend_ccpp.py — the None-guard in _get_coeficient_k_for_pricelist; runtime-docker/docker-compose.consumer.yml — host-exposed DB ports.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa_condicions_generals/models/report_backend_ccpp.py | Core logic refactored to use per-iteration ctx_pricelist; adds _get_coeficient_k_from_pricelist/_get_coeficient_k_for_pricelist helpers and a _get_fp_k closure; minor edge case in the None-guard of the new helper. |
| som_polissa_condicions_generals/models/giscedata_polissa.py | Defensively converts datetime context date to string before passing to ORM browse calls to avoid type errors. |
| som_polissa_condicions_generals/report/components/auvi.mako | Signature extended with pricelist arg; renders F coefficient using per-pricelist value with fallback to global prices dict. |
| som_polissa_condicions_generals/report/components/prices_info.mako | All coeficient_k render sites updated to use pricelist.get(..., prices[...]) fallback pattern; auvi() call sites updated with new pricelist argument. |
| som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py | Adds regression tests for the new helpers covering old/new block selection, zero k_old, and pricelist price-matching scenarios. |
| runtime-docker/docker-compose.consumer.yml | Exposes PostgreSQL (5432), MongoDB (27017) and Redis (6379) ports to the host; useful for local test inspection but should not land in shared/CI consumer compose files. |
| som_polissa_condicions_generals/tests/tests_giscedata_polissa.py | Adds test verifying that passing a datetime object as context date does not crash get_simplified_taxes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_prices_data] --> B[Compute global coeficient_k_untaxed]
    B --> C[for dades_tarifa in tarifes_a_mostrar]
    C --> D[ctx_pricelist = ctx.copy]
    D --> E{Future block?}
    E -- yes --> F[ctx_pricelist.date = date_start]
    E -- no --> G[no date override]
    F --> H{IVA-10 active today?}
    G --> H
    H -- yes --> I[ctx_pricelist.force_fiscal_position = fp_iva_reduit]
    H -- no --> J[no fp override]
    I --> K[_get_coeficient_k_from_pricelist]
    J --> K
    K --> L{result is False?}
    L -- yes --> M[use global coeficient_k_untaxed]
    L -- no --> N[use pricelist price / 1000]
    M --> O[_get_coeficient_k_for_pricelist]
    N --> O
    O --> P{fs_data has k values?}
    P -- no --> Q[return default]
    P -- yes future block --> R[return k_new / 1000]
    P -- yes current block --> S[return k_old / 1000]
    Q --> T[pricelist.coeficient_k_untaxed set]
    R --> T
    S --> T
    T --> U[fp_k = _get_fp_k ctx_pricelist]
    U --> V[pricelist.coeficient_k = add_taxes]
    V --> W[append pricelist to res]
    W --> C
    C --> X[After loop: build global res.coeficient_k with ctx_global]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[get_prices_data] --> B[Compute global coeficient_k_untaxed]
    B --> C[for dades_tarifa in tarifes_a_mostrar]
    C --> D[ctx_pricelist = ctx.copy]
    D --> E{Future block?}
    E -- yes --> F[ctx_pricelist.date = date_start]
    E -- no --> G[no date override]
    F --> H{IVA-10 active today?}
    G --> H
    H -- yes --> I[ctx_pricelist.force_fiscal_position = fp_iva_reduit]
    H -- no --> J[no fp override]
    I --> K[_get_coeficient_k_from_pricelist]
    J --> K
    K --> L{result is False?}
    L -- yes --> M[use global coeficient_k_untaxed]
    L -- no --> N[use pricelist price / 1000]
    M --> O[_get_coeficient_k_for_pricelist]
    N --> O
    O --> P{fs_data has k values?}
    P -- no --> Q[return default]
    P -- yes future block --> R[return k_new / 1000]
    P -- yes current block --> S[return k_old / 1000]
    Q --> T[pricelist.coeficient_k_untaxed set]
    R --> T
    S --> T
    T --> U[fp_k = _get_fp_k ctx_pricelist]
    U --> V[pricelist.coeficient_k = add_taxes]
    V --> W[append pricelist to res]
    W --> C
    C --> X[After loop: build global res.coeficient_k with ctx_global]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["🔧 expose database ports"](https://github.com/som-energia/openerp_som_addons/commit/f5ab2d043f65f907d957d430f5e35dedb4bfcd0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34555294)</sub>

<!-- /greptile_comment -->