### PR TITLE
🐛 Fix bug using res.partner id for res.partner.address

### DIFF
--- a/som_polissa_soci/models/res_partner_address.py
+++ b/som_polissa_soci/models/res_partner_address.py
@@ -234,10 +234,7 @@ class ResPartnerAddress(osv.osv):
         """Prepare the fields with the data of a member, to be sent to Mailchimp
         from res.partner id
         """
-        try:
-            partner_address_id = self.search(cursor, uid, [("partner_id", "=", partner_id)], limit=1)[0]  # noqa: E501
-        except IndexError:
-            raise osv.except_osv(_("Error"), _("Partner address not found. Partner ID: {}".format(partner_id)))  # noqa: E501
+        partner_address_id = self._get_partner_address_id(cursor, uid, partner_id, context=context)
         return self.fill_merge_fields_clients(cursor, uid, partner_address_id, context=context)
 
     def fill_merge_fields_clients(self, cursor, uid, id, context=None):
@@ -288,11 +285,16 @@ class ResPartnerAddress(osv.osv):
         """Prepare the fields with the data of a member, to be sent to Mailchimp
         from res.partner id
         """
-        try:
-            partner_address_id = self.search(cursor, uid, [("partner_id", "=", partner_id)], limit=1)[0]  # noqa: E501
-        except IndexError:
-            raise osv.except_osv(_("Error"), _("Partner address not found. Partner ID: {}".format(partner_id)))  # noqa: E501
+        partner_address_id = self._get_partner_address_id(cursor, uid, partner_id, context=context)
         return self.fill_merge_fields_soci(cursor, uid, partner_address_id, context=context)
+
+    def _get_partner_address_id(self, cursor, uid, partner_id, context=None):
+        try:
+            return self.search(cursor, uid, [("partner_id", "=", partner_id)], limit=1)[0]
+        except IndexError:
+            raise osv.except_osv(
+                _("Error"), _("Partner address not found. Partner ID: {}".format(partner_id))
+            )
 
     def fill_merge_fields_soci(self, cursor, uid, id, context=None):
         """
@@ -583,8 +585,9 @@ class ResPartnerAddress(osv.osv):
         list_id = self.get_mailchimp_list_id(list_name, MAILCHIMP_CLIENT)
 
         for _id in partner_ids:
+            address_id = self._get_partner_address_id(cursor, uid, _id, context=context)
             self.archieve_mail_in_list_sync(
-                cursor, uid, _id, list_id, MAILCHIMP_CLIENT
+                cursor, uid, address_id, list_id, MAILCHIMP_CLIENT
             )
 
     @job(queue="mailchimp_tasks")
@@ -597,9 +600,10 @@ class ResPartnerAddress(osv.osv):
         list_ids = [self.get_mailchimp_list_id(name, MAILCHIMP_CLIENT) for name in list_names]
 
         for _id in partner_ids:
+            address_id = self._get_partner_address_id(cursor, uid, _id, context=context)
             for list_id in list_ids:
                 self.archieve_mail_in_list_sync(
-                    cursor, uid, _id, list_id, MAILCHIMP_CLIENT
+                    cursor, uid, address_id, list_id, MAILCHIMP_CLIENT
                 )
 
     @job(queue="mailchimp_tasks")

--- a/som_polissa_soci/tests/tests_partner_address.py
+++ b/som_polissa_soci/tests/tests_partner_address.py
@@ -224,3 +224,59 @@ class TestsPartnerAddress(testing.OOTestCase):
         )
 
         mock_fakemailchimp.delete_list_member.assert_called()
+
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "archieve_mail_in_list_sync")
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "get_mailchimp_list_id")
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "_get_mailchimp_client")
+    def test_unsubscribe_partner_in_customers_no_members_lists_uses_address_id(
+        self, get_mailchimp_client_mock, get_mailchimp_list_id_mock, archive_mock
+    ):
+        partner_address_o = self.pool.get("res.partner.address")
+        imd_o = self.pool.get("ir.model.data")
+        address_id = imd_o.get_object_reference(
+            self.cursor, self.uid, "som_polissa_soci", "res_partner_address_soci"
+        )[1]
+        partner_id = partner_address_o.read(self.cursor, self.uid, address_id, ["partner_id"])[
+            "partner_id"
+        ][0]
+
+        get_mailchimp_client_mock.return_value = fake_mchimp_client
+        get_mailchimp_list_id_mock.return_value = 99
+
+        partner_address_o.unsubscribe_partner_in_customers_no_members_lists(
+            self.cursor, self.txn, partner_id
+        )
+
+        archive_mock.assert_called_once_with(
+            self.cursor, self.txn, address_id, 99, fake_mchimp_client
+        )
+
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "archieve_mail_in_list_sync")
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "_get_members_mailchimp_lists")
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "get_mailchimp_list_id")
+    @mock.patch.object(res_partner_address.ResPartnerAddress, "_get_mailchimp_client")
+    def test_unsubscribe_partner_in_members_lists_uses_address_id(
+        self,
+        get_mailchimp_client_mock,
+        get_mailchimp_list_id_mock,
+        get_members_mailchimp_lists_mock,
+        archive_mock,
+    ):
+        partner_address_o = self.pool.get("res.partner.address")
+        imd_o = self.pool.get("ir.model.data")
+        address_id = imd_o.get_object_reference(
+            self.cursor, self.uid, "som_polissa_soci", "res_partner_address_soci"
+        )[1]
+        partner_id = partner_address_o.read(self.cursor, self.uid, address_id, ["partner_id"])[
+            "partner_id"
+        ][0]
+
+        get_mailchimp_client_mock.return_value = fake_mchimp_client
+        get_members_mailchimp_lists_mock.return_value = ["socis", "crinforma"]
+        get_mailchimp_list_id_mock.side_effect = [11, 22]
+
+        partner_address_o.unsubscribe_partner_in_members_lists(self.cursor, self.txn, partner_id)
+
+        self.assertEqual(archive_mock.call_count, 2)
+        archive_mock.assert_any_call(self.cursor, self.txn, address_id, 11, fake_mchimp_client)
+        archive_mock.assert_any_call(self.cursor, self.txn, address_id, 22, fake_mchimp_client)

--- a/som_sortida/models/res_partner_address.py
+++ b/som_sortida/models/res_partner_address.py
@@ -124,8 +124,9 @@ class ResPartnerAddress(osv.osv):
         list_id = self.get_mailchimp_list_id(list_name, MAILCHIMP_CLIENT)
 
         for _id in partner_ids:
+            address_id = self._get_partner_address_id(cursor, uid, _id, context=context)
             self.archieve_mail_in_list_sync(
-                cursor, uid, _id, list_id, MAILCHIMP_CLIENT
+                cursor, uid, address_id, list_id, MAILCHIMP_CLIENT
             )
 
 

--- a/som_sortida/tests/tests_res_partner_address.py
+++ b/som_sortida/tests/tests_res_partner_address.py
@@ -71,3 +71,28 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
             },
             'status': 'subscribed'
         })
+
+    @mock.patch('som_polissa_soci.models.res_partner_address.ResPartnerAddress.archieve_mail_in_list_sync')  # noqa: E501
+    @mock.patch('som_polissa_soci.models.res_partner_address.ResPartnerAddress.get_mailchimp_list_id')  # noqa: E501
+    @mock.patch('som_polissa_soci.models.res_partner_address.ResPartnerAddress._get_mailchimp_client')  # noqa: E501
+    def test__unsubscribe_titular_in_ctss_lists__uses_address_id(
+        self, mocked_get_mailchimp_client, mocked_get_mailchimp_list_id, mocked_archive
+    ):
+        cursor = self.cursor
+        uid = self.uid
+        rpa_obj = self.openerp.pool.get("res.partner.address")
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        address_id = imd_obj.get_object_reference(
+            cursor, uid, 'som_polissa_soci', 'res_partner_address_soci'
+        )[1]
+        partner_id = rpa_obj.read(cursor, uid, address_id, ['partner_id'])['partner_id'][0]
+        mailchimp_client = mock.Mock()
+
+        mocked_get_mailchimp_client.return_value = mailchimp_client
+        mocked_get_mailchimp_list_id.return_value = 77
+
+        rpa_obj.unsubscribe_titular_in_ctss_lists(cursor, uid, partner_id)
+
+        mocked_archive.assert_called_once_with(
+            cursor, uid, address_id, 77, mailchimp_client
+        )


### PR DESCRIPTION
## Objectiu
Liadinya: feiem servir la ID de partner per buscar una adreça. Aquest PR ho arregla :pray: 

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8175397?folder_id=103

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in three Mailchimp unsubscribe methods that were passing `res.partner` IDs directly to `archieve_mail_in_list_sync`, which expects `res.partner.address` IDs. It also extracts the repeated partner-address lookup into a new `_get_partner_address_id` helper, reducing duplication.

- **`som_polissa_soci`**: Extracted `_get_partner_address_id` and applied it to fix `unsubscribe_partner_in_customers_no_members_lists`, `unsubscribe_partner_in_members_lists`, `fill_merge_fields_clients_from_partner`, and `fill_merge_fields_soci_from_partner`. Two new integration-style tests verify the correct `address_id` is forwarded.
- **`som_sortida`**: Applies the same fix to `unsubscribe_titular_in_ctss_lists`, relying on the helper defined in the parent module (which `som_sortida` inherits via `_inherit = "res.partner.address"` and its declared dependency on `som_polissa_soci`).
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core bug fix is correct and well-tested in `som_polissa_soci`; the only gap is a missing test for the parallel change in `som_sortida`.

The refactoring correctly extracts `_get_partner_address_id` and applies it consistently across all call sites. The new tests in `som_polissa_soci` validate that `archieve_mail_in_list_sync` receives the resolved address ID rather than the raw partner ID. The equivalent change in `som_sortida/models/res_partner_address.py` lacks a corresponding test, leaving one fixed path unverified.

som_sortida/models/res_partner_address.py — the fix to `unsubscribe_titular_in_ctss_lists` is untested.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| som_polissa_soci/models/res_partner_address.py | Extracts `_get_partner_address_id` helper and correctly fixes all three call sites that were passing partner IDs where address IDs are required. |
| som_polissa_soci/tests/tests_partner_address.py | Adds two integration-style tests that verify the correct `address_id` is passed to `archieve_mail_in_list_sync`; mock ordering and fixture usage look correct. |
| som_sortida/models/res_partner_address.py | Applies the same `_get_partner_address_id` fix to `unsubscribe_titular_in_ctss_lists`, but no corresponding test was added for this change. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant ResPartnerAddress
    participant DB as ORM (res.partner.address)
    participant Mailchimp

    Note over Caller,Mailchimp: Before fix — wrong ID type passed
    Caller->>ResPartnerAddress: unsubscribe_partner_in_customers_no_members_lists(partner_id)
    ResPartnerAddress->>Mailchimp: archieve_mail_in_list_sync(partner_id, ...) ❌

    Note over Caller,Mailchimp: After fix — address ID resolved first
    Caller->>ResPartnerAddress: unsubscribe_partner_in_customers_no_members_lists(partner_id)
    ResPartnerAddress->>ResPartnerAddress: _get_partner_address_id(partner_id)
    ResPartnerAddress->>DB: "search([partner_id = partner_id], limit=1)"
    DB-->>ResPartnerAddress: address_id
    ResPartnerAddress->>Mailchimp: archieve_mail_in_list_sync(address_id, ...) ✅
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `som_sortida/models/res_partner_address.py`, line 116-130 ([link](https://github.com/som-energia/openerp_som_addons/blob/8344960afc65fb024eddbf55b5fb54ee4c09a3d3/som_sortida/models/res_partner_address.py#L116-L130)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing test for `som_sortida` fix**

   `som_polissa_soci` received two new tests that verify the corrected `address_id` is forwarded to `archieve_mail_in_list_sync`, but the equivalent fix in `unsubscribe_titular_in_ctss_lists` (in `som_sortida`) has no corresponding test. Without a test here, a future regression in this code path — or a change to how `_get_partner_address_id` is resolved via the `_inherit` chain — could go undetected.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["🐛 Fix bug using res.partner id for res...."](https://github.com/som-energia/openerp_som_addons/commit/8344960afc65fb024eddbf55b5fb54ee4c09a3d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36982489)</sub>

<!-- /greptile_comment -->