### PR TITLE
Corregir report_id de signatures Signaturit de Generation kWh

### DIFF
--- a/som_generationkwh/investment_strategy.py
+++ b/som_generationkwh/investment_strategy.py
@@ -265,6 +265,11 @@ class GenerationkwhActions(InvestmentActions):
     def attach_signature(self, cursor, uid, investment_id, signaturit_data, context=None):
         GenerationkwhInvestment = self.erp.pool.get('generationkwh.investment')
         SignaturaProcess = self.erp.pool.get('giscedata.signatura.process')
+        IrModelData = self.erp.pool.get('ir.model.data')
+
+        report_id = IrModelData.get_object_reference(
+            cursor, uid, 'som_generationkwh', 'report_generationkwh_signaturit_doc'
+        )[1]
 
         investment = GenerationkwhInvestment.browse(cursor, uid, investment_id)
         recipients = [
@@ -279,6 +284,7 @@ class GenerationkwhActions(InvestmentActions):
                 'signature_id': signaturit_data['documents'][0]['id'],
                 'model': 'generationkwh.investment,{}'.format(investment_id),
                 'filename': signaturit_data['documents'][0]['file']['name'],
+                'report_id': report_id,
             })
         ]
         values = {

--- a/som_generationkwh/migrations/5.0.25.5.0/post-0002_FIX_generationkwh_signaturit_report_id.py
+++ b/som_generationkwh/migrations/5.0.25.5.0/post-0002_FIX_generationkwh_signaturit_report_id.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info('Loading Generation kWh Signaturit report metadata')
+    load_data(
+        cursor, 'som_generationkwh', 'som_generationkwh_data.xml',
+        idref=None, mode='update'
+    )
+
+    cursor.execute("""
+        SELECT res_id
+        FROM ir_model_data
+        WHERE module = %s
+          AND name = %s
+          AND model = %s
+    """, (
+        'som_generationkwh',
+        'report_generationkwh_signaturit_doc',
+        'ir.actions.report.xml',
+    ))
+    row = cursor.fetchone()
+    if not row:
+        raise Exception(
+            'Missing som_generationkwh.report_generationkwh_signaturit_doc'
+        )
+
+    report_id = row[0]
+    cursor.execute("""
+        UPDATE giscedata_signatura_documents
+        SET report_id = %s
+        WHERE report_id IS NULL
+          AND model LIKE 'generationkwh.investment,%%'
+    """, (report_id,))
+    logger.info(
+        'Updated %s Generation kWh signature documents with report_id %s',
+        cursor.rowcount,
+        report_id,
+    )
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_generationkwh/som_generationkwh_data.xml
+++ b/som_generationkwh/som_generationkwh_data.xml
@@ -9,7 +9,17 @@
         <record model="giscedata.signatura.models" id="signatura_model_generationkwh_investment">
             <field name="name" ref="account.model_account_invoice"/>
         </record>
-
+        <record id="report_generationkwh_signaturit_doc" model="ir.actions.report.xml">
+            <field name="report_type">webkit</field>
+            <field name="report_name">generationkwh.signaturit.doc</field>
+            <field eval="[(6,0,[])]" name="groups_id"/>
+            <field eval="0" name="multi"/>
+            <field eval="0" name="auto"/>
+            <field eval="0" name="header"/>
+            <field name="model">generationkwh.investment</field>
+            <field name="type">ir.actions.report.xml</field>
+            <field name="name">Contracte Generation kWh signat</field>
+        </record>
     </data>
     <data noupdate="1">
         <record model="product.category" id="categ_inversions">

--- a/som_generationkwh/tests/investment_tests.py
+++ b/som_generationkwh/tests/investment_tests.py
@@ -2913,6 +2913,16 @@ class InvestmentTests(testing.OOTestCase):
             )
             investment = self.Investment.browse(cursor, uid, id)
             self.assertTrue(investment.signed_date)
+            report_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'report_generationkwh_signaturit_doc'
+            )[1]
+            sign_doc_obj = self.openerp.pool.get('giscedata.signatura.documents')
+            sign_doc_id = sign_doc_obj.search(cursor, uid, [
+                ('model', '=', 'generationkwh.investment,{}'.format(id)),
+                ('signature_id', '=', 'th1s-i5-a-f4ls3-d0c-1d'),
+            ])[0]
+            sign_doc = sign_doc_obj.read(cursor, uid, sign_doc_id, ['report_id'])
+            self.assertEqual(sign_doc['report_id'][0], report_id)
             mocked_update_sign.assert_called()
 
     @mock.patch("generationkwh.investmentstate.InvestmentState.addAction")


### PR DESCRIPTION
## Objectiu

Corregir l'error en descarregar/actualitzar signatures digitals de Generation kWh creades des del flux de Signaturit quan no tenen `report_id`.

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/8172350?folder_id=103

## Comportament antic

Les signatures de Generation kWh creades amb dades ja existents a Signaturit generaven documents de signatura sense `report_id`.

Quan el procés de Signaturit s'actualitzava o descarregava el document signat, `giscedata_signatura_documents_signaturit` intentava accedir a `doc['report_id'][0]` i fallava perquè el camp era buit.

## Comportament nou

S'afegeix un report placeholder per a documents signats de Generation kWh, associat al model `generationkwh.investment`.

El flux de creació de signatures amb dades de Signaturit informa aquest `report_id` resolent-lo via `ir.model.data`.

També s'afegeix una migració que:

- carrega el nou XML de dades
- localitza el nou report
- informa `report_id` als documents de signatura existents amb `model LIKE 'generationkwh.investment,%'` i `report_id IS NULL`

S'afegeix un test de regressió per comprovar que el document de signatura creat té el `report_id` esperat.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [x] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in the Signaturit update/download flow for Generation kWh investments by ensuring `report_id` is always populated on the created `giscedata.signatura.documents` record. A placeholder `ir.actions.report.xml` record is added to `som_generationkwh_data.xml`, wired in at creation time via `ir.model.data`, and a migration backfills existing NULL `report_id` rows.

- **`investment_strategy.py`**: `attach_signature` now resolves the new placeholder report via `IrModelData.get_object_reference` and passes its id as `report_id` when creating the signature document record.
- **`som_generationkwh_data.xml`**: Adds a webkit-typed `ir.actions.report.xml` record (`report_generationkwh_signaturit_doc`) bound to the `generationkwh.investment` model; it serves as a placeholder so the downstream `document.report_id.id` access no longer crashes.
- **Migration `post-0002`**: Loads the new XML data, asserts the record exists, and bulk-updates all existing Generation kWh signature documents that still have `report_id IS NULL`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it closes a real crash in the Signaturit update flow and the migration correctly backfills existing rows.

The fix is well-scoped and the migration is properly guarded. The only concern is the placeholder webkit report record whose `report_name` has no backing template — if `generate_report` is ever triggered on these documents the service lookup will raise a `KeyError`. The current `start_sync` guard makes this safe today, but the assumption is implicit and not documented in the XML.

som_generationkwh/som_generationkwh_data.xml — the placeholder report record warrants a brief inline comment explaining why no real template is needed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_generationkwh/investment_strategy.py | Adds `IrModelData.get_object_reference` call to resolve the placeholder report and sets `report_id` on the created signature document; straightforward and correct. |
| som_generationkwh/migrations/5.0.25.5.0/post-0002_FIX_generationkwh_signaturit_report_id.py | Migration loads new XML data, asserts the report record exists, and backfills NULL report_id rows with a targeted LIKE filter; logic is sound and uses parameterized queries correctly. |
| som_generationkwh/som_generationkwh_data.xml | Adds placeholder `ir.actions.report.xml` record for Generation kWh Signaturit docs; report_name points to a non-existent webkit template which is intentional but undocumented. |
| som_generationkwh/tests/investment_tests.py | Adds a regression assertion verifying that the created signature document has the expected `report_id`; test setup and assertions are correct. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant attach_signature
    participant IrModelData
    participant SignaturaProcess
    participant UpdateThread
    participant trg_process_attachment_callback

    Client->>attach_signature: attach_signature(investment_id, signaturit_data)
    attach_signature->>IrModelData: get_object_reference('report_generationkwh_signaturit_doc')
    IrModelData-->>attach_signature: report_id
    attach_signature->>SignaturaProcess: create(values incl. report_id)
    SignaturaProcess-->>attach_signature: process_id
    attach_signature->>UpdateThread: start (after 20s delay)
    Note over UpdateThread: _wait_and_update_signature_threaded
    UpdateThread->>SignaturaProcess: update([process_id])
    SignaturaProcess->>trg_process_attachment_callback: "doc.status == 'completed'"
    Note over trg_process_attachment_callback: document.report_id.id no longer NULL
    trg_process_attachment_callback->>SignaturaProcess: default_attach_document(..., report_id.id)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 (generationkwh) Corregir report\_id de..."](https://github.com/som-energia/openerp_som_addons/commit/907acd26fca3e971bf5623396d50602ddc272760) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35630575)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->