### PR TITLE
✨ Fer parametritzables els ports de les bases de dades

### DIFF
--- a/runtime-docker/.env.consumer.example
+++ b/runtime-docker/.env.consumer.example
@@ -16,6 +16,11 @@ POSTGRES_USER=erp
 POSTGRES_PASSWORD=erp
 POSTGRES_DB=erp
 
+# Host port mappings (use 5432/27017/6379 for the real default ports if needed)
+POSTGRES_HOST_PORT=15432
+MONGO_HOST_PORT=37017
+REDIS_HOST_PORT=16379
+
 # Post-restore credentials (evita usuaris sense password)
 RESET_ADMIN_LOGIN=admin
 RESET_ADMIN_PASSWORD=admin

--- a/runtime-docker/docker-compose.consumer.yml
+++ b/runtime-docker/docker-compose.consumer.yml
@@ -15,17 +15,17 @@ services:
       timeout: 5s
       retries: 20
     ports:
-      - "15432:5432"
+      - "${POSTGRES_HOST_PORT:-15432}:5432"
 
   mongo:
     image: mongo:3.0
     ports:
-      - "27017:27017"
+      - "${MONGO_HOST_PORT:-37017}:27017"
 
   redis:
     image: redis:5.0
     ports:
-      - "16379:6379"
+      - "${REDIS_HOST_PORT:-16379}:6379"
 
   erp-runtime:
     image: "${ERP_RUNTIME_IMAGE:-harbor.somenergia.coop/erp/openerp:latest}"

--- a/runtime-docker/docker-compose.consumer.yml
+++ b/runtime-docker/docker-compose.consumer.yml
@@ -15,7 +15,7 @@ services:
       timeout: 5s
       retries: 20
     ports:
-      - "5432:5432"
+      - "15432:5432"
 
   mongo:
     image: mongo:3.0
@@ -25,7 +25,7 @@ services:
   redis:
     image: redis:5.0
     ports:
-      - "6379:6379"
+      - "16379:6379"
 
   erp-runtime:
     image: "${ERP_RUNTIME_IMAGE:-harbor.somenergia.coop/erp/openerp:latest}"


### PR DESCRIPTION
## Objectiu

Canviar el mapeig de port que s'utilitza perque el contenidor pugui conviure amb altres serveis

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/som-energia/boards/45/details/1649 ??

## Comportament antic

Mapejar els ports de postgres i redys al 5432 i 6379 pel contenidor de consum

## Comportament nou

Mapejar els ports de postgres i redys al 15432 i 16379 pel contenidor de consum

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR remaps the host-side ports for PostgreSQL and Redis in the consumer Docker Compose stack so it can run alongside other services that occupy the default ports (5432 and 6379).

- PostgreSQL host port changed from `5432` to `15432`; Redis host port changed from `6379` to `16379`. Container-internal ports and all intra-stack references (`wait_for_port`, `OPENERP_REDIS_URL`, etc.) are untouched and remain correct.
- The base `docker-compose.yml` still maps Postgres at `5432:5432`, so both stacks can now coexist without a port collision on the host.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change only affects host-side port bindings; all intra-container communication is unaltered.

The remapping is correct: internal Docker-network addresses and ports used by erp-runtime (wait_for_port, OPENERP_REDIS_URL, OPENERP_DB_HOST) are unchanged. The only open question is whether the mongo host port should also be remapped for consistency, but that is a non-blocking concern.

No files require special attention; the single changed file is straightforward.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| runtime-docker/docker-compose.consumer.yml | Host port mappings for PostgreSQL (5432→15432) and Redis (6379→16379) updated to avoid conflicts when running alongside other compose stacks; internal Docker-network references (ports 5432/6379) are unchanged and correct. MongoDB host port (27017) was not remapped. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    HOST["Host machine"]

    subgraph consumer ["docker-compose.consumer.yml"]
        PG["postgres\n(timescaledb)"]
        REDIS["redis"]
        MONGO["mongo"]
        ERP["erp-runtime"]
    end

    HOST -- "host:15432 → container:5432" --> PG
    HOST -- "host:16379 → container:6379" --> REDIS
    HOST -- "host:27017 → container:27017" --> MONGO

    ERP -- "postgres:5432 (internal)" --> PG
    ERP -- "redis:6379 (internal)" --> REDIS
    ERP -- "mongo:27017 (internal)" --> MONGO
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    HOST["Host machine"]

    subgraph consumer ["docker-compose.consumer.yml"]
        PG["postgres\n(timescaledb)"]
        REDIS["redis"]
        MONGO["mongo"]
        ERP["erp-runtime"]
    end

    HOST -- "host:15432 → container:5432" --> PG
    HOST -- "host:16379 → container:6379" --> REDIS
    HOST -- "host:27017 → container:27017" --> MONGO

    ERP -- "postgres:5432 (internal)" --> PG
    ERP -- "redis:6379 (internal)" --> REDIS
    ERP -- "mongo:27017 (internal)" --> MONGO
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runtime-docker/docker-compose.consumer.yml`, line 22-23 ([link](https://github.com/som-energia/openerp_som_addons/blob/24cbf071cee358e9d23626b9c7b4ae9c9eff6752/runtime-docker/docker-compose.consumer.yml#L22-L23)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **MongoDB port not remapped alongside Postgres and Redis**

   The `mongo` service still exposes `27017:27017` on the host. If the goal is to allow this consumer compose stack to coexist with another stack that also brings up a MongoDB container (e.g., the base `docker-compose.yml`), that port would clash in the same way that Postgres and Redis did before this fix. Consider remapping it to something like `27017` → `127017` (or another free port) for consistency.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["🐛 fix runtime docker consumer ports"](https://github.com/som-energia/openerp_som_addons/commit/24cbf071cee358e9d23626b9c7b4ae9c9eff6752) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38637528)</sub>

<!-- /greptile_comment -->