### PR TITLE
👷 fix false-positive file collection in Python 3 lint workflow

### DIFF
--- a/.github/workflows/python3-compat-lint.yml
+++ b/.github/workflows/python3-compat-lint.yml
@@ -28,11 +28,11 @@ jobs:
         id: python-files
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           if [ "$EVENT_NAME" = "pull_request" ]; then
+            MERGE_BASE=$(git merge-base origin/main HEAD)
             git diff -z --name-only --diff-filter=ACMRT \
-              "$BASE_SHA" HEAD -- "*.py" > python-files.txt
+              "$MERGE_BASE" HEAD -- "*.py" > python-files.txt
           else
             git ls-files -z "*.py" > python-files.txt
           fi


### PR DESCRIPTION
## Objectiu

Fix the "Collect Python files" step to use `git merge-base` instead of `github.event.pull_request.base.sha`.

## Comportament antic

The workflow used `github.event.pull_request.base.sha` (current tip of main) as the diff base. When main advances between the PR creation and the workflow run, this can include files from other PRs that aren't part of the current change.

## Comportament nou

The workflow now computes the actual merge base using `git merge-base origin/main HEAD`. This ensures only files truly changed by the PR are linted.

## Comprovacions

- [ ] Verify workflow passes on this PR
- [ ] Verify no false-positive files are collected

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a false-positive file collection issue in the Python 3 compatibility lint workflow. By computing the actual merge base (`git merge-base origin/main HEAD`) instead of relying on `github.event.pull_request.base.sha`, the diff is anchored to the true divergence point of the PR branch regardless of how far `main` has advanced since the PR was opened.

- **Root cause addressed**: `github.event.pull_request.base.sha` reflects the base branch tip at PR creation/sync time; if `main` advances before the workflow runs, the diff window widens and picks up unrelated files.
- **Fix**: One-liner shell change that stores `MERGE_BASE` and passes it to `git diff`; the existing `fetch-depth: 0` already ensures full history is available so `git merge-base` will always resolve correctly.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-liner that replaces a static SHA variable with a dynamically computed merge base, and the existing fetch-depth: 0 guarantees the full git history needed for git merge-base to resolve correctly.

The only modified file is the CI workflow itself. The fix correctly uses git merge-base origin/main HEAD to find the true divergence point, which is the standard approach for PR-scoped diffs in GitHub Actions. All prerequisites (full history via fetch-depth: 0, origin/main being fetched) are already in place, and the surrounding logic is untouched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/python3-compat-lint.yml | Replaces github.event.pull_request.base.sha with git merge-base origin/main HEAD in the file-collection step; requires fetch-depth: 0 which is already present. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Git as git (runner)
    participant Pylint as pylint (Docker)

    GH->>Git: "actions/checkout@v4 (fetch-depth: 0)"
    Note over Git: Full history + origin/main available

    alt pull_request event (before fix)
        GH->>Git: "git diff BASE_SHA HEAD -- *.py"
        Note over Git: BASE_SHA = base branch tip at PR open/sync
    else pull_request event (after fix)
        Git->>Git: git merge-base origin/main HEAD → MERGE_BASE
        GH->>Git: "git diff MERGE_BASE HEAD -- *.py"
        Note over Git: MERGE_BASE = true divergence point
    else workflow_dispatch
        GH->>Git: "git ls-files *.py"
    end

    Git-->>GH: python-files.txt

    alt "has_files == true"
        GH->>Pylint: "xargs -0 pylint --py3k < python-files.txt"
        Pylint-->>GH: lint results
    else no files
        GH->>GH: skip lint step
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["👷 fix false-positive file collection us..."](https://github.com/som-energia/openerp_som_addons/commit/f0d06b8cb667e1a04494be34193cddefd0456efa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35798183)</sub>

<!-- /greptile_comment -->