### PR TITLE
🎡[Canvi de Tarifes] DEMO de com funcionarien els banners en un mail de canvi de tarifes

### DIFF
--- a/som_polissa_condicions_generals/__terp__.py
+++ b/som_polissa_condicions_generals/__terp__.py
@@ -29,6 +29,7 @@
         "report/giscedata_polissa_condicions_generals_report.xml",
         "report/giscedata_polissa_condicions_generals_m101_report.xml",
         "report/giscedata_polissa_condicions_generals_ignore_modcon_report.xml",
+        "report/report_mailcanvipreus_report.xml",
         "security/ir.model.access.csv",
     ],
     "active": False,

--- a/som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0002_demo_canvi_preus_migrate_fields_data.py
+++ b/som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0002_demo_canvi_preus_migrate_fields_data.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'report/report_mailcanvipreus_report.xml',
+    ]
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_polissa_condicions_generals', data_file,
+            idref=None, mode='update'
+        )
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0002_demo_canvi_preus_migrate_fields_data.py
+++ b/som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0002_demo_canvi_preus_migrate_fields_data.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import logging
 from oopgrade.oopgrade import load_data
 

--- a/som_polissa_condicions_generals/report/__init__.py
+++ b/som_polissa_condicions_generals/report/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from . import giscedata_polissa_comer_somenergia
+from . import report_mailcanvipreus

--- a/som_polissa_condicions_generals/report/report_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report/report_mailcanvipreus.py
@@ -28,17 +28,17 @@ class MailCanviPreusReport(report_int):
             "canviPreusBackend"
         )[1]
 
+        addons_lookup = TemplateLookup(
+            directories=[config['addons_path']], input_encoding='utf-8'
+        )
+        template = template_o.browse(cursor, uid, template_id, context=context)
+        message = template.def_body_html
+        templ = MakoTemplate(message, input_encoding='utf-8', lookup=addons_lookup)
+
         result = []
 
         for pol_id in ids:
             pol_br = pol_o.browse(cursor, uid, pol_id, context=context)
-
-            addons_lookup = TemplateLookup(
-                directories=[config['addons_path']], input_encoding='utf-8'
-            )
-            template = template_o.browse(cursor, uid, template_id, context=context)
-            message = template.def_body_html
-            templ = MakoTemplate(message, input_encoding='utf-8', lookup=addons_lookup)
 
             values = {
                 'pool': pool,

--- a/som_polissa_condicions_generals/report/report_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report/report_mailcanvipreus.py
@@ -84,8 +84,6 @@ class MailCanviPreusReport(report_int):
                 ]
                 generate_command = ' '.join(command)
                 subprocess.call(generate_command, shell=True)
-            except Exception:
-                raise
             finally:
                 os.remove(html_file_path)
 

--- a/som_polissa_condicions_generals/report/report_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report/report_mailcanvipreus.py
@@ -21,12 +21,14 @@ class MailCanviPreusReport(report_int):
         pol_o = pool.get("giscedata.polissa")
         template_o = pool.get("poweremail.templates")
 
-        ir_model_data = self.pool.get("ir.model.data")
+        ir_model_data = pool.get("ir.model.data")
         template_id = ir_model_data.get_object_reference(
             cursor, uid,
             "som_polissa_condicions_generals",
             "canviPreusBackend"
         )[1]
+
+        result = []
 
         for pol_id in ids:
             pol_br = pol_o.browse(cursor, uid, pol_id, context=context)
@@ -56,9 +58,7 @@ class MailCanviPreusReport(report_int):
 
             puppeteer_script_path = 'get_pdf'
 
-            node_bin_path = os.environ.get('NODE_BIN_PATH', 'node')
-            if not node_bin_path:
-                node_bin_path = 'node'
+            node_bin_path = os.environ.get('NODE_BIN_PATH') or 'node'
 
             node_modules_path = os.environ.get('NODE_PATH', False)
             if node_modules_path:
@@ -90,9 +90,11 @@ class MailCanviPreusReport(report_int):
                 os.remove(html_file_path)
 
             with open(pdf_file_path, "rb") as pdf_file:
-                result = base64.b64encode(pdf_file.read())
+                result.append(base64.b64encode(pdf_file.read()))
+            if os.path.exists(pdf_file_path):
+                os.remove(pdf_file_path)
 
-            return result, 'pdf'
+        return result, 'pdf'
 
 
 MailCanviPreusReport('report.report_mailcanvipreus')

--- a/som_polissa_condicions_generals/report/report_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report/report_mailcanvipreus.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import json
 import base64

--- a/som_polissa_condicions_generals/report/report_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report/report_mailcanvipreus.py
@@ -1,0 +1,98 @@
+import os
+import json
+import base64
+import pooler
+import subprocess
+from report.interface import report_int
+
+from mako.template import Template as MakoTemplate
+from mako.lookup import TemplateLookup
+from tools import config
+from report_backend.report_parser import ReportParser
+
+
+class MailCanviPreusReport(report_int):
+
+    def create(self, cursor, uid, ids, datas, context=None):
+        if context is None:
+            context = {}
+
+        pool = pooler.get_pool(cursor.dbname)
+        pol_o = pool.get("giscedata.polissa")
+        template_o = pool.get("poweremail.templates")
+
+        ir_model_data = self.pool.get("ir.model.data")
+        template_id = ir_model_data.get_object_reference(
+            cursor, uid,
+            "som_polissa_condicions_generals",
+            "canviPreusBackend"
+        )[1]
+
+        for pol_id in ids:
+            pol_br = pol_o.browse(cursor, uid, pol_id, context=context)
+
+            addons_lookup = TemplateLookup(
+                directories=[config['addons_path']], input_encoding='utf-8'
+            )
+            template = template_o.browse(cursor, uid, template_id, context=context)
+            message = template.def_body_html
+            templ = MakoTemplate(message, input_encoding='utf-8', lookup=addons_lookup)
+
+            values = {
+                'pool': pool,
+                'cursor': cursor,
+                'uid': uid,
+                'object': pol_br,
+                'peobject': pol_br,
+                'env': {},
+                'format_exceptions': True,
+                'template': template,
+                'lang': context.get('lang'),
+            }
+            reply = templ.render_unicode(**values)
+
+            pdf_file_path = ReportParser.get_temporal_file_path('pdf')
+            html_file_path = ReportParser.write_temporal_file(reply, 'html')
+
+            puppeteer_script_path = 'get_pdf'
+
+            node_bin_path = os.environ.get('NODE_BIN_PATH', 'node')
+            if not node_bin_path:
+                node_bin_path = 'node'
+
+            node_modules_path = os.environ.get('NODE_PATH', False)
+            if node_modules_path:
+                node_bin_path = 'NODE_PATH={} {}'.format(
+                    node_modules_path, node_bin_path
+                )
+
+            try:
+                params = {
+                    'path': {
+                        'html': html_file_path,
+                        'pdf': pdf_file_path
+                    },
+                    'options': {
+                        'landscape': False,
+                    }
+                }
+                command = [
+                    node_bin_path,
+                    '{}/report_puppeteer/js/{}.js'.format(
+                        config['addons_path'], puppeteer_script_path),
+                    "'{}'".format(json.dumps(params))
+                ]
+                generate_command = ' '.join(command)
+                subprocess.call(generate_command, shell=True)
+            except Exception:
+                raise
+            finally:
+                os.remove(html_file_path)
+
+            with open(pdf_file_path, "rb") as pdf_file:
+                result = base64.b64encode(pdf_file.read())
+
+            return result, 'pdf'
+
+
+MailCanviPreusReport('report.report_mailcanvipreus')

--- a/som_polissa_condicions_generals/report/report_mailcanvipreus_report.xml
+++ b/som_polissa_condicions_generals/report/report_mailcanvipreus_report.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="action_report_mailcanvipreus" model="ir.actions.report.xml">
+            <field name="report_name">report_mailcanvipreus</field>
+            <field name="name">Mail Canvi Preus</field>
+            <field name="model">giscedata.polissa</field>
+            <field name="report_webkit" eval=""/>
+            <field name="report_type">pdf</field>
+            <field name="header" eval="0"/>
+            <field name="auto" eval="0"/>
+        </record>
+        <record id="value_report_mailcanvipreus" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Mail Canvi Preus</field>
+            <field name="key2">client_print_multi</field>
+            <field name="model">giscedata.polissa</field>
+            <field name="value" eval="'ir.actions.report.xml,'+str(ref('action_report_mailcanvipreus'))"/>
+        </record>
+    </data>
+</openerp>

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -21,6 +21,18 @@ class ReportBackendMailcanvipreusEnviamentMassiu(ReportBackend):
 
         return data
 
+    def get_lang(self, cursor, uid, record_id, context=None):
+        if context is None:
+            context = {}
+
+        env_o = self.pool.get("som.enviament.massiu")
+        env_br = env_o.browse(cursor, uid, record_id, context=context)
+
+        return env_br.polissa_id.titular.lang
+
+
+ReportBackendMailcanvipreusEnviamentMassiu()
+
 
 class ReportBackendMailcanvipreusPDF(ReportBackend):
     _source_model = "giscedata.polissa"

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -8,7 +8,7 @@ from datetime import date, timedelta
 
 
 class ReportBackendMailcanvipreusEnviamentMassiu(ReportBackend):
-    _source_model = "giscedata.polissa"
+    _source_model = "som.enviament.massiu"
     _name = "report.backend.mailcanvipreus"
 
     def get_data(self, cursor, uid, env, context=None):
@@ -17,7 +17,7 @@ class ReportBackendMailcanvipreusEnviamentMassiu(ReportBackend):
 
         backend_o = self.pool.get("report.backend.mailcanvipreus.pdf")
 
-        data = backend_o.get_data(cursor, uid, env.polissa_id, context=context)
+        data = backend_o.get_data(cursor, uid, env.polissa_id.id, context=context)
 
         return data
 

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -7,9 +7,24 @@ from som_indexada.utils import calculate_new_indexed_prices
 from datetime import date, timedelta
 
 
-class ReportBackendMailcanvipreus(ReportBackend):
-    _source_model = "som.enviament.massiu"
+class ReportBackendMailcanvipreusEnviamentMassiu(ReportBackend):
+    _source_model = "giscedata.polissa"
     _name = "report.backend.mailcanvipreus"
+
+    def get_data(self, cursor, uid, env, context=None):
+        if context is None:
+            context = {}
+
+        backend_o = self.pool.get("report.backend.mailcanvipreus.pdf")
+
+        data = backend_o.get_data(cursor, uid, env.polissa_id, context=context)
+
+        return data
+
+
+class ReportBackendMailcanvipreusPDF(ReportBackend):
+    _source_model = "giscedata.polissa"
+    _name = "report.backend.mailcanvipreus.pdf"
 
     _decimals = {
         ("preus_nous_generation", "P1"): 3,
@@ -100,16 +115,16 @@ class ReportBackendMailcanvipreus(ReportBackend):
     }
 
     @report_browsify
-    def get_data(self, cursor, uid, env, context=None):
+    def get_data(self, cursor, uid, pol_id, context=None):
         imd_obj = self.pool.get('ir.model.data')
         pol_obj = self.pool.get("giscedata.polissa")
         if context is None:
             context = {}
 
-        context['iva10'] = env.polissa_id.potencia <= 10
+        context['iva10'] = pol_id.potencia <= 10
 
         self.simplified_taxes = pol_obj.get_simplified_taxes(
-            cursor, uid, env.polissa_id.id, context=context)
+            cursor, uid, pol_id.id, context=context)
 
         impostos_str = self.get_iva_text()
 
@@ -125,34 +140,34 @@ class ReportBackendMailcanvipreus(ReportBackend):
         context_preus_nous["date"] = (date.today() + timedelta(days=60)).strftime("%Y-%m-%d")
 
         preus_antics = self.get_preus(
-            cursor, uid, env.polissa_id, with_taxes=False, context=context_preus_antics
+            cursor, uid, pol_id, with_taxes=False, context=context_preus_antics
         )
         preus_nous = self.get_preus(
-            cursor, uid, env.polissa_id, with_taxes=False, context=context_preus_nous
+            cursor, uid, pol_id, with_taxes=False, context=context_preus_nous
         )
         preus_antics_imp = self.get_preus(
-            cursor, uid, env.polissa_id, with_taxes=True, context=context_preus_antics
+            cursor, uid, pol_id, with_taxes=True, context=context_preus_antics
         )
         preus_nous_imp = self.get_preus(
-            cursor, uid, env.polissa_id, with_taxes=True, context=context_preus_nous
+            cursor, uid, pol_id, with_taxes=True, context=context_preus_nous
         )
 
-        gurb = self.has_gurb(cursor, uid, env.polissa_id, context)
+        gurb = self.has_gurb(cursor, uid, pol_id, context)
 
-        canaries = self.esCanaries(cursor, uid, env, context=context)
-        balears = self.esBalears(cursor, uid, env, context=context)
+        canaries = self.esCanaries(cursor, uid, pol_id, context=context)
+        balears = self.esBalears(cursor, uid, pol_id, context=context)
 
         data = {
-            "codi_polissa": env.polissa_id.name,
+            "codi_polissa": pol_id.name,
             "canaries": canaries,
             "balears": balears,
-            "tarifa_acces": env.polissa_id.tarifa.name,
-            "mode_facturacio": env.polissa_id.mode_facturacio,
-            "text_legal": self.get_text_legal(cursor, uid, env, context=context),
-            "lang": env.polissa_id.titular.lang,
-            "nom_titular": self.getPartnerName(cursor, uid, env),
-            "iva_reduit": env.polissa_id.potencia <= 10 and not canaries,
-            "te_gkwh": env.polissa_id.te_assignacio_gkwh,
+            "tarifa_acces": pol_id.tarifa.name,
+            "mode_facturacio": pol_id.mode_facturacio,
+            "text_legal": self.get_text_legal(cursor, uid, pol_id, context=context),
+            "lang": pol_id.titular.lang,
+            "nom_titular": self.getPartnerName(cursor, uid, pol_id),
+            "iva_reduit": pol_id.potencia <= 10 and not canaries,
+            "te_gkwh": pol_id.te_assignacio_gkwh,
             "preus_antics": preus_antics,
             "preus_nous": preus_nous,
             "preus_antics_imp": preus_antics_imp,
@@ -161,29 +176,29 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
             "impostos_str": impostos_str,
             "modcon": (
-                env.polissa_id.modcontractuals_ids[0].state == "pendent"
-                and env.polissa_id.mode_facturacio
-                != env.polissa_id.modcontractuals_ids[0].mode_facturacio
-                and env.polissa_id.modcontractuals_ids[0].mode_facturacio
+                pol_id.modcontractuals_ids[0].state == "pendent"
+                and pol_id.mode_facturacio
+                != pol_id.modcontractuals_ids[0].mode_facturacio
+                and pol_id.modcontractuals_ids[0].mode_facturacio
             ),
             'autoconsum': {
-                'es_autoconsum': env.polissa_id.es_autoconsum,
-                'compensacio': env.polissa_id.tipus_subseccio in ['21']
+                'es_autoconsum': pol_id.es_autoconsum,
+                'compensacio': pol_id.tipus_subseccio in ['21']
             },
         }
 
         if data['autoconsum']['compensacio'] and data['mode_facturacio'] == 'atr':
             preu_auto_antic = get_atr_price(
-                cursor, uid, env.polissa_id, 'P1', 'ac', context_preus_antics, with_taxes=False)[0]
+                cursor, uid, pol_id, 'P1', 'ac', context_preus_antics, with_taxes=False)[0]
 
             preu_auto_nou = get_atr_price(
-                cursor, uid, env.polissa_id, 'P1', 'ac', context_preus_nous, with_taxes=False)[0]
+                cursor, uid, pol_id, 'P1', 'ac', context_preus_nous, with_taxes=False)[0]
 
             preu_auto_antic_imp = get_atr_price(
-                cursor, uid, env.polissa_id, 'P1', 'ac', context_preus_antics, with_taxes=True)[0]
+                cursor, uid, pol_id, 'P1', 'ac', context_preus_antics, with_taxes=True)[0]
 
             preu_auto_nou_imp = get_atr_price(
-                cursor, uid, env.polissa_id, 'P1', 'ac', context_preus_nous, with_taxes=True)[0]
+                cursor, uid, pol_id, 'P1', 'ac', context_preus_nous, with_taxes=True)[0]
             data['preu_auto_antic'] = preu_auto_antic
             data['preu_auto_nou'] = preu_auto_nou
             data['preu_auto_antic_imp'] = preu_auto_antic_imp
@@ -191,31 +206,31 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
         if data["te_gkwh"]:
             data["preus_antics_generation"] = self.get_preus_gkwh(
-                cursor, uid, env.polissa_id, with_taxes=False, context=context_preus_antics
+                cursor, uid, pol_id, with_taxes=False, context=context_preus_antics
             )
             data["preus_antics_generation_imp"] = self.get_preus_gkwh(
-                cursor, uid, env.polissa_id, with_taxes=True, context=context_preus_antics
+                cursor, uid, pol_id, with_taxes=True, context=context_preus_antics
             )
             data["preus_nous_generation"] = self.get_preus_gkwh(
-                cursor, uid, env.polissa_id, with_taxes=False, context=context_preus_nous
+                cursor, uid, pol_id, with_taxes=False, context=context_preus_nous
             )
             data["preus_nous_generation_imp"] = self.get_preus_gkwh(
-                cursor, uid, env.polissa_id, with_taxes=True, context=context_preus_nous
+                cursor, uid, pol_id, with_taxes=True, context=context_preus_nous
             )
-            data.update(self.get_gkwh_estimation(cursor, uid, env, context=context_preus_nous))
+            data.update(self.get_gkwh_estimation(cursor, uid, pol_id, context=context_preus_nous))
 
-        data.update(self.getEstimacioData(cursor, uid, env, context=context_preus_nous))
-        data.update(self.getTarifaCorreu(cursor, uid, env, context))
+        data.update(self.getEstimacioData(cursor, uid, pol_id, context=context_preus_nous))
+        data.update(self.getTarifaCorreu(cursor, uid, pol_id, context))
         return data
 
     def get_lang(self, cursor, uid, record_id, context=None):
         if context is None:
             context = {}
 
-        env_o = self.pool.get("som.enviament.massiu")
-        env_br = env_o.browse(cursor, uid, record_id, context=context)
+        pol_o = self.pool.get("giscedata.polissa")
+        pol_br = pol_o.browse(cursor, uid, record_id, context=context)
 
-        return env_br.polissa_id.titular.lang
+        return pol_br.titular.lang
 
     def getConsumEstimatPotencia(self, potencia):  # noqa: C901
         res = 0
@@ -422,18 +437,18 @@ class ReportBackendMailcanvipreus(ReportBackend):
         consums = {k: consum_anual * coeficients[tarifa][k] for k in coeficients[tarifa].keys()}
         return consums
 
-    def getConanyDict(self, cursor, uid, env):
+    def getConanyDict(self, cursor, uid, pol_id):
         conany = {
-            "P1": env.polissa_id.cups.conany_kwh_p1,
-            "P2": env.polissa_id.cups.conany_kwh_p2,
-            "P3": env.polissa_id.cups.conany_kwh_p3,
+            "P1": pol_id.cups.conany_kwh_p1,
+            "P2": pol_id.cups.conany_kwh_p2,
+            "P3": pol_id.cups.conany_kwh_p3,
         }
-        if env.polissa_id.tarifa_codi != "2.0TD":
+        if pol_id.tarifa_codi != "2.0TD":
             conany.update(
                 {
-                    "P4": env.polissa_id.cups.conany_kwh_p4,
-                    "P5": env.polissa_id.cups.conany_kwh_p5,
-                    "P6": env.polissa_id.cups.conany_kwh_p6,
+                    "P4": pol_id.cups.conany_kwh_p4,
+                    "P5": pol_id.cups.conany_kwh_p5,
+                    "P6": pol_id.cups.conany_kwh_p6,
                 }
             )
         return conany
@@ -455,34 +470,34 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
         return gurb_cups_id
 
-    def getEstimacioData(self, cursor, uid, env, context=False):
-        potencies = self.getPotenciesPolissa(cursor, uid, env.polissa_id)
+    def getEstimacioData(self, cursor, uid, pol_id, context=False):
+        potencies = self.getPotenciesPolissa(cursor, uid, pol_id)
 
-        tarifa = env.polissa_id.tarifa.name
+        tarifa = pol_id.tarifa.name
         consums = ""
         origen = ""
-        potencia = env.polissa_id.potencia
-        if "index" in env.polissa_id.mode_facturacio:
+        potencia = pol_id.potencia
+        if "index" in pol_id.mode_facturacio:
             origen = "indexada"
-            consums = self.getConanyDict(cursor, uid, env)
-            consum_total = env.polissa_id.cups.conany_kwh
+            consums = self.getConanyDict(cursor, uid, pol_id)
+            consum_total = pol_id.cups.conany_kwh
         elif any(
             [
-                env.polissa_id.cups.conany_kwh_p1,
-                env.polissa_id.cups.conany_kwh_p2,
-                env.polissa_id.cups.conany_kwh_p3,
+                pol_id.cups.conany_kwh_p1,
+                pol_id.cups.conany_kwh_p2,
+                pol_id.cups.conany_kwh_p3,
             ]
         ):
-            consums = self.getConanyDict(cursor, uid, env)
-            consum_total = env.polissa_id.cups.conany_kwh
-            origen = env.polissa_id.cups.conany_origen
+            consums = self.getConanyDict(cursor, uid, pol_id)
+            consum_total = pol_id.cups.conany_kwh
+            origen = pol_id.cups.conany_origen
         else:
-            consum_total = self.getConsumEstimatPotencia(env.polissa_id.potencia)
+            consum_total = self.getConsumEstimatPotencia(pol_id.potencia)
             consums = self.aplicarCoeficients(consum_total, tarifa)
             origen = "estadistic"
 
         if origen == "indexada":
-            dades_index = calculate_new_indexed_prices(cursor, uid, env.polissa_id, context=context)
+            dades_index = calculate_new_indexed_prices(cursor, uid, pol_id, context=context)
             preu_vell = dades_index["import_total_anual_antiga"]
             preu_nou = dades_index["import_total_anual_nova"]
             preu_vell_imp = dades_index["import_total_anual_antiga_amb_impost"]
@@ -491,7 +506,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
             preu_vell = self.calcularPreuTotal(
                 cursor,
                 uid,
-                env.polissa_id,
+                pol_id,
                 consums,
                 potencies,
                 afegir_servei_ajust=False,
@@ -502,12 +517,12 @@ class ReportBackendMailcanvipreus(ReportBackend):
             preu_nou = self.calcularPreuTotal(
                 cursor,
                 uid,
-                env.polissa_id,
+                pol_id,
                 consums,
                 potencies,
                 afegir_servei_ajust=True,
                 bo_social_separat=True,
-                date=self.get_price_change_date(cursor, uid, env.polissa_id, context),
+                date=self.get_price_change_date(cursor, uid, pol_id, context),
                 context=context,
             )
 
@@ -524,11 +539,11 @@ class ReportBackendMailcanvipreus(ReportBackend):
             "potencia": potencia,
         }
 
-    def get_gkwh_estimation(self, cursor, uid, env, context=False):
+    def get_gkwh_estimation(self, cursor, uid, pol_id, context=False):
         pol_o = self.pool.get("giscedata.polissa")
 
         consums, origen = pol_o.generationkwh_anual_estimation(
-            cursor, uid, env.polissa_id.id, context=context)
+            cursor, uid, pol_id.id, context=context)
 
         if origen == 'no_data':
             consum_total = False
@@ -542,7 +557,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
             preu_vell = self.calcularPreuTotal(
                 cursor,
                 uid,
-                env.polissa_id,
+                pol_id,
                 consums,
                 {},
                 afegir_servei_ajust=False,
@@ -554,12 +569,12 @@ class ReportBackendMailcanvipreus(ReportBackend):
             preu_nou = self.calcularPreuTotal(
                 cursor,
                 uid,
-                env.polissa_id,
+                pol_id,
                 consums,
                 {},
                 afegir_servei_ajust=True,
                 bo_social_separat=False,
-                date=self.get_price_change_date(cursor, uid, env.polissa_id, context),
+                date=self.get_price_change_date(cursor, uid, pol_id, context),
                 is_gkwh=True,
                 context=context,
             )
@@ -590,15 +605,15 @@ class ReportBackendMailcanvipreus(ReportBackend):
                 return min(future_version_starts)
         return (date.today() + timedelta(days=60)).strftime("%Y-%m-%d")
 
-    def esCanaries(self, cursor, uid, env, context=False):
-        return env.polissa_id.cups.id_municipi.subsistema_id.code in [
+    def esCanaries(self, cursor, uid, pol_id, context=False):
+        return pol_id.cups.id_municipi.subsistema_id.code in [
             'TF', 'PA', 'LG', 'HI', 'GC', 'FL'
         ]
 
-    def esBalears(self, cursor, uid, env, context=False):
-        return env.polissa_id.cups.id_municipi.subsistema_id.code in ['MM', 'IF']
+    def esBalears(self, cursor, uid, pol_id, context=False):
+        return pol_id.cups.id_municipi.subsistema_id.code in ['MM', 'IF']
 
-    def getTarifaCorreu(self, cursor, uid, env, context=False):
+    def getTarifaCorreu(self, cursor, uid, pol_id, context=False):
         key_prefixes = ["Indexada", "Periodes"]
         tariffs = ["20TD", "30TD", "61TD", "30TDVE"]
         regions = ["Peninsula", "Canaries", "Balears"]
@@ -610,17 +625,17 @@ class ReportBackendMailcanvipreus(ReportBackend):
                     data["{}{}{}".format(prefix, tariff, region)] = False
         data.update({"igic": False, "indexada": False, "periodes": False})
 
-        mode_facturacio = env.polissa_id.mode_facturacio
-        tarifa = env.polissa_id.tarifa.name.replace(".", "")
+        mode_facturacio = pol_id.mode_facturacio
+        tarifa = pol_id.tarifa.name.replace(".", "")
 
         operation = "Indexada" if "index" in mode_facturacio else "Periodes"
         data[operation.lower()] = True
 
         for t in tariffs:
             if t in tarifa:
-                if self.esCanaries(cursor, uid, env):
+                if self.esCanaries(cursor, uid, pol_id):
                     region_key = "Canaries"
-                elif self.esBalears(cursor, uid, env):
+                elif self.esBalears(cursor, uid, pol_id):
                     region_key = "Balears"
                 else:
                     region_key = "Peninsula"
@@ -634,18 +649,18 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
         return data
 
-    def getPartnerName(self, cursor, uid, env):
+    def getPartnerName(self, cursor, uid, pol_id):
         try:
-            p_obj = env.pool.get("res.partner")
-            if not p_obj.vat_es_empresa(env._cr, env._uid, env.polissa_id.titular.vat):
-                nom_titular = " " + env.polissa_id.titular.name.split(",")[1].strip() + ","
+            p_obj = pol_id.pool.get("res.partner")
+            if not p_obj.vat_es_empresa(pol_id._cr, pol_id._uid, pol_id.titular.vat):
+                nom_titular = " " + pol_id.titular.name.split(",")[1].strip() + ","
             else:
                 nom_titular = ","
         except Exception:
             nom_titular = ","
         return nom_titular
 
-    def get_text_legal(self, cursor, uid, env, context=None):
+    def get_text_legal(self, cursor, uid, pol_id, context=None):
         def render(text_to_render, object_):
             templ = Template(text_to_render)
             return templ.render_unicode(object=object_, format_exceptions=True)
@@ -660,10 +675,10 @@ class ReportBackendMailcanvipreus(ReportBackend):
             cursor, uid, "som_poweremail_common_templates", "common_template_legal_footer"
         )[1]
         data = render(
-            t_obj.read(cursor, uid, [template_id], ["def_body_text"])[0]["def_body_text"], env
+            t_obj.read(cursor, uid, [template_id], ["def_body_text"])[0]["def_body_text"], pol_id
         )
 
         return data
 
 
-ReportBackendMailcanvipreus()
+ReportBackendMailcanvipreusPDF()

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -11,6 +11,7 @@ class ReportBackendMailcanvipreusEnviamentMassiu(ReportBackend):
     _source_model = "som.enviament.massiu"
     _name = "report.backend.mailcanvipreus"
 
+    @report_browsify
     def get_data(self, cursor, uid, env, context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
## Objectiu
🎡[Canvi de Tarifes] DEMO de com funcionarien els banners en un mail de canvi de tarifes

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/1364/activity

## Comportament antic
-

## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a demo showing how PDF banners would work in a "price change" email. It splits `ReportBackendMailcanvipreus` into two classes — one for `som.enviament.massiu` (preserving the original `_name`) and a new `ReportBackendMailcanvipreusPDF` for `giscedata.polissa` — and introduces a standalone `MailCanviPreusReport` that renders the `canviPreusBackend` email template directly to PDF via puppeteer.

- `report_backend_mailcanvipreus.py` is refactored so `ReportBackendMailcanvipreusEnviamentMassiu` delegates to `ReportBackendMailcanvipreusPDF`, replacing all `env.polissa_id.*` access with direct `pol_id.*` on the polissa browse record.
- A new `ir.actions.report.xml` record and matching `ir.values` binding are registered via `report/report_mailcanvipreus_report.xml`, added to both `update_xml` and a new oopgrade migration script.
- The `common_template_legal_footer` template used in `get_text_legal` is fully static HTML with no `object.*` Mako expressions, so changing the passed record model there is safe.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The backend refactoring is logically sound, but the new migration script is placed in a version directory already superseded by existing migrations, so it will not execute on any environment that has already passed that version checkpoint.

The report_backend_mailcanvipreus.py split is consistent and the common_template_legal_footer model change is safe (static HTML body). However, the new oopgrade migration is filed under 5.0.25.5.0 while 5.0.25.6 migrations already exist, meaning it will be silently skipped on upgraded instances.

som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0002_demo_canvi_preus_migrate_fields_data.py — should be moved to a version directory above 5.0.25.6.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa_condicions_generals/__terp__.py | Adds `report/report_mailcanvipreus_report.xml` to `update_xml`; straightforward and correct. |
| som_polissa_condicions_generals/migrations/5.0.25.5.0/post-0002_demo_canvi_preus_migrate_fields_data.py | Migration placed in `5.0.25.5.0`, which is below the already-existing `5.0.25.6` directory — will be skipped on any environment already past that version checkpoint. |
| som_polissa_condicions_generals/report/__init__.py | Adds import of the new `report_mailcanvipreus` module so `MailCanviPreusReport` is registered on startup. |
| som_polissa_condicions_generals/report/report_mailcanvipreus.py | New report class with issues flagged in prior review threads (shell=True injection, no subprocess exit-code check, template model mismatch). |
| som_polissa_condicions_generals/report/report_mailcanvipreus_report.xml | Registers the `ir.actions.report.xml` record and its `ir.values` binding for `giscedata.polissa`; XML structure is well-formed. |
| som_polissa_condicions_generals/report_backend_mailcanvipreus.py | Splits the original class into `ReportBackendMailcanvipreusEnviamentMassiu` and `ReportBackendMailcanvipreusPDF`; refactoring is consistent and the `common_template_legal_footer` model change is safe (static HTML body). |

</details>

<sub>Reviews (2): Last reviewed commit: ["🩹 (canviPreus) missing decorator"](https://github.com/som-energia/openerp_som_addons/commit/102ed141f1b01f5755f86c83a8b0ab6b8b85c8d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36224792)</sub>

<!-- /greptile_comment -->