### PR TITLE
✨ Runtime docker ara es pot updatar mòdul i fer servir pudb per telnet

### DIFF
--- a/runtime-docker/Makefile
+++ b/runtime-docker/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: dataset-producer-create dataset-producer-dump dataset-producer-publish dataset-producer-all dataset-producer-legacy-all dataset-consumer-all dataset-consumer-prepare dataset-consumer-pull dataset-consumer-restore dataset-consumer-up dataset-consumer-up-local dataset-consumer-refresh dataset-smoke-vpn runtime-build-prewarmed runtime-export-prewarmed-db runtime-publish-prewarmed dataset-create dataset-dump dataset-publish dataset-pull dataset-restore
+.PHONY: dataset-producer-create dataset-producer-dump dataset-producer-publish dataset-producer-all dataset-producer-legacy-all dataset-consumer-all dataset-consumer-sync dataset-consumer-prepare dataset-consumer-pull dataset-consumer-restore dataset-consumer-up dataset-consumer-up-local dataset-consumer-refresh dataset-smoke-vpn runtime-build-prewarmed runtime-export-prewarmed-db runtime-publish-prewarmed dataset-create dataset-dump dataset-publish dataset-pull dataset-restore
 
 dataset-producer-create:
 	bash -lc 'set -euo pipefail; [ -f .env.producer ] || { echo ".env.producer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.producer; ./scripts/producer_create_db.sh'
@@ -15,7 +15,10 @@ dataset-producer-all: runtime-build-prewarmed dataset-producer-publish
 
 dataset-producer-legacy-all: dataset-producer-create dataset-producer-dump dataset-producer-publish
 
-dataset-consumer-all: dataset-consumer-prepare dataset-consumer-restore dataset-consumer-up
+dataset-consumer-all: dataset-consumer-sync dataset-consumer-up
+
+dataset-consumer-sync:
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; ./scripts/consumer_sync.sh'
 
 dataset-consumer-prepare:
 	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; ./scripts/consumer_prepare_assets.sh'
@@ -24,16 +27,16 @@ dataset-consumer-pull:
 	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; ./scripts/pull_dataset.sh'
 
 dataset-consumer-restore:
-	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; ./scripts/restore_dataset.sh'
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; COMPOSE_FILE=./docker-compose.consumer.yml DB_SERVICE=postgres ./scripts/restore_dataset.sh'
 
 dataset-consumer-up:
-	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml up --pull always --force-recreate postgres mongo redis erp-runtime'
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml up --force-recreate postgres mongo redis erp-runtime'
 
 dataset-consumer-up-local:
-	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; [ -f ./docker-compose.consumer.override.yml ] || { echo "docker-compose.consumer.override.yml is required for local mode" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml -f ./docker-compose.consumer.override.yml up --pull always --force-recreate postgres mongo redis erp-runtime'
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; [ -f ./docker-compose.consumer.override.yml ] || { echo "docker-compose.consumer.override.yml is required for local mode" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml -f ./docker-compose.consumer.override.yml up --force-recreate postgres mongo redis erp-runtime'
 
 dataset-consumer-refresh:
-	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml down; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml up --pull always --force-recreate postgres mongo redis erp-runtime'
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml down; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml up --force-recreate postgres mongo redis erp-runtime'
 
 dataset-smoke-vpn:
 	bash -lc 'set -euo pipefail; [ -f .env.producer ] || { echo ".env.producer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.producer; ./scripts/smoke_test_dataset_flow.sh'
@@ -57,6 +60,8 @@ dataset-publish: dataset-producer-publish
 dataset-pull: dataset-consumer-pull
 
 consumer-prepare: dataset-consumer-prepare
+
+consumer-sync: dataset-consumer-sync
 
 consumer-up: dataset-consumer-up
 

--- a/runtime-docker/Makefile
+++ b/runtime-docker/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: dataset-producer-create dataset-producer-dump dataset-producer-publish dataset-producer-all dataset-producer-legacy-all dataset-consumer-all dataset-consumer-sync dataset-consumer-prepare dataset-consumer-pull dataset-consumer-restore dataset-consumer-up dataset-consumer-up-local dataset-consumer-refresh dataset-smoke-vpn runtime-build-prewarmed runtime-export-prewarmed-db runtime-publish-prewarmed dataset-create dataset-dump dataset-publish dataset-pull dataset-restore
+.PHONY: dataset-producer-create dataset-producer-dump dataset-producer-publish dataset-producer-all dataset-producer-legacy-all dataset-consumer-all dataset-consumer-sync dataset-consumer-prepare dataset-consumer-pull dataset-consumer-restore dataset-consumer-up dataset-consumer-up-local dataset-consumer-update-module dataset-consumer-refresh dataset-smoke-vpn runtime-build-prewarmed runtime-export-prewarmed-db runtime-publish-prewarmed dataset-create dataset-dump dataset-publish dataset-pull dataset-restore
 
 dataset-producer-create:
 	bash -lc 'set -euo pipefail; [ -f .env.producer ] || { echo ".env.producer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.producer; ./scripts/producer_create_db.sh'
@@ -35,6 +35,9 @@ dataset-consumer-up:
 dataset-consumer-up-local:
 	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; [ -f ./docker-compose.consumer.override.yml ] || { echo "docker-compose.consumer.override.yml is required for local mode" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml -f ./docker-compose.consumer.override.yml up --force-recreate postgres mongo redis erp-runtime'
 
+dataset-consumer-update-module:
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; if [ "$(or $(LOCAL),0)" = "1" ]; then [ -f ./docker-compose.consumer.override.yml ] || { echo "docker-compose.consumer.override.yml is required for local mode" >&2; exit 1; }; fi; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; CONSUMER_LOCAL_MODE="$(or $(LOCAL),0)" ./scripts/update_runtime_module.sh'
+
 dataset-consumer-refresh:
 	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml down; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml up --force-recreate postgres mongo redis erp-runtime'
 
@@ -64,6 +67,8 @@ consumer-prepare: dataset-consumer-prepare
 consumer-sync: dataset-consumer-sync
 
 consumer-up: dataset-consumer-up
+
+consumer-update-module: dataset-consumer-update-module
 
 consumer-all: dataset-consumer-all
 

--- a/runtime-docker/Makefile
+++ b/runtime-docker/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: dataset-producer-create dataset-producer-dump dataset-producer-publish dataset-producer-all dataset-producer-legacy-all dataset-consumer-all dataset-consumer-sync dataset-consumer-prepare dataset-consumer-pull dataset-consumer-restore dataset-consumer-up dataset-consumer-up-local dataset-consumer-update-module dataset-consumer-refresh dataset-smoke-vpn runtime-build-prewarmed runtime-export-prewarmed-db runtime-publish-prewarmed dataset-create dataset-dump dataset-publish dataset-pull dataset-restore
+.PHONY: dataset-producer-create dataset-producer-dump dataset-producer-publish dataset-producer-all dataset-producer-legacy-all dataset-consumer-all dataset-consumer-sync dataset-consumer-prepare dataset-consumer-pull dataset-consumer-restore dataset-consumer-up dataset-consumer-up-local dataset-consumer-update-module dataset-consumer-install-package dataset-consumer-refresh dataset-smoke-vpn runtime-build-prewarmed runtime-export-prewarmed-db runtime-publish-prewarmed dataset-create dataset-dump dataset-publish dataset-pull dataset-restore
 
 dataset-producer-create:
 	bash -lc 'set -euo pipefail; [ -f .env.producer ] || { echo ".env.producer is required" >&2; exit 1; }; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.producer; ./scripts/producer_create_db.sh'
@@ -37,6 +37,9 @@ dataset-consumer-up-local:
 
 dataset-consumer-update-module:
 	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; if [ "$(or $(LOCAL),0)" = "1" ]; then [ -f ./docker-compose.consumer.override.yml ] || { echo "docker-compose.consumer.override.yml is required for local mode" >&2; exit 1; }; fi; while IFS= read -r line; do case "$$line" in ""|\#*) continue;; esac; export "$$line"; done < ./.env.consumer; CONSUMER_LOCAL_MODE="$(or $(LOCAL),0)" ./scripts/update_runtime_module.sh'
+
+dataset-consumer-install-package:
+	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; [ -n "$(PACKAGE)" ] || { echo "PACKAGE is required, for example PACKAGE=\"pudb==2019.2\"" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml exec -T erp-runtime bash -lc "pip install \"$(PACKAGE)\""'
 
 dataset-consumer-refresh:
 	bash -lc 'set -euo pipefail; [ -f .env.consumer ] || { echo ".env.consumer is required" >&2; exit 1; }; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml down; docker compose --env-file ./.env.consumer -f ./docker-compose.consumer.yml up --force-recreate postgres mongo redis erp-runtime'

--- a/runtime-docker/README.md
+++ b/runtime-docker/README.md
@@ -425,6 +425,58 @@ Aquest flow:
 - executa `--update=<modul>` amb `--stop-after-init` sobre la mateixa BD del consumer,
 - i torna a arrencar `erp-runtime` si abans estava en marxa.
 
+### Debug remot amb PuDB
+
+El runtime publica també el port remot de PuDB (`6899` per defecte) per poder
+entrar al debugger des del host.
+
+Snippet recomanat al codi:
+
+```python
+from pudb.remote import set_trace
+set_trace(host="0.0.0.0", port=6899, term_size=(120, 40))
+```
+
+Abans de disparar el codi, al teu host connecta't al port publicat:
+
+```bash
+telnet 127.0.0.1 6899
+```
+
+Després executa el flow que vulguis depurar, normalment en mode local:
+
+```bash
+make -C runtime-docker dataset-consumer-up-local
+```
+
+Quan l'execució arribi al `set_trace()`, PuDB quedarà esperant la connexió i la
+veuràs a la terminal del `telnet`.
+
+Tecles útils:
+
+- `n`: next
+- `s`: step into
+- `r`: return
+- `c`: continue
+- `q`: quit
+
+Notes:
+
+- Si la imatge consumer actual és anterior a aquest canvi, PuDB encara no hi serà.
+  Rebuilda/publica la imatge runtime o instal·la temporalment `pudb==2019.2`
+  dins del contenidor per la sessió actual.
+- Fem servir `pudb==2019.2` perquè el runtime és Python 2.7.
+- Si vols canviar el port remot, defineix `PUDB_RDB_PORT` a `.env.consumer`.
+
+Instal·lació temporal ràpida de PuDB dins del contenidor actual:
+
+```bash
+make -C runtime-docker dataset-consumer-install-package PACKAGE="pudb==2019.2"
+```
+
+Com que això s'instal·la dins del contenidor viu, si el recrees ho perdràs i ho
+hauràs de tornar a executar.
+
 ### Carregar manualment el dataset actual a PostgreSQL local
 
 ```bash

--- a/runtime-docker/README.md
+++ b/runtime-docker/README.md
@@ -65,9 +65,9 @@ Fem servir un sol `Makefile`, però separat per rols:
   - `dataset-producer-create`
   - `dataset-producer-publish`
 - Consumidor:
-  - `dataset-consumer-prepare`
+  - `dataset-consumer-sync`
   - `dataset-consumer-up`
-  - `dataset-consumer-restore`
+  - `dataset-consumer-up-local`
 
 També es mantenen aliases curts per compatibilitat:
 
@@ -142,19 +142,23 @@ make -C runtime-docker dataset-consumer-all
 
 Això fa:
 ```bash
-# 1) baixa imatge+dataset només si falten
-make -C runtime-docker dataset-consumer-prepare
+# 1) sincronitza imatge i dataset; restaura la base només si el dataset resolt és nou
+make -C runtime-docker dataset-consumer-sync
 
-# 2) restaura la base de dades
-make -C runtime-docker dataset-consumer-restore
-
-# 3) arrenca el compose (consumer pur: sempre pull + recreate)
+# 2) arrenca el compose compartit (consumer pur)
 make -C runtime-docker dataset-consumer-up
 
-# 3) opcional: mode local/dev amb docker-compose.consumer.override.yml
+# 3) opcional: mateix stack i mateixa BD, però amb openerp_som_addons local
 cp runtime-docker/docker-compose.consumer.override.example.yml runtime-docker/docker-compose.consumer.override.yml
 make -C runtime-docker dataset-consumer-up-local
 ```
+
+La sincronització guarda una marca local a `runtime-docker/.cache/consumer-state/dataset-state.env` amb:
+
+- `requested_tag`: el tag demanat (`latest`, `YYYYMMDD`, ...)
+- `resolved_tag`: el `dataset_version` real restaurat
+
+Si falta aquesta marca, `dataset-consumer-sync` assumeix estat desconegut i restaura.
 
 ### Crear dataset
 
@@ -302,7 +306,8 @@ S'inclou un compose dedicat per consumidors:
 Què fa:
 
 - aixeca `postgres` (PG13), `mongo`, `redis` i `erp-runtime` (imatge preconstruida),
-- permet executar un job one-shot `dataset-restore` que baixa `erp/datasets:latest` via ORAS i restaura la base.
+- comparteix el mateix stack i la mateixa BD entre mode empaquetat i mode local,
+- separa `dataset-consumer-sync` del `up`, per evitar refresh o restore accidental a cada arrencada.
 
 Nota sobre `erp-runtime`:
 
@@ -372,20 +377,27 @@ ERP_RUNTIME_IMAGE="harbor.example.com/erp/openerp:latest"
 
 Modes disponibles:
 
-- `dataset-consumer-up`: consumer pur (imatge Harbor, sense mounts locals), amb `--pull always --force-recreate`.
-- `dataset-consumer-up-local`: usa `docker-compose.consumer.override.yml` per mounts locals.
-- `dataset-consumer-refresh`: baixa i recrea stack consumer pur.
+- `dataset-consumer-up`: consumer pur (imatge Harbor, sense mounts locals), sense fer cap sync ni restore.
+- `dataset-consumer-up-local`: usa `docker-compose.consumer.override.yml` per mounts locals sobre el mateix stack i la mateixa BD.
+- `dataset-consumer-sync`: actualitza la imatge si canvia i restaura la BD només quan el dataset resolt és nou.
+- `dataset-consumer-refresh`: recrea el stack consumer pur sense tocar l'estat sincronitzat.
 
 
 ```bash
 cp runtime-docker/.env.consumer.example runtime-docker/.env.consumer
 # edita credencials Harbor i valors necessaris
 
-make -C runtime-docker dataset-consumer-prepare
+make -C runtime-docker dataset-consumer-sync
 make -C runtime-docker dataset-consumer-up
 ```
 
-### Carregar el dataset més recent a PostgreSQL local
+### Forçar una restauració del dataset actual
+
+```bash
+FORCE_RESTORE=1 make -C runtime-docker dataset-consumer-sync
+```
+
+### Carregar manualment el dataset actual a PostgreSQL local
 
 ```bash
 make -C runtime-docker dataset-consumer-restore
@@ -409,6 +421,8 @@ Variables recomanades:
 Troubleshooting ràpid:
 
 - Si el contenidor carrega codi antic tot i fer pull, comprova que no estiguis en mode local (`dataset-consumer-up-local`) amb mounts que tapen `/opt/somenergia/src`.
+
+- Si `dataset-consumer-sync` no restaura quan esperaves, revisa `runtime-docker/.cache/consumer-state/dataset-state.env` per veure quin `resolved_tag` considera aplicat.
 
 - Si veus `artifact erp/openerp:latest not found`, revisa que `ERP_RUNTIME_IMAGE` sigui una referència completa i existent a Harbor.
 - Pots validar la interpolació final amb:

--- a/runtime-docker/README.md
+++ b/runtime-docker/README.md
@@ -68,6 +68,7 @@ Fem servir un sol `Makefile`, però separat per rols:
   - `dataset-consumer-sync`
   - `dataset-consumer-up`
   - `dataset-consumer-up-local`
+  - `dataset-consumer-update-module`
 
 També es mantenen aliases curts per compatibilitat:
 
@@ -396,6 +397,33 @@ make -C runtime-docker dataset-consumer-up
 ```bash
 FORCE_RESTORE=1 make -C runtime-docker dataset-consumer-sync
 ```
+
+### Actualitzar un mòdul al runtime consumidor
+
+Mode empaquetat:
+
+```bash
+make -C runtime-docker dataset-consumer-update-module MODULE=som_polissa
+```
+
+Mode local amb `openerp_som_addons` mapat:
+
+```bash
+make -C runtime-docker dataset-consumer-update-module MODULE=som_polissa LOCAL=1
+```
+
+També pots actualitzar diversos mòduls:
+
+```bash
+make -C runtime-docker dataset-consumer-update-module MODULES=som_polissa,som_switching
+```
+
+Aquest flow:
+
+- assegura `postgres`, `mongo` i `redis`,
+- atura temporalment `erp-runtime` si estava corrent,
+- executa `--update=<modul>` amb `--stop-after-init` sobre la mateixa BD del consumer,
+- i torna a arrencar `erp-runtime` si abans estava en marxa.
 
 ### Carregar manualment el dataset actual a PostgreSQL local
 

--- a/runtime-docker/docker-compose.consumer.yml
+++ b/runtime-docker/docker-compose.consumer.yml
@@ -29,6 +29,8 @@ services:
 
   erp-runtime:
     image: "${ERP_RUNTIME_IMAGE:-harbor.somenergia.coop/erp/openerp:latest}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy
@@ -80,6 +82,7 @@ services:
         exec bash /opt/somenergia/src/openerp_som_addons/scripts/start-openerp-server.sh
     ports:
       - "${ERP_XMLRPC_PORT:-8069}:${ERP_XMLRPC_PORT:-8069}"
+      - "${PUDB_RDB_PORT:-6899}:6899"
 
   dataset-restore:
     image: ubuntu:22.04

--- a/runtime-docker/docker-compose.yml
+++ b/runtime-docker/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     build:
       context: ..
       dockerfile: runtime-docker/Dockerfile
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy
@@ -38,6 +40,7 @@ services:
       OPENERP_DB_PASSWORD: erp
     ports:
       - "${ERP_XMLRPC_PORT:-8069}:${ERP_XMLRPC_PORT:-8069}"
+      - "${PUDB_RDB_PORT:-6899}:6899"
     healthcheck:
       test:
         [

--- a/runtime-docker/scripts/consumer_prepare_assets.sh
+++ b/runtime-docker/scripts/consumer_prepare_assets.sh
@@ -21,6 +21,19 @@ require_cmd() {
 	command -v "$1" >/dev/null 2>&1 || fail "Falta l'eina requerida: $1"
 }
 
+docker_login_if_configured() {
+	if [ -z "${HARBOR_DOMAIN:-}" ] && [ -z "${HARBOR_USERNAME:-}" ] && [ -z "${HARBOR_PASSWORD:-}" ]; then
+		return
+	fi
+
+	[ -n "${HARBOR_DOMAIN:-}" ] || fail "Cal HARBOR_DOMAIN per fer docker login"
+	[ -n "${HARBOR_USERNAME:-}" ] || fail "Cal HARBOR_USERNAME per fer docker login"
+	[ -n "${HARBOR_PASSWORD:-}" ] || fail "Cal HARBOR_PASSWORD per fer docker login"
+
+	log "Fent docker login a ${HARBOR_DOMAIN}"
+	printf '%s' "${HARBOR_PASSWORD}" | docker login "${HARBOR_DOMAIN}" -u "${HARBOR_USERNAME}" --password-stdin >/dev/null
+}
+
 has_dataset_cached() {
 	local target_dir="$1"
 	shopt -s nullglob
@@ -71,6 +84,7 @@ should_pull_latest_image() {
 
 main() {
 	require_cmd docker
+	docker_login_if_configured
 
 	if [[ "${ERP_RUNTIME_IMAGE}" == *":latest" ]] && [ "${FORCE_REFRESH_LATEST}" = "1" ]; then
 		if should_pull_latest_image; then

--- a/runtime-docker/scripts/consumer_sync.sh
+++ b/runtime-docker/scripts/consumer_sync.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DATASET_TAG="${DATASET_TAG:-latest}"
+CACHE_DIR="${CACHE_DIR:-${ROOT_DIR}/.cache/datasets}"
+CONSUMER_STATE_DIR="${CONSUMER_STATE_DIR:-${ROOT_DIR}/.cache/consumer-state}"
+CONSUMER_STATE_FILE="${CONSUMER_STATE_FILE:-${CONSUMER_STATE_DIR}/dataset-state.env}"
+CONSUMER_COMPOSE_FILE="${CONSUMER_COMPOSE_FILE:-${ROOT_DIR}/docker-compose.consumer.yml}"
+CONSUMER_DB_SERVICE="${CONSUMER_DB_SERVICE:-postgres}"
+FORCE_RESTORE="${FORCE_RESTORE:-0}"
+
+RESTORED_REQUESTED_TAG=""
+RESTORED_RESOLVED_TAG=""
+RESTORED_AT=""
+
+log() {
+	printf '[consumer_sync] %s\n' "$*"
+}
+
+fail() {
+	printf '[consumer_sync] ERROR: %s\n' "$*" >&2
+	exit 1
+}
+
+metadata_value() {
+	local key="$1"
+	local metadata_file="$2"
+
+	grep -Eo '"'"${key}"'"[[:space:]]*:[[:space:]]*"[^"]+"' "${metadata_file}" \
+		| head -n1 \
+		| sed -E 's/^[^:]+:[[:space:]]*"([^"]+)"$/\1/'
+}
+
+resolve_metadata_file() {
+	local metadata_file="${CACHE_DIR}/${DATASET_TAG}/metadata.json"
+	[ -f "${metadata_file}" ] || fail "No s'ha trobat metadata del dataset a ${metadata_file}"
+	printf '%s\n' "${metadata_file}"
+}
+
+load_state() {
+	if [ ! -f "${CONSUMER_STATE_FILE}" ]; then
+		return
+	fi
+
+	# shellcheck disable=SC1090
+	source "${CONSUMER_STATE_FILE}"
+	RESTORED_REQUESTED_TAG="${requested_tag:-}"
+	RESTORED_RESOLVED_TAG="${resolved_tag:-}"
+	RESTORED_AT="${restored_at:-}"
+}
+
+write_state() {
+	local requested_tag="$1"
+	local resolved_tag="$2"
+	local restored_at="$3"
+
+	mkdir -p "${CONSUMER_STATE_DIR}"
+	cat >"${CONSUMER_STATE_FILE}" <<EOF
+requested_tag=${requested_tag}
+resolved_tag=${resolved_tag}
+restored_at=${restored_at}
+last_sync_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+compose_file=${CONSUMER_COMPOSE_FILE}
+db_service=${CONSUMER_DB_SERVICE}
+EOF
+}
+
+should_restore() {
+	local resolved_tag="$1"
+
+	if [ "${FORCE_RESTORE}" = "1" ]; then
+		log "FORCE_RESTORE=1; forço restore"
+		return 0
+	fi
+
+	if [ ! -f "${CONSUMER_STATE_FILE}" ]; then
+		log "No hi ha marca de dataset restaurat; cal restore"
+		return 0
+	fi
+
+	if [ -z "${RESTORED_RESOLVED_TAG}" ]; then
+		log "La marca no té resolved_tag; cal restore"
+		return 0
+	fi
+
+	if [ "${RESTORED_RESOLVED_TAG}" != "${resolved_tag}" ]; then
+		log "Dataset resolt nou (${RESTORED_RESOLVED_TAG} -> ${resolved_tag}); cal restore"
+		return 0
+	fi
+
+	log "El dataset resolt ${resolved_tag} ja està restaurat"
+	return 1
+}
+
+main() {
+	local metadata_file resolved_tag restored_at
+
+	[ -f "${CONSUMER_COMPOSE_FILE}" ] || fail "No existeix el compose consumidor: ${CONSUMER_COMPOSE_FILE}"
+
+	./scripts/consumer_prepare_assets.sh
+	metadata_file="$(resolve_metadata_file)"
+	resolved_tag="$(metadata_value dataset_version "${metadata_file}")"
+	[ -n "${resolved_tag}" ] || fail "No s'ha pogut resoldre dataset_version de ${metadata_file}"
+
+	load_state
+
+	if should_restore "${resolved_tag}"; then
+		COMPOSE_FILE="${CONSUMER_COMPOSE_FILE}" DB_SERVICE="${CONSUMER_DB_SERVICE}" ./scripts/restore_dataset.sh
+		restored_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	else
+		restored_at="${RESTORED_AT:-unknown}"
+	fi
+
+	write_state "${DATASET_TAG}" "${resolved_tag}" "${restored_at}"
+	log "Sync consumidor completat (requested=${DATASET_TAG}, resolved=${resolved_tag})"
+}
+
+main "$@"

--- a/runtime-docker/scripts/pull_dataset.sh
+++ b/runtime-docker/scripts/pull_dataset.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 HARBOR_DATASET_REPOSITORY="${HARBOR_DATASET_REPOSITORY:-harbor.example.com/openerp/datasets}"
+HARBOR_DOMAIN="${HARBOR_DOMAIN:-}"
+HARBOR_USERNAME="${HARBOR_USERNAME:-}"
+HARBOR_PASSWORD="${HARBOR_PASSWORD:-}"
 DATASET_TAG="${DATASET_TAG:-latest}"
 CACHE_DIR="${CACHE_DIR:-${ROOT_DIR}/.cache/datasets}"
 
@@ -20,8 +23,33 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "Falta l'eina requerida: $1"
 }
 
+registry_from_repository() {
+  printf '%s' "${HARBOR_DATASET_REPOSITORY%%/*}"
+}
+
+oras_login_if_configured() {
+  local registry
+  registry="$(registry_from_repository)"
+
+  if [ -z "${HARBOR_DOMAIN}" ] && [ -z "${HARBOR_USERNAME}" ] && [ -z "${HARBOR_PASSWORD}" ]; then
+    return
+  fi
+
+  [ -n "${HARBOR_DOMAIN}" ] || fail "Cal HARBOR_DOMAIN per fer login"
+  [ -n "${HARBOR_USERNAME}" ] || fail "Cal HARBOR_USERNAME per fer login"
+  [ -n "${HARBOR_PASSWORD}" ] || fail "Cal HARBOR_PASSWORD per fer login"
+
+  if [ "${HARBOR_DOMAIN}" != "${registry}" ]; then
+    fail "HARBOR_DOMAIN (${HARBOR_DOMAIN}) no coincideix amb el registry de HARBOR_DATASET_REPOSITORY (${registry})"
+  fi
+
+  log "Fent login ORAS a ${HARBOR_DOMAIN}"
+  printf '%s' "${HARBOR_PASSWORD}" | oras login "${HARBOR_DOMAIN}" --username "${HARBOR_USERNAME}" --password-stdin --insecure
+}
+
 main() {
   require_cmd oras
+  oras_login_if_configured
 
   local target_dir ref
   target_dir="${CACHE_DIR}/${DATASET_TAG}"
@@ -29,7 +57,7 @@ main() {
 
   mkdir -p "${target_dir}"
   log "Descarregant ${ref} a ${target_dir}"
-  oras pull --output "${target_dir}" "${ref}"
+  oras pull --output "${target_dir}" "${ref}" --insecure
 
   log "Dataset descarregat"
 }

--- a/runtime-docker/scripts/update_runtime_module.sh
+++ b/runtime-docker/scripts/update_runtime_module.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+MODULES="${MODULES:-${MODULE:-}}"
+CONSUMER_LOCAL_MODE="${CONSUMER_LOCAL_MODE:-0}"
+COMPOSE_ENV_FILE="${COMPOSE_ENV_FILE:-${ROOT_DIR}/.env.consumer}"
+POSTGRES_USER="${POSTGRES_USER:-erp}"
+COMPOSE_FILE_ARGS=(-f "${ROOT_DIR}/docker-compose.consumer.yml")
+
+log() {
+  printf '[update_runtime_module] %s\n' "$*"
+}
+
+fail() {
+  printf '[update_runtime_module] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+run_compose() {
+  docker compose --env-file "${COMPOSE_ENV_FILE}" "${COMPOSE_FILE_ARGS[@]}" "$@"
+}
+
+wait_for_postgres() {
+  local tries=30
+  local i
+  for ((i = 1; i <= tries; i++)); do
+    if run_compose exec -T postgres pg_isready -U "${POSTGRES_USER}" -d postgres >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  fail "PostgreSQL del consumer no està llest després d'esperar"
+}
+
+main() {
+  local was_running=0
+
+  command -v docker >/dev/null 2>&1 || fail "Falta l'eina requerida: docker"
+  [ -n "${MODULES}" ] || fail "Cal informar MODULE=<modul> o MODULES=<m1,m2>"
+  [ -f "${COMPOSE_ENV_FILE}" ] || fail "No existeix ${COMPOSE_ENV_FILE}"
+
+  if [ "${CONSUMER_LOCAL_MODE}" = "1" ]; then
+    [ -f "${ROOT_DIR}/docker-compose.consumer.override.yml" ] || fail "Cal docker-compose.consumer.override.yml per al mode local"
+    COMPOSE_FILE_ARGS+=(-f "${ROOT_DIR}/docker-compose.consumer.override.yml")
+  fi
+
+  log "Assegurant dependències del consumer"
+  run_compose up -d postgres mongo redis >/dev/null
+  wait_for_postgres
+
+  if run_compose ps --status running --services | grep -Fxq 'erp-runtime'; then
+    was_running=1
+    log "Aturant temporalment erp-runtime per actualitzar mòduls"
+    run_compose stop erp-runtime >/dev/null
+  fi
+
+  log "Actualitzant mòduls: ${MODULES}"
+  run_compose run --rm --no-deps -e MODULES="${MODULES}" --entrypoint /bin/bash erp-runtime -lc '
+    set -euo pipefail
+    export ERP_SERVER="/opt/somenergia/src/erp/server/bin/openerp-server.py"
+    export OPENERP_CONFIG="/opt/somenergia/src/openerp_som_addons/runtime-docker/erp.conf"
+    export OPENERP_DB_HOST="postgres"
+    export OPENERP_MONGODB_HOST="mongo"
+    export OPENERP_REDIS_URL="redis://redis:6379/0"
+    export PYTHONPATH="/opt/somenergia/src/erp/server/bin:/opt/somenergia/src/erp/server/bin/addons:/opt/somenergia/src/erp/server/sitecustomize:${PYTHONPATH:-}"
+    export ERP_FOREGROUND=1
+    export OPENERP_EXTRA_ARGS="--update=${MODULES} --stop-after-init"
+    exec bash /opt/somenergia/src/openerp_som_addons/scripts/start-openerp-server.sh
+  '
+
+  if [ "${was_running}" = "1" ]; then
+    log "Tornant a arrencar erp-runtime"
+    run_compose up -d erp-runtime >/dev/null
+  fi
+
+  log "Actualització completada"
+}
+
+main "$@"

--- a/scripts/bootstrap-erp-env.sh
+++ b/scripts/bootstrap-erp-env.sh
@@ -106,6 +106,7 @@ pip install "cachelib<0.2"
 pip install "Mako<1.2"
 pip install "pypdftk<0.5"
 pip install "paramiko<2.8"
+pip install "pudb==2019.2"
 
 if [ "$PYTHON_VERSION" != "2.7" ]; then
 	pip install somutils

--- a/scripts/build-openerp-server.sh
+++ b/scripts/build-openerp-server.sh
@@ -75,7 +75,7 @@ echo "Building ERP model in database '$ERP_DATABASE'"
 SAVED_OPENERP_CONFIG="${OPENERP_CONFIG:-}"
 unset OPENERP_CONFIG
 set +e
-"${DESTRAL_RUN[@]}" -m som_modul_fulla -d "$ERP_DATABASE
+"${DESTRAL_RUN[@]}" -m som_modul_fulla -d "$ERP_DATABASE"
 DESTRAL_EXIT_CODE=$?
 set -e
 if [ -n "$SAVED_OPENERP_CONFIG" ]; then

--- a/som_modul_fulla/__terp__.py
+++ b/som_modul_fulla/__terp__.py
@@ -127,7 +127,9 @@
         "ws_transactions",
     ],
     "init_xml": [],
-    "demo_xml": [],
+    "demo_xml": [
+        "demo/res_partner_demo.xml",
+    ],
     "update_xml": [],
     "active": False,
     "installable": True,

--- a/som_modul_fulla/demo/res_partner_demo.xml
+++ b/som_modul_fulla/demo/res_partner_demo.xml
@@ -1,0 +1,14 @@
+<openerp>
+    <data>
+        <record id="res_partner_demo" model="res.partner">
+            <field name="name">Demo Partner</field>
+            <field name="email">demo@partner.com</field>
+            <field name="lang">en_US</field>
+        </record>
+        <record id="res_partner_address_demo3" model="res.partner.address">
+            <field name="name">Demo Address</field>
+            <field name="partner_id" ref="res_partner_demo"/>
+            <field name="type">default</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectiu

Poder updatar el mòdul per a que agafi darrers canvis de demo.xml

## Targeta on es demana o Incidència


## Comportament antic
S'havia d'entrar dins el contenidor i des d'allar updatar

## Comportament nou
Es pot updatar amb juna comanda make
Es pot fer servir pudb dins un docker

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the consumer dataset restore workflow to be idempotent: a new `dataset-consumer-sync` step (script + Makefile target) compares the resolved `dataset_version` against a local state file and skips the expensive restore when the tag hasn't changed. It also adds `docker login` / `oras login` helpers so Harbor credentials can be injected at runtime and removes `--pull always` from the `docker compose up` commands.

- **New `consumer_sync.sh`**: orchestrates `consumer_prepare_assets.sh` → metadata resolution → conditional `restore_dataset.sh`, persisting state to `.cache/consumer-state/dataset-state.env`.
- **`consumer_prepare_assets.sh`**: gains `docker_login_if_configured` to authenticate before pulling the runtime image.
- **`pull_dataset.sh`**: gains `oras_login_if_configured` plus an unconditional `--insecure` flag on `oras pull`.
- **Makefile/README**: `dataset-consumer-all` now delegates to `dataset-consumer-sync + up`; old `prepare → restore → up` sequence is gone.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core sync logic is sound, but two issues in the changed scripts should be addressed before merging: TLS certificate verification is silently disabled for every ORAS pull, and the state file is shell-executed rather than parsed, which can crash the sync when paths contain spaces.

The --insecure flag on oras pull is unconditional — it bypasses TLS for all dataset downloads even when no credentials are configured and the registry uses valid certificates. The source call on the state file will abort the script under set -e if any written path value contains spaces. Both are on the hot path that every consumer sync runs through.

runtime-docker/scripts/pull_dataset.sh (unconditional --insecure) and runtime-docker/scripts/consumer_sync.sh (source on state file, CWD-relative sub-script calls).
</details>

<details open><summary><h3>Security Review</h3></summary>

- **TLS bypass on ORAS pull** (`runtime-docker/scripts/pull_dataset.sh` line 60): `--insecure` is now appended unconditionally to every `oras pull`, disabling certificate verification even when no credentials are configured and the target registry uses valid TLS. This exposes artifact downloads to man-in-the-middle substitution.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| runtime-docker/scripts/consumer_sync.sh | New script that orchestrates prepare -> compare resolved tag -> conditional restore; uses source on a file it partially controls and calls sub-scripts via relative CWD paths instead of ROOT_DIR. |
| runtime-docker/scripts/pull_dataset.sh | Adds ORAS login support; also unconditionally appends --insecure to oras pull, bypassing TLS regardless of whether credentials or an explicitly insecure registry are configured. |
| runtime-docker/scripts/consumer_prepare_assets.sh | Adds docker_login_if_configured helper; logic is correct: all-empty -> skip, any partial -> fail with clear message. |
| runtime-docker/Makefile | Introduces dataset-consumer-sync target, wires it into dataset-consumer-all, passes explicit COMPOSE_FILE/DB_SERVICE env vars to restore_dataset.sh, and removes --pull always from up commands. |
| runtime-docker/README.md | Documentation updated to reflect the new sync-first workflow and the state cache file; accurate and consistent with the code changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([make dataset-consumer-all]) --> B[dataset-consumer-sync]
    B --> C[consumer_sync.sh]
    C --> D[consumer_prepare_assets.sh]
    D --> E[resolve metadata_file / extract dataset_version]
    E --> F[load_state from dataset-state.env]
    F --> G{should_restore?}
    G -- yes --> H[restore_dataset.sh]
    G -- no --> I[skip restore]
    H --> J[write_state]
    I --> J
    J --> K[dataset-consumer-up]
    K --> L[docker compose up]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([make dataset-consumer-all]) --> B[dataset-consumer-sync]
    B --> C[consumer_sync.sh]
    C --> D[consumer_prepare_assets.sh]
    D --> E[resolve metadata_file / extract dataset_version]
    E --> F[load_state from dataset-state.env]
    F --> G{should_restore?}
    G -- yes --> H[restore_dataset.sh]
    G -- no --> I[skip restore]
    H --> J[write_state]
    I --> J
    J --> K[dataset-consumer-up]
    K --> L[docker compose up]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 fix runtime docker restore database"](https://github.com/som-energia/openerp_som_addons/commit/169105bb9c50b161fc431664c032258e54c04fc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38080872)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->