### PR TITLE
Treure camps del modul som_facturacio_comer que ja estaran disponibles al ERP general a la versio v26.5

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot.py
@@ -220,17 +220,6 @@ class GiscedataFacturacioContracteLot(osv.osv):
             string="Col·lectiu",
             readonly=True,
         ),
-        "tarifaATR": fields.related(
-            "polissa_id", "tarifa", "name", type="char", string=_("Tarifa Accés"), readonly=True
-        ),
-        "llista_preu": fields.related(
-            "polissa_id",
-            "llista_preu",
-            "name",
-            type="char",
-            string=_("Tarifa Comercialitzadora"),
-            readonly=True,
-        ),
         "total_incidencies": fields.function(
             _ff_update_fields,
             multi="totals",

--- a/som_facturacio_comer/giscedata_facturacio_contracte_lot_view.xml
+++ b/som_facturacio_comer/giscedata_facturacio_contracte_lot_view.xml
@@ -11,8 +11,7 @@
                     <field name="polissa_distribuidora"/>
                     <field name="autoconsum" />
                     <field name="collectiu" />
-                    <field name="tarifaATR" />
-                    <field name="llista_preu" />
+                    <field name="pricelist_id" />
                     <field name="n_retrocedir_lot"/>
                 </field>
                 <field name="falten_dades" position="after">
@@ -29,8 +28,6 @@
                     <field name="polissa_distribuidora" select="1"/>
                     <field name="autoconsum" select="1"/>
                     <field name="collectiu" select="1"/>
-                    <field name="tarifaATR" select="1"/>
-                    <field name="llista_preu" select="1"/>
                     <field name="date_invoice" select="1"/>
                     <field name="consum_facturat" select="2"/>
                     <field name="total_incidencies" select="1"/>

--- a/som_facturacio_comer/migrations/5.0.26.5.0/post-0001_remove_columns_from_view.py
+++ b/som_facturacio_comer/migrations/5.0.26.5.0/post-0001_remove_columns_from_view.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("UPDATE views")
+    records = ['view_giscedata_facturacio_contracte_lot_som_tree', 'view_giscedata_facturacio_contracte_lot_som_form']
+    load_data_records(cursor, 'som_facturacio_comer', 'giscedata_crm_lead_validation_data.xml', records)
+    logger.info("Views updated succesfully")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_facturacio_comer/migrations/5.0.26.5.0/pre-0001_remove_migrated_fields.py
+++ b/som_facturacio_comer/migrations/5.0.26.5.0/pre-0001_remove_migrated_fields.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import logging
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Removing ir_model_data ")
+
+    fields = ['field_giscedata_facturacio_contracte_lot_tarifaATR',
+              'field_giscedata_facturacio_contracte_lot_llista_preu']
+    for field in fields:
+        sql = """SELECT id, res_id FROM ir_model_data WHERE name='{}'""".format(field)
+        cursor.execute(sql)
+        camp = cursor.fetchOne()
+        if camp:
+            sql = """DELETE FROM ir_model_data WHERE name = '{}' """.format(camp[0])
+            cursor.execute(sql)
+            sql = """DELETE FROM ir_model_fields WHERE id = {} """.format(camp[1])
+            cursor.execute(sql)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu
Treure els camps de `tarifaATR` i `llista_preu` del mòdul de som_facturacio_comer perquè a la versió v26.5.0 del ERP ja estaran disponibles a nivell general.

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
  script `pre-0001_remove_migrated_fields` de `som_facturacio_comer`
- [ ] Modifica traduccions
