### PR TITLE
Modificació degut a que la PR 27961 ha canviat les condicions de check de la F070

### DIFF
--- a/som_facturacio_comer/giscedata_facturacio_validation.py
+++ b/som_facturacio_comer/giscedata_facturacio_validation.py
@@ -291,9 +291,14 @@ class GiscedataFacturacioValidationValidator(osv.osv):
             self
         ).check_exceding_days(cursor, uid, fact, parameters)
 
-    def check_f070_condicions_especials(self, cursor, uid, fact, linia_saju, parameters):
-        """ To be customized """
-        res = super(GiscedataFacturacioValidationValidator, self).check_f070_condicions_especials(
+    def check_f070_ha_de_saltar(self, cursor, uid, fact, linia_saju, parameters):
+        """ Si True farà saltar error F070 si hi ha diferencia, si False, no farà saltar validació
+        Customitzat per a que en validar una corba amb consums anteriors a 1 de maig de 2026
+        Es validi contra la corba original i no la "cuinada". Si la diferència és menor o igual
+        a la tolerància establerta, fer que no salti la F070 ja que de base comprova contra la
+        corba "cuinada" utilitzada
+        """
+        res = super(GiscedataFacturacioValidationValidator, self).check_f070_ha_de_saltar(
             cursor, uid, fact, linia_saju, parameters
         )
         if res and fact.data_inici < '2026-05-01' <= fact.data_final:
@@ -310,7 +315,7 @@ class GiscedataFacturacioValidationValidator(osv.osv):
 
             tolerancia = parameters.get("tolerancia", 1)
             diferencia_facturada_saju = original_consum - fact.energia_kwh
-            if abs(diferencia_facturada_saju) > tolerancia:
+            if abs(diferencia_facturada_saju) <= tolerancia:
                 res = False
         return res
 

--- a/som_facturacio_comer/giscedata_facturacio_validation.py
+++ b/som_facturacio_comer/giscedata_facturacio_validation.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from osv import osv
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta


### PR DESCRIPTION
## Objectiu

Modificació degut a que la PR 27961 ha canviat les condicions de check de la F070

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adapts the F070 validation override to align with a base-class method rename and semantic change introduced in PR 27961. The custom override `check_f070_condicions_especials` is renamed to `check_f070_ha_de_saltar`, and the tolerance condition is inverted so that F070 is suppressed only when the difference between original and billed consumption is **within** tolerance (rather than outside it).

- **Method rename**: `check_f070_condicions_especials` → `check_f070_ha_de_saltar`, matching the updated base-class contract where `True` means "F070 should fire" and `False` means "suppress the validation".
- **Condition fix**: `abs(diferencia) > tolerancia → res = False` (old, backwards) becomes `abs(diferencia) <= tolerancia → res = False` (new, correct), ensuring F070 is only suppressed when the gap between original and cooked consumption is acceptably small for invoices spanning before 2026-05-01.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is small and logically coherent; the inverted condition now correctly reflects the docstring intent and the new base-class contract.

Both changes (rename + condition inversion) work together correctly: the new condition suppresses F070 when the difference is within tolerance and lets it fire when the difference exceeds tolerance, which matches the docstring and the described base-class redesign. No tests cover this method in the module, so regressions would only surface at runtime.

som_facturacio_comer/giscedata_facturacio_validation.py — the tolerance-comparison branch has no automated test coverage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_facturacio_comer/giscedata_facturacio_validation.py | Renames check_f070_condicions_especials to check_f070_ha_de_saltar and inverts the tolerance condition to correctly suppress F070 only when the difference is within acceptable limits |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check_f070_ha_de_saltar called] --> B[super call: check_f070_ha_de_saltar]
    B --> C{res is True?}
    C -- No --> Z[return res = False]
    C -- Yes --> D{data_inici < 2026-05-01 <= data_final?}
    D -- No --> Y[return res = True\nF070 triggers]
    D -- Yes --> E[Fetch original SSAA curves\nget_original_ssaa_curves=True]
    E --> F[Sum original_consum from curves]
    F --> G[diferencia = original_consum - fact.energia_kwh]
    G --> H{abs diff <= tolerancia\ndefault 1 kWh?}
    H -- Yes --> I[res = False\nF070 suppressed]
    H -- No --> J[res stays True\nF070 triggers]
    I --> Z2[return res]
    J --> Z2
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Modificació degut a que la PR 27961 ha c..."](https://github.com/som-energia/openerp_som_addons/commit/887a3b751011641b27b4a6d674016a6261dde5cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36681656)</sub>

<!-- /greptile_comment -->