### PR TITLE
FIX_reuse_test_db_per_pr

### DIFF
--- a/.agents/skills/erp-test/SKILL.md
+++ b/.agents/skills/erp-test/SKILL.md
@@ -49,6 +49,8 @@ Si **no** passes `<database>`, el script genera una DB determinística per branc
 scripts/run-tests.sh -m <module_name>
 ```
 
+En aquest mode, el wrapper afegeix `--no-dropdb` automàticament (si no l'has passat tu), perquè la DB es conservi.
+
 **Exemple**:
 ```bash
 scripts/run-tests.sh test_som_polissa -m som_polissa
@@ -63,6 +65,8 @@ Forçar DB nova (sense reutilitzar cache de branca/PR):
 ```bash
 OPENERP_TEST_DB_FRESH=1 scripts/run-tests.sh -m som_polissa
 ```
+
+En mode `OPENERP_TEST_DB_FRESH=1`, el wrapper afegeix `--dropdb` automàticament (si no l'has passat tu) per netejar aquesta execució puntual.
 
 Opcionalment pots fixar la referència usada per al nom determinístic:
 ```bash

--- a/.agents/skills/erp-test/SKILL.md
+++ b/.agents/skills/erp-test/SKILL.md
@@ -43,6 +43,12 @@ Contenidors esperats:
 scripts/run-tests.sh <database> -m <module_name>
 ```
 
+Si **no** passes `<database>`, el script genera una DB determinística per branca/PR i la reutilitza entre execucions:
+
+```bash
+scripts/run-tests.sh -m <module_name>
+```
+
 **Exemple**:
 ```bash
 scripts/run-tests.sh test_som_polissa -m som_polissa
@@ -51,6 +57,16 @@ scripts/run-tests.sh test_som_polissa -m som_polissa
 Test únic:
 ```bash
 scripts/run-tests.sh test_som_polissa -m som_polissa -t TestsClass.test_method
+```
+
+Forçar DB nova (sense reutilitzar cache de branca/PR):
+```bash
+OPENERP_TEST_DB_FRESH=1 scripts/run-tests.sh -m som_polissa
+```
+
+Opcionalment pots fixar la referència usada per al nom determinístic:
+```bash
+OPENERP_TEST_DB_REF="IMP_fix_factures" scripts/run-tests.sh -m som_polissa
 ```
 
 ## Errors Comuns

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 
 # WORKSPACE: carpeta arrel on hi ha tots els repositoris del projecte
 # Ex: export WORKSPACE=/home/<user>/src o /home/<user>/projects
 : "${WORKSPACE:?WORKSPACE no definit. Ex: export WORKSPACE=/home/<user>/src}"
 
 export PYTHONIOENCODING="UTF-8"
-export PYTHONPATH="$WORKSPACE/erp/server/bin:$WORKSPACE/erp/server/bin/addons:$WORKSPACE/erp/server/sitecustomize:$PYTHONPATH"
+export PYTHONPATH="$WORKSPACE/erp/server/bin:$WORKSPACE/erp/server/bin/addons:$WORKSPACE/erp/server/sitecustomize:${PYTHONPATH:-}"
 export PYTHONUNBUFFERED="1"
 
 export DEBUG_ENABLED=0
@@ -29,5 +30,87 @@ export OPENERP_ENVIRONMENT=local
 export OPENERP_SII_TEST_MODE=1
 export OPENERP_IGNORE_PUBSUB=1
 
+sanitize_db_name() {
+  local value="${1:-}"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '_')"
+  value="${value#_}"
+  value="${value%_}"
+  if [ -z "$value" ]; then
+    value="default"
+  fi
+  printf '%s' "$value"
+}
+
+detect_ref_name() {
+  if [ -n "${OPENERP_TEST_DB_REF:-}" ]; then
+    printf '%s' "$OPENERP_TEST_DB_REF"
+    return 0
+  fi
+  if [ -n "${GITHUB_HEAD_REF:-}" ]; then
+    printf '%s' "$GITHUB_HEAD_REF"
+    return 0
+  fi
+  if [ -n "${CI_COMMIT_REF_NAME:-}" ]; then
+    printf '%s' "$CI_COMMIT_REF_NAME"
+    return 0
+  fi
+  if [ -n "${BRANCH_NAME:-}" ]; then
+    printf '%s' "$BRANCH_NAME"
+    return 0
+  fi
+  if ref_name="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
+    printf '%s' "$ref_name"
+    return 0
+  fi
+  printf 'default'
+}
+
+build_reuse_db_name() {
+  local pr_number="${PR_NUMBER:-${CI_MERGE_REQUEST_IID:-${GITHUB_PR_NUMBER:-}}}"
+  local ref_name
+  local slug
+  local name
+
+  ref_name="$(detect_ref_name)"
+  slug="$(sanitize_db_name "$ref_name")"
+
+  if [ -n "$pr_number" ]; then
+    name="test_pr_${pr_number}_${slug}"
+  else
+    name="test_branch_${slug}"
+  fi
+
+  printf '%.63s' "$(sanitize_db_name "$name")"
+}
+
+fresh_db_name() {
+  local base="$1"
+  local suffix
+  local max_base_len
+
+  suffix="$(date +%s)_$$"
+  max_base_len=$((63 - ${#suffix} - 1))
+  if [ "$max_base_len" -lt 1 ]; then
+    max_base_len=1
+  fi
+
+  printf '%s_%s' "${base:0:max_base_len}" "$suffix"
+}
+
+db_name=""
+if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
+  db_name="$1"
+  shift
+else
+  db_name="$(build_reuse_db_name)"
+  if [ "${OPENERP_TEST_DB_FRESH:-0}" = "1" ]; then
+    db_name="$(fresh_db_name "$db_name")"
+  fi
+fi
+
+args=("$db_name" "$@")
+
+export OPENERP_DB_NAME="$db_name"
+
 # --no-requirements evita que destral intenti instal·lar dependències (recomanat en entorns locals)
-python $WORKSPACE/destral/destral/cli.py "$@"
+python "$WORKSPACE/destral/destral/cli.py" "${args[@]}"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -97,11 +97,23 @@ fresh_db_name() {
   printf '%s_%s' "${base:0:max_base_len}" "$suffix"
 }
 
+has_dropdb_flag() {
+  local arg
+  for arg in "$@"; do
+    if [ "$arg" = "--dropdb" ] || [ "$arg" = "--no-dropdb" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 db_name=""
+auto_db_mode=0
 if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
   db_name="$1"
   shift
 else
+  auto_db_mode=1
   db_name="$(build_reuse_db_name)"
   if [ "${OPENERP_TEST_DB_FRESH:-0}" = "1" ]; then
     db_name="$(fresh_db_name "$db_name")"
@@ -109,6 +121,16 @@ else
 fi
 
 args=("$db_name" "$@")
+
+if ! has_dropdb_flag "$@"; then
+  if [ "$auto_db_mode" = "1" ]; then
+    if [ "${OPENERP_TEST_DB_FRESH:-0}" = "1" ]; then
+      args+=("--dropdb")
+    else
+      args+=("--no-dropdb")
+    fi
+  fi
+fi
 
 export OPENERP_DB_NAME="$db_name"
 


### PR DESCRIPTION
## Objectiu

Evitar recrear la base de dades de test a cada execució i reutilitzar-la per branca/PR per reduir molt el temps de test local.

## Targeta on es demana o Incidència

No hi ha issue associada.

## Comportament antic

Amb scripts/run-tests.sh, si no es gestionava manualment la DB, les execucions acabaven reconstruint la base de dades des de zero i el cicle de test era lent.

## Comportament nou

- Si passes <database>, el comportament es manté igual (compatibilitat enrere).
- Si NO passes <database>, el script calcula una DB determinística per branca/PR i la reutilitza.
- Es pot forçar una DB nova puntual amb OPENERP_TEST_DB_FRESH=1.
- S'ha documentat l'ús al skill erp-test.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions