### PR TITLE
Evitar passar tests de carpetes que no són mòduls

### DIFF
--- a/.github/workflows/all_modules_test.yml
+++ b/.github/workflows/all_modules_test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|docs' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|^docs|^openspec|^runtime-docker|^webclient-docker' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   test-modules:
     name: test-modules

--- a/.github/workflows/all_modules_test_py3.yml
+++ b/.github/workflows/all_modules_test_py3.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|docs' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|^docs|^openspec|^runtime-docker|^webclient-docker' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   test-modules:
     name: test-modules

--- a/.github/workflows/all_modules_test_serp01.yml
+++ b/.github/workflows/all_modules_test_serp01.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|docs' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|^docs|^openspec|^runtime-docker|^webclient-docker' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   test-modules:
     name: test-modules

--- a/.github/workflows/som_modules_tests_developer.yml
+++ b/.github/workflows/som_modules_tests_developer.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|docs' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(ls -d */ | sed 's|[/]||g' | egrep -v '^scripts|^docs|^openspec|^runtime-docker|^webclient-docker' | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   test-modules:
     name: test-modules


### PR DESCRIPTION
## Objectiu
Hi ha noves carpetes que no són mòduls a testejar i s'ha d'evitar passar tests d'aquestes carpetes per a que no doni error.

## Targeta on es demana o Incidència
NS/NC

## Comportament antic
Els GA que passen els tests de tots els repos, estaven en vermell.

## Comportament nou
Els GA estaran en verd (o en vermell els mòduls que realment no passen tests.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates four GitHub Actions workflow files to exclude non-module directories (`openspec`, `runtime-docker`, `webclient-docker`) from the dynamic test matrix, preventing CI failures caused by attempting to run OpenERP module tests against directories that are not modules. It also fixes an existing inconsistency by anchoring the `docs` exclusion with `^`, which previously could have matched any directory whose name contained "docs".

- Three new top-level directories (`openspec`, `webclient-docker`, `runtime-docker`) are excluded from the test matrix across all four workflow variants using properly anchored `^` patterns.
- The pre-existing `docs` exclusion gains a `^` anchor, aligning it with the `scripts` pattern already in place.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only narrows the CI test matrix by excluding directories that are confirmed non-modules in the repo.

The four workflow files receive an identical, mechanical update. The excluded directories (openspec, runtime-docker, webclient-docker) were verified to contain Docker/config artefacts and no OpenERP module manifest. All new patterns use ^ anchors, and the long-standing unanchored docs pattern is fixed in the same commit.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/all_modules_test.yml | Adds ^openspec, ^runtime-docker, and ^webclient-docker to the egrep exclusion list; also anchors docs with ^ for consistency. |
| .github/workflows/all_modules_test_py3.yml | Same exclusion pattern update as all_modules_test.yml — mirrors the change for the Python 3 variant. |
| .github/workflows/all_modules_test_serp01.yml | Same exclusion pattern update applied consistently for the serp01 variant. |
| .github/workflows/som_modules_tests_developer.yml | Same exclusion pattern update applied consistently for the developer workflow variant. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[list-modules job
ls -d */] --> B[sed: strip trailing /]
    B --> C{egrep -v exclusions}
    C -->|excluded| D[scripts
docs
openspec
runtime-docker
webclient-docker]
    C -->|included| E[OpenERP module directories
e.g. som_polissa, som_atc ...]
    E --> F[test-modules matrix job
reusable_workflow.yml]
    F --> G[Run module tests]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update matrix filtering in all\_modules\_t..."](https://github.com/som-energia/openerp_som_addons/commit/92b865b9aae74ee69559d15acbaf4d8d35251a82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36193245)</sub>

<!-- /greptile_comment -->