### PR TITLE
✅ (leads) Modificar representant

### DIFF
--- a/som_leads_polissa/tests/test_lead_www_creation.py
+++ b/som_leads_polissa/tests/test_lead_www_creation.py
@@ -152,9 +152,30 @@ class TestLeadWwwCreation(BaseSomLeadWwwTest):
         # Check that the representative is created and correctly linked
         rep_id = partner_o.search(self.cursor, self.uid, [("vat", "=", "ES40323835M")])[0]
         self.assertEqual(lead.polissa_id.titular.representante_id.id, rep_id)
+        self.assertEqual(lead.polissa_id.titular.representante_id.name, "Palotes, Pepito")
         self.assertEqual(lead.polissa_id.titular.name, "PEC COOP SCCL")
         self.mock_subscribe_member.assert_called()
         self.mock_unsubscribe_customer.assert_called()
+
+    def test_create_simple_juridic_lead_keeps_existing_representative_format(self):
+        www_lead_o = self.get_model("som.lead.www")
+        lead_o = self.get_model("giscedata.crm.lead")
+        partner_o = self.get_model("res.partner")
+
+        values = self._basic_values
+        values["new_member_info"]["is_juridic"] = True
+        values["new_member_info"]["vat"] = "C81837452"
+        values["new_member_info"]["name"] = "PEC COOP SCCL"
+        values["new_member_info"]["proxy_name"] = "Palotes, Pepito"
+        values["new_member_info"]["proxy_vat"] = "40323835M"
+
+        result = www_lead_o.create_lead(self.cursor, self.uid, values)
+        www_lead_o.activate_lead(self.cursor, self.uid, result["lead_id"], context={"sync": True})
+
+        lead = lead_o.browse(self.cursor, self.uid, result["lead_id"])
+        rep_id = partner_o.search(self.cursor, self.uid, [("vat", "=", "ES40323835M")])[0]
+        self.assertEqual(lead.polissa_id.titular.representante_id.id, rep_id)
+        self.assertEqual(lead.polissa_id.titular.representante_id.name, "Palotes, Pepito")
 
     def test_create_simple_juridic_lead_with_existing_representative(self):
         www_lead_o = self.get_model("som.lead.www")

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -98,6 +98,15 @@ class SomLeadWww(osv.osv_memory):
                 'surname2': names['cognoms'][1],
             })
 
+        representative_name = member.get("proxy_name")
+        if representative_name and "," not in representative_name:
+            rep_names = partner_o.separa_cognoms(cr, uid, representative_name)
+            representative_surnames = " ".join(filter(None, rep_names['cognoms']))
+            if rep_names['nom'] and representative_surnames:
+                representative_name = "{}, {}".format(
+                    representative_surnames, rep_names['nom']
+                )
+
         values = {
             "state": "open",
             "name": "{} / {}".format(member["vat"].upper(), contract_info["cups"]),
@@ -168,7 +177,7 @@ class SomLeadWww(osv.osv_memory):
 
         if member.get("is_juridic"):
             values["persona_firmant_vat"] = member["proxy_vat"]
-            values["persona_nom"] = member["proxy_name"]
+            values["persona_nom"] = representative_name
             values["is_juridic"] = True
 
         for i, power in enumerate(contract_info["powers"]):


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR normalizes the representative (`proxy_name`) name format to "Surnames, Name" before it is stored in the lead, so names submitted in natural order (e.g. "Pepito Palotes") are automatically converted to the ERP's expected format ("Palotes, Pepito"). Names already containing a comma are left unchanged.

- **`som_lead_www.py`**: Adds a pre-processing block that calls `separa_cognoms` on `proxy_name` and reformats the result only when no comma is present; the value is then used for `persona_nom` in the juridic lead path.
- **`test_lead_www_creation.py`**: Extends the existing juridic-lead test with a name-format assertion and adds a new test (`test_create_simple_juridic_lead_keeps_existing_representative_format`) verifying that already-formatted names pass through unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a small, well-tested normalization of the representative name before it reaches the ERP.

The normalization logic is correct and the new test covers both the conversion path and the already-formatted bypass. The only thing worth a second look is that the separa_cognoms call sits outside the is_juridic guard, which is harmless today but slightly harder to follow.

No files require special attention; the logic in som_lead_www.py around the placement of the normalization block is worth a quick read.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/www/som_lead_www.py | Adds pre-processing of proxy_name to 'Surnames, Name' format before it is stored as persona_nom; logic is correct and handles the already-formatted case, but the computation sits outside the is_juridic guard. |
| som_leads_polissa/tests/test_lead_www_creation.py | Adds a new test for the already-formatted name case and extends the existing juridic-lead test with a name-format assertion; coverage is solid for the changed behaviour. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[activate_lead called] --> B{member_type?}
    B -- new_member --> C[member = new_member_info]
    B -- sponsored/already_member --> D[member = contract_owner / vat+address]
    C --> E[Split phone prefix]
    D --> E
    E --> F{member has name + surname?}
    F -- yes --> G[separa_cognoms → normalize titular name]
    F -- no --> H
    G --> H[representative_name = member.get proxy_name]
    H --> I{representative_name exists AND no comma?}
    I -- yes --> J[separa_cognoms → build Surnames, Name]
    I -- no --> K[keep representative_name as-is]
    J --> L{both nom and surnames found?}
    L -- yes --> M[representative_name = Surnames, Name]
    L -- no --> K
    K --> N[Build values dict]
    M --> N
    N --> O{member.is_juridic?}
    O -- yes --> P[values.persona_nom = representative_name]
    O -- no --> Q[skip]
    P --> R[create / update lead]
    Q --> R
```
</details>

<sub>Reviews (1): Last reviewed commit: ["✅ (leads) Add representative tests"](https://github.com/som-energia/openerp_som_addons/commit/504814e27516add5ab10fc639ab3198378ac58b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37603383)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->