### PR TITLE
✨ add ERP devcontainer workflow

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,199 @@
+# Devcontainer setup
+
+This directory adds a devcontainer entrypoint on top of the existing `runtime-docker` stack while keeping the runtime files as the source of truth for ERP services.
+
+## Files
+
+- `devcontainer.json` — standard devcontainer definition that starts the existing compose stack and attaches to `erp-runtime`.
+- `docker-compose.devcontainer.yml` — compose override that keeps the main container alive for editor attachment and mounts the full host workspace into the expected source root.
+- `bin/bootstrap-erp-workspace` — waits for compose dependencies, requires a real `GITHUB_TOKEN` only when private sibling repositories are missing, clones only missing sibling repositories, and prepares the mounted Python environment.
+- `bin/start-erp-runtime` — waits for compose dependencies, exports the runtime environment, auto-runs bootstrap if required imports are still missing, and then runs the existing ERP build/start script.
+- `bin/show-pudb-remote-debug` — prints the exact PuDB remote breakpoint snippet and the connection steps for this devcontainer setup.
+- `helpers/common.sh` — shared shell helpers used by the devcontainer-only commands.
+
+## How it works
+
+The devcontainer reuses:
+
+- `runtime-docker/Dockerfile`
+- `runtime-docker/docker-compose.yml`
+
+The override file changes only devcontainer behavior:
+
+- overrides the runtime image `entrypoint` and `command` so the container stays alive for attachment,
+- bind-mounts the full host workspace root at `/opt/somenergia/src`,
+- keeps this repository available at `/opt/somenergia/src/openerp_som_addons` and sibling repositories such as `/opt/somenergia/src/erp`,
+- defaults devcontainer helpers to the pyenv environment name `erp`, but falls back to the image's Python `2.7.18` interpreter when that alias is not available in the container,
+- exposes `.devcontainer/bin` on `PATH` inside the container so the helper commands can be run directly.
+
+## Environment expectations
+
+- Export a real `GITHUB_TOKEN` on the host **before** opening the devcontainer so Docker Compose can resolve the existing runtime stack configuration.
+- Application flows that truly need GitHub authentication will still require a real token.
+- The current bind mount assumes this repository lives under `/home/pau/src` and mounts that full host workspace into `/opt/somenergia/src`.
+
+## Manual ERP workflow inside the devcontainer
+
+Open the devcontainer first. You can run the helpers either from a shell inside the container or through the versioned VS Code tasks in `.vscode/tasks.json`.
+
+### Editor task flow
+
+After the devcontainer is attached:
+
+1. If you want to use the editor task for bootstrap, export a real `GITHUB_TOKEN` on the host before opening the devcontainer.
+2. Run `Tasks: Run Task` from the command palette.
+3. Choose `ERP: Bootstrap workspace` the first time you prepare the workspace.
+4. After bootstrap completes, run `ERP: Start runtime` whenever you want to start ERP manually.
+
+These tasks stay manual on purpose. They do not auto-bootstrap on container creation or editor startup.
+
+### 1. Provide a real GitHub token
+
+Before opening the devcontainer, export `GITHUB_TOKEN` on the host:
+
+```bash
+export GITHUB_TOKEN=ghp_your_real_token_here
+```
+
+The bootstrap helper fails fast only when it must clone private repositories and `GITHUB_TOKEN` is missing.
+
+### 2. Bootstrap the ERP workspace
+
+```bash
+bootstrap-erp-workspace
+```
+
+What it does:
+
+- waits for `postgres`, `redis`, and `mongo`,
+- defaults `PYENV_VERSION` to `erp` and falls back to `2.7.18` when the alias is not available in the container,
+- ensures the mounted workspace repositories exist without recloning directories that are already present,
+- installs the Python requirements needed by the ERP runtime even if `/opt/somenergia/src/erp` already existed before the container started,
+- refreshes editable installs and addon links for the mounted workspace,
+- verifies the selected interpreter can import `six` and `destral.utils`,
+- is the same command used by the `ERP: Bootstrap workspace` editor task.
+
+### 3. Start ERP manually
+
+```bash
+start-erp-runtime
+```
+
+What it does:
+
+- waits for `postgres`, `redis`, and `mongo`,
+- verifies the workspace was bootstrapped,
+- exports the same runtime variables used by the existing runtime flow,
+- prepends the mounted workspace repositories such as `destral/`, `libFacturacioATR/`, `OMIE/`, `cchloader/`, and `gestionatr/` to `PYTHONPATH`,
+- temporarily patches the OMIE private requirement during startup when a real `GITHUB_TOKEN` is available, then restores your mounted file afterwards,
+- auto-runs `bootstrap-erp-workspace` when the selected interpreter still cannot import the required runtime modules,
+- reuses `scripts/build-openerp-server.sh`, which in turn starts ERP through `scripts/start-openerp-server.sh`,
+- is the same command used by the `ERP: Start runtime` editor task.
+
+### Optional runtime overrides
+
+You can override the same environment values before running `start-erp-runtime`:
+
+```bash
+export ERP_DATABASE=my_dev_db
+export ERP_XMLRPC_PORT=8070
+start-erp-runtime
+```
+
+The defaults match the runtime container flow:
+
+- `ROOT_DIR_SRC=/opt/somenergia/src`
+- `PYENV_VERSION=erp` (with automatic fallback to `2.7.18` if needed)
+- `OPENERP_DB_HOST=postgres`
+- `OPENERP_DB_USER=erp`
+- `OPENERP_DB_PASSWORD=erp`
+- `OPENERP_MONGODB_HOST=mongo`
+- `OPENERP_REDIS_URL=redis://redis:6379/0`
+- `OPENERP_CONFIG=/opt/somenergia/src/openerp_som_addons/runtime-docker/erp.conf`
+
+This matches the devcontainer mount layout: the host workspace `/home/pau/src` is exposed at `/opt/somenergia/src`, while the editor still attaches to `/opt/somenergia/src/openerp_som_addons`.
+
+If you need a different interpreter selection for troubleshooting, override it explicitly before running a helper:
+
+```bash
+export PYENV_VERSION=2.7.18
+start-erp-runtime
+```
+
+## PuDB remote debugging from the devcontainer
+
+This repository already exposes the PuDB remote debugger port through the runtime stack and forwards it in the devcontainer. The devcontainer-only workflow is:
+
+1. Open the devcontainer.
+2. Bootstrap once if needed:
+
+   ```bash
+   bootstrap-erp-workspace
+   ```
+
+3. Start ERP manually:
+
+   ```bash
+   start-erp-runtime
+   ```
+
+4. Add this breakpoint in the code path you want to inspect:
+
+   ```python
+   import pudb.remote
+   pudb.remote.set_trace(host="0.0.0.0", port=6899, term_size=(120, 40))
+   ```
+
+5. Trigger that code path so ERP stops on the remote breakpoint.
+6. Open a second terminal in the same devcontainer and connect to the debugger:
+
+   ```bash
+   telnet 127.0.0.1 6899
+   ```
+
+   If `telnet` is not installed in your environment, try:
+
+   ```bash
+   nc 127.0.0.1 6899
+   ```
+
+7. Use PuDB in the second terminal. When you continue or quit the debugger, ERP resumes in the first terminal.
+
+If you want the instructions printed for quick copy/paste inside the container, run:
+
+```bash
+bash .devcontainer/bin/show-pudb-remote-debug
+```
+
+Or use the editor task `ERP: PuDB remote debugging help`.
+
+## Validation
+
+From the repository root, a lightweight validation is:
+
+```bash
+docker compose \
+  -f runtime-docker/docker-compose.yml \
+  -f .devcontainer/docker-compose.devcontainer.yml \
+  config
+```
+
+This checks that the compose merge is valid without editing or starting the existing runtime files. Use a placeholder token for this validation if you do not want to expose a real token in your shell history:
+
+```bash
+GITHUB_TOKEN=devcontainer-placeholder-token docker compose \
+  -f runtime-docker/docker-compose.yml \
+  -f .devcontainer/docker-compose.devcontainer.yml \
+  config
+```
+
+Inside the repository, shell syntax can also be validated without secrets:
+
+```bash
+bash -n .devcontainer/helpers/common.sh \
+  && bash -n .devcontainer/bin/bootstrap-erp-workspace \
+  && bash -n .devcontainer/bin/start-erp-runtime \
+  && bash -n .devcontainer/bin/show-pudb-remote-debug
+```
+
+The bootstrap/start helpers cannot be fully executed without the running compose services and, for bootstrap, a real `GITHUB_TOKEN` with access to the private repositories.

--- a/.devcontainer/bin/bootstrap-erp-workspace
+++ b/.devcontainer/bin/bootstrap-erp-workspace
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers/common.sh"
+
+wait_for_dependencies
+export_runtime_environment
+
+if workspace_needs_private_repo_access; then
+	require_real_github_token
+else
+	echo "Mounted workspace already contains the private repositories; bootstrap will continue without cloning"
+fi
+
+echo "Bootstrapping ERP workspace into ${ROOT_DIR_SRC} using PYENV_VERSION=${PYENV_VERSION}"
+bootstrap_workspace_sources
+
+if workspace_python_is_ready; then
+	echo "Python environment already satisfies the devcontainer runtime checks (six + destral.utils)"
+	echo "Refreshing editable installs and addon links to keep the mounted workspace aligned"
+else
+	echo "Python environment is incomplete for the mounted workspace; installing missing dependencies"
+fi
+
+install_workspace_python_packages
+export_runtime_environment
+
+if ! workspace_python_is_ready; then
+	echo "Bootstrap completed but Python environment is still missing required imports" >&2
+	echo "Expected imports: six, destral.utils" >&2
+	exit 1
+fi
+
+echo "ERP workspace bootstrap completed"

--- a/.devcontainer/bin/show-pudb-remote-debug
+++ b/.devcontainer/bin/show-pudb-remote-debug
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cat <<'EOF'
+PuDB remote debugging in this devcontainer
+==========================================
+
+1. Open the devcontainer and start ERP manually when you are ready:
+
+   bootstrap-erp-workspace   # first time only
+   start-erp-runtime
+
+2. Add this breakpoint where you want execution to stop:
+
+   import pudb.remote
+   pudb.remote.set_trace(host="0.0.0.0", port=6899, term_size=(120, 40))
+
+3. Make the code path run inside ERP.
+
+4. When execution stops, connect from another terminal attached to the same devcontainer:
+
+   telnet 127.0.0.1 6899
+
+   If telnet is not available, try:
+
+   nc 127.0.0.1 6899
+
+5. Interact with PuDB in that terminal. When you continue/quit the session,
+   ERP resumes in the original terminal.
+
+Notes
+-----
+- Port 6899 is already forwarded by the devcontainer and published by docker compose.
+- Keep bootstrap/start manual. This helper only documents the flow.
+- Use a second terminal for the debugger client so the ERP process can stay attached
+  to the first one.
+EOF

--- a/.devcontainer/bin/start-erp-runtime
+++ b/.devcontainer/bin/start-erp-runtime
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers/common.sh"
+
+wait_for_dependencies
+ensure_workspace_bootstrapped
+export_runtime_environment
+
+if ! workspace_python_is_ready; then
+	echo "Python environment is not ready for ERP startup; running bootstrap-erp-workspace first"
+	bash "${SCRIPT_DIR}/bootstrap-erp-workspace"
+	export_runtime_environment
+fi
+
+echo "Starting ERP runtime for database ${ERP_DATABASE} on port ${ERP_XMLRPC_PORT}"
+prepare_authenticated_omie_requirements
+trap restore_authenticated_omie_requirements EXIT
+bash "${REPO_ROOT}/scripts/build-openerp-server.sh"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "openerp_som_addons runtime",
+  "dockerComposeFile": [
+    "../runtime-docker/docker-compose.yml",
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "erp-runtime",
+  "runServices": [
+    "postgres",
+    "redis",
+    "mongo",
+    "erp-runtime"
+  ],
+  "workspaceFolder": "/opt/somenergia/src/openerp_som_addons",
+  "shutdownAction": "stopCompose",
+  "overrideCommand": false,
+  "containerEnv": {
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN:devcontainer-placeholder-token}"
+  },
+  "remoteEnv": {
+    "PATH": "/opt/somenergia/src/openerp_som_addons/.devcontainer/bin:${containerEnv:PATH}"
+  },
+  "forwardPorts": [8069, 5432, 6899],
+  "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,13 @@
+services:
+  erp-runtime:
+    environment:
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-devcontainer-placeholder-token}
+    entrypoint:
+      - /bin/bash
+      - -lc
+    command:
+      - while sleep 1000; do :; done
+    volumes:
+      - ../..:/opt/somenergia/src:cached
+    tty: true
+    stdin_open: true

--- a/.devcontainer/helpers/common.sh
+++ b/.devcontainer/helpers/common.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEVCONTAINER_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVCONTAINER_DIR="$(dirname "$DEVCONTAINER_HELPERS_DIR")"
+REPO_ROOT="$(dirname "$DEVCONTAINER_DIR")"
+
+ROOT_DIR_SRC="${ROOT_DIR_SRC:-/opt/somenergia/src}"
+ERP_BOOTSTRAP_TIMEOUT="${ERP_BOOTSTRAP_TIMEOUT:-180}"
+ERP_DATABASE="${ERP_DATABASE:-erp_runtime}"
+ERP_XMLRPC_PORT="${ERP_XMLRPC_PORT:-8069}"
+ERP_BIND_ADDRESS="${ERP_BIND_ADDRESS:-0.0.0.0}"
+ERP_HEALTH_TIMEOUT="${ERP_HEALTH_TIMEOUT:-300}"
+ERP_BRANCH="${ERP_BRANCH:-rolling_erp01}"
+OPENERP_DB_USER="${OPENERP_DB_USER:-erp}"
+OPENERP_DB_PASSWORD="${OPENERP_DB_PASSWORD:-erp}"
+PYENV_ROOT="${PYENV_ROOT:-/opt/pyenv}"
+PYENV_BASE_VERSION="${PYENV_BASE_VERSION:-2.7.18}"
+PYENV_DEFAULT_VERSION="${PYENV_DEFAULT_VERSION:-erp}"
+
+DEVCONTAINER_LOCAL_PYTHON_REPOS=(
+	"destral"
+	"libFacturacioATR"
+	"ooop"
+	"OMIE"
+	"cchloader"
+	"gestionatr"
+	"somenergia-generationkwh"
+	"plantmeter"
+	"somenergia-utils"
+)
+
+BOOTSTRAP_CLONED_REPOS=()
+TEMP_OMIE_REQUIREMENTS_BACKUP=""
+
+wait_for_port() {
+	local host="$1"
+	local port="$2"
+	local timeout="$3"
+	local start
+
+	start=$(date +%s)
+	while true; do
+		if nc -z "$host" "$port" >/dev/null 2>&1; then
+			return 0
+		fi
+
+		if [ $(($(date +%s) - start)) -ge "$timeout" ]; then
+			echo "Timeout waiting for ${host}:${port}" >&2
+			return 1
+		fi
+
+		sleep 2
+	done
+}
+
+wait_for_dependencies() {
+	if [ "${DEVCONTAINER_SKIP_WAIT:-0}" = "1" ]; then
+		echo "Skipping dependency wait because DEVCONTAINER_SKIP_WAIT=1"
+		return 0
+	fi
+
+	echo "Waiting for postgres, redis, and mongo"
+	wait_for_port "postgres" "5432" "$ERP_BOOTSTRAP_TIMEOUT"
+	wait_for_port "redis" "6379" "$ERP_BOOTSTRAP_TIMEOUT"
+	wait_for_port "mongo" "27017" "$ERP_BOOTSTRAP_TIMEOUT"
+}
+
+require_real_github_token() {
+	if [ -z "${GITHUB_TOKEN:-}" ] || [ "${GITHUB_TOKEN}" = "devcontainer-placeholder-token" ]; then
+		echo "A real GITHUB_TOKEN is required to bootstrap the ERP workspace." >&2
+		echo "Export GITHUB_TOKEN inside the devcontainer or reopen it with the host token available." >&2
+		return 1
+	fi
+}
+
+has_real_github_token() {
+	[ -n "${GITHUB_TOKEN:-}" ] && [ "${GITHUB_TOKEN}" != "devcontainer-placeholder-token" ]
+}
+
+ensure_workspace_bootstrapped() {
+	if [ ! -d "${ROOT_DIR_SRC}/erp" ]; then
+		echo "ERP workspace not found at ${ROOT_DIR_SRC}/erp" >&2
+		echo "Run .devcontainer/bin/bootstrap-erp-workspace first." >&2
+		return 1
+	fi
+}
+
+ensure_pyenv_runtime() {
+	export PYENV_ROOT
+	export PYENV_VERSION="${PYENV_VERSION:-$PYENV_DEFAULT_VERSION}"
+	export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
+
+	local requested_path="${PYENV_ROOT}/versions/${PYENV_VERSION}"
+	local base_path="${PYENV_ROOT}/versions/${PYENV_BASE_VERSION}"
+
+	if [ "$PYENV_VERSION" = "$PYENV_BASE_VERSION" ]; then
+		return 0
+	fi
+
+	if [ -e "$requested_path" ]; then
+		return 0
+	fi
+
+	if [ -d "$base_path" ]; then
+		echo "Pyenv environment '${PYENV_VERSION}' is not available in the container; falling back to ${PYENV_BASE_VERSION}"
+		export PYENV_VERSION="$PYENV_BASE_VERSION"
+	fi
+}
+
+devcontainer_python_bin() {
+	ensure_pyenv_runtime
+
+	local candidate="${PYENV_ROOT}/versions/${PYENV_VERSION}/bin/python"
+	if [ -x "$candidate" ]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+
+	if command -v python >/dev/null 2>&1; then
+		command -v python
+		return 0
+	fi
+
+	echo "python interpreter not found for PYENV_VERSION=${PYENV_VERSION}" >&2
+	return 1
+}
+
+devcontainer_pip_bin() {
+	ensure_pyenv_runtime
+
+	local candidate="${PYENV_ROOT}/versions/${PYENV_VERSION}/bin/pip"
+	if [ -x "$candidate" ]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+
+	if command -v pip >/dev/null 2>&1; then
+		command -v pip
+		return 0
+	fi
+
+	echo "pip not found for PYENV_VERSION=${PYENV_VERSION}" >&2
+	return 1
+}
+
+devcontainer_python() {
+	local python_bin
+	python_bin="$(devcontainer_python_bin)"
+	"$python_bin" "$@"
+}
+
+devcontainer_pip() {
+	local pip_bin
+	pipefail_return=0
+	pip_bin="$(devcontainer_pip_bin)" || pipefail_return=$?
+	if [ "$pipefail_return" -ne 0 ]; then
+		return "$pipefail_return"
+	fi
+	"$pip_bin" "$@"
+}
+
+append_pythonpath_entry() {
+	local entry="$1"
+	if [ ! -d "$entry" ]; then
+		return 0
+	fi
+
+	case ":${PYTHONPATH:-}:" in
+	*":${entry}:"*) ;;
+	*)
+		if [ -n "${PYTHONPATH:-}" ]; then
+			PYTHONPATH="${entry}:${PYTHONPATH}"
+		else
+			PYTHONPATH="$entry"
+		fi
+		;;
+	esac
+}
+
+export_workspace_pythonpath() {
+	append_pythonpath_entry "${ROOT_DIR_SRC}/erp/server/bin"
+	append_pythonpath_entry "${ROOT_DIR_SRC}/erp/server/bin/addons"
+	append_pythonpath_entry "${ROOT_DIR_SRC}/erp/server/sitecustomize"
+
+	local repo
+	for repo in "${DEVCONTAINER_LOCAL_PYTHON_REPOS[@]}"; do
+		append_pythonpath_entry "${ROOT_DIR_SRC}/${repo}"
+	done
+
+	export PYTHONPATH
+}
+
+python_import_check() {
+	local module_name="$1"
+	devcontainer_python -c "import ${module_name}" >/dev/null 2>&1
+}
+
+workspace_python_is_ready() {
+	ensure_workspace_bootstrapped || return 1
+	export_runtime_environment
+	python_import_check six && python_import_check destral.utils
+}
+
+clone_repo_if_missing() {
+	local destination="$1"
+	local repo_url="$2"
+	local branch="${3:-}"
+
+	if [ -d "$destination/.git" ] || [ -d "$destination" ]; then
+		echo "Keeping existing repository: $destination"
+		return 0
+	fi
+
+	echo "Cloning missing repository into $destination"
+	if [ -n "$branch" ]; then
+		git clone --depth 1 -b "$branch" "$repo_url" "$destination"
+	else
+		git clone --depth 1 "$repo_url" "$destination"
+	fi
+	BOOTSTRAP_CLONED_REPOS+=("$destination")
+}
+
+checkout_latest_tag_if_available() {
+	local repo_path="$1"
+	local cloned_repo
+	local was_cloned=0
+
+	if [ ! -d "$repo_path/.git" ]; then
+		return 0
+	fi
+
+	for cloned_repo in "${BOOTSTRAP_CLONED_REPOS[@]}"; do
+		if [ "$cloned_repo" = "$repo_path" ]; then
+			was_cloned=1
+			break
+		fi
+	done
+
+	if [ "$was_cloned" -ne 1 ]; then
+		return 0
+	fi
+
+	(
+		cd "$repo_path"
+		local latest_tag
+		latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1 2>/dev/null)" 2>/dev/null || true)
+		if [ -n "$latest_tag" ]; then
+			git checkout "$latest_tag"
+		fi
+	)
+}
+
+bootstrap_workspace_sources() {
+	echo "Ensuring ERP workspace sources exist under ${ROOT_DIR_SRC}"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/erp" "https://${GITHUB_TOKEN}@github.com/Som-Energia/erp.git" "$ERP_BRANCH"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/destral" "https://github.com/gisce/destral.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/libFacturacioATR" "https://${GITHUB_TOKEN}@github.com/Som-Energia/libFacturacioATR.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/OMIE" "https://${GITHUB_TOKEN}@github.com/Som-Energia/OMIE.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/omie-modules" "https://${GITHUB_TOKEN}@github.com/Som-Energia/omie-modules.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/somenergia-utils" "https://github.com/Som-Energia/somenergia-utils.git" "py2"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/poweremail2" "https://github.com/Som-Energia/poweremail.git" "v5_backport"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/openerp-sentry" "https://github.com/gisce/openerp-sentry.git" "v5_legacy"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/ws_transactions" "https://github.com/gisce/ws_transactions.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/ir_attachment_mongodb" "https://github.com/gisce/ir_attachment_mongodb.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/mongodb_backend" "https://github.com/gisce/mongodb_backend.git" "gisce"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/poweremail-modules" "https://github.com/gisce/poweremail-modules.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/crm_poweremail" "https://github.com/gisce/crm_poweremail.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/ooop" "https://github.com/gisce/ooop.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/cchloader" "https://${GITHUB_TOKEN}@github.com/Som-Energia/cchloader.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/gestionatr" "https://${GITHUB_TOKEN}@github.com/Som-Energia/gestionatr.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/somenergia-generationkwh" "https://github.com/Som-Energia/somenergia-generationkwh.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/plantmeter" "https://github.com/Som-Energia/plantmeter.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/som_sync_openerp_modules" "https://github.com/Som-Energia/som_sync_openerp_modules.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/giscedata_facturacio_indexada_som" "https://github.com/Som-Energia/giscedata_facturacio_indexada_som.git"
+	clone_repo_if_missing "${ROOT_DIR_SRC}/oorq" "https://github.com/gisce/oorq.git" "api_v5"
+
+}
+
+workspace_needs_private_repo_access() {
+	local repo
+	for repo in erp libFacturacioATR OMIE omie-modules cchloader gestionatr; do
+		if [ ! -d "${ROOT_DIR_SRC}/${repo}" ]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+install_workspace_python_packages() {
+	echo "Preparing Python environment with PYENV_VERSION=${PYENV_VERSION}"
+
+	checkout_latest_tag_if_available "${ROOT_DIR_SRC}/libFacturacioATR"
+	checkout_latest_tag_if_available "${ROOT_DIR_SRC}/ooop"
+	checkout_latest_tag_if_available "${ROOT_DIR_SRC}/OMIE"
+	checkout_latest_tag_if_available "${ROOT_DIR_SRC}/cchloader"
+	checkout_latest_tag_if_available "${ROOT_DIR_SRC}/gestionatr"
+
+	if [ -d "${ROOT_DIR_SRC}/libFacturacioATR" ]; then
+		devcontainer_pip install -e "${ROOT_DIR_SRC}/libFacturacioATR"
+	fi
+	if [ -d "${ROOT_DIR_SRC}/ooop" ]; then
+		devcontainer_pip install -e "${ROOT_DIR_SRC}/ooop"
+	fi
+	if [ -d "${ROOT_DIR_SRC}/OMIE" ]; then
+		devcontainer_pip install --no-build-isolation -e "${ROOT_DIR_SRC}/OMIE"
+	fi
+	if [ -d "${ROOT_DIR_SRC}/cchloader" ]; then
+		devcontainer_pip install --no-build-isolation -e "${ROOT_DIR_SRC}/cchloader"
+	fi
+	if [ -d "${ROOT_DIR_SRC}/gestionatr" ]; then
+		devcontainer_pip install --no-build-isolation -e "${ROOT_DIR_SRC}/gestionatr"
+	fi
+	if [ -d "${ROOT_DIR_SRC}/somenergia-generationkwh" ]; then
+		devcontainer_pip install -e "${ROOT_DIR_SRC}/somenergia-generationkwh" || true
+	fi
+	if [ -d "${ROOT_DIR_SRC}/plantmeter" ]; then
+		devcontainer_pip install -e "${ROOT_DIR_SRC}/plantmeter" || true
+	fi
+	if [ -f "${ROOT_DIR_SRC}/erp/requirements-dev.txt" ]; then
+		devcontainer_pip install lazy-object-proxy==1.6.0
+		devcontainer_pip install -r "${ROOT_DIR_SRC}/erp/requirements-dev.txt"
+	fi
+	if [ -f "${ROOT_DIR_SRC}/erp/requirements.txt" ]; then
+		devcontainer_pip install -r "${ROOT_DIR_SRC}/erp/requirements.txt"
+	fi
+	devcontainer_pip install "rq-scheduler<0.11" "Pympler<0.8" "Flask-RESTful<0.4" "Flask-Login<0.5" "Flask-Cors<3" "Flask-SSE<1.0" "msgpack-python<1.0" "Cerberus<1.3" "cachelib<0.2" "Mako<1.2" "pypdftk<0.5" "paramiko<2.8" "pudb==2019.2"
+	if [ -d "${ROOT_DIR_SRC}/somenergia-utils" ]; then
+		devcontainer_pip install -e "${ROOT_DIR_SRC}/somenergia-utils" || true
+	fi
+	devcontainer_pip install "dm.xmlsec.binding<=1.3.2"
+
+	if [ -x "${ROOT_DIR_SRC}/erp/tools/link_addons.sh" ]; then
+		echo "Linking ERP addons"
+		(
+			cd "${ROOT_DIR_SRC}/erp"
+			bash "tools/link_addons.sh"
+		)
+	fi
+}
+
+prepare_authenticated_omie_requirements() {
+	local requirements_file="${ROOT_DIR_SRC}/omie-modules/giscedata_omie_api/requirements.txt"
+
+	if [ ! -f "$requirements_file" ] || ! has_real_github_token; then
+		return 0
+	fi
+
+	TEMP_OMIE_REQUIREMENTS_BACKUP="$(mktemp)"
+	cp "$requirements_file" "$TEMP_OMIE_REQUIREMENTS_BACKUP"
+	printf '%s\n' "git+https://${GITHUB_TOKEN}@github.com/som-energia/omie.git" >"$requirements_file"
+}
+
+restore_authenticated_omie_requirements() {
+	local requirements_file="${ROOT_DIR_SRC}/omie-modules/giscedata_omie_api/requirements.txt"
+
+	if [ -n "$TEMP_OMIE_REQUIREMENTS_BACKUP" ] && [ -f "$TEMP_OMIE_REQUIREMENTS_BACKUP" ]; then
+		mv "$TEMP_OMIE_REQUIREMENTS_BACKUP" "$requirements_file"
+		TEMP_OMIE_REQUIREMENTS_BACKUP=""
+	fi
+}
+
+export_runtime_environment() {
+	ensure_pyenv_runtime
+	export ROOT_DIR_SRC
+	export ERP_DATABASE
+	export ERP_XMLRPC_PORT
+	export ERP_BIND_ADDRESS
+	export ERP_HEALTH_TIMEOUT
+	export OPENERP_DB_HOST="${OPENERP_DB_HOST:-postgres}"
+	export OPENERP_DB_USER
+	export OPENERP_DB_PASSWORD
+	export OPENERP_MONGODB_HOST="${OPENERP_MONGODB_HOST:-mongo}"
+	export OPENERP_REDIS_URL="${OPENERP_REDIS_URL:-redis://redis:6379/0}"
+	export OPENERP_CONFIG="${OPENERP_CONFIG:-${REPO_ROOT}/runtime-docker/erp.conf}"
+	export_workspace_pythonpath
+}

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,9 @@ patches/
 *.jasper
 
 # VSCode
-.vscode/
+.vscode/*
+!.vscode/
+!.vscode/tasks.json
 
 # Agents
 .engram/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,58 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "ERP: Bootstrap workspace",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-lc",
+        "bootstrap-erp-workspace"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "ERP: Start runtime",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-lc",
+        "start-erp-runtime"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "ERP: PuDB remote debugging help",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        ".devcontainer/bin/show-pudb-remote-debug"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Objectiu

Afegir un workflow de devcontainer per treballar amb `openerp_som_addons` i el workspace complet de `/home/pau/src`, incloent helpers per bootstrap, arrencada manual de l'ERP i suport de depuració amb PuDB.

## Targeta on es demana o Incidència


## Comportament antic

No hi havia una configuració versionada de devcontainer per aquest repo. La posada en marxa depenia del runtime docker existent i de passos manuals no integrats amb l'editor.

## Comportament nou

Hi ha una configuració `.devcontainer/` que:
- reutilitza l'stack existent de `runtime-docker`
- munta el workspace complet sota `/opt/somenergia/src`
- afegeix helpers per bootstrap i arrencada manual de l'ERP
- documenta i facilita el flux de depuració amb `pudb.remote`
- afegeix tasks compartides a `.vscode/tasks.json`

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

