### PR TITLE
⚡️ Millorar la performance de postgres en entorns locals de desenvolupament

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,15 @@ services:
         -c max_parallel_workers=8
         -c max_parallel_workers_per_gather=4
         -c timescaledb.max_background_workers=8
+        -c track_activities=off
+        -c track_counts=off
+        -c track_functions=none
+        -c wal_level=minimal
+        -c synchronous_commit=off
+        -c fsync=off
+        -c max_wal_size=2GB
+        -c min_wal_size=512MB
+        -c max_wal_senders=0
     volumes:
       - erp_db_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## Objectiu
⚡️ Millorar la performance de postgres en entorns locals de desenvolupament

## Targeta on es demana o Incidència
Ya tu sabe

## Comportament antic
Es carregava el postgres normal.

## Comportament nou
Es carrega el postgres amb estadístiques, logs de queries encallades i autovacuum deshabilitats.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds nine PostgreSQL configuration flags to the local development `docker-compose.yaml` to improve query throughput by disabling durability guarantees, statistics collection, and autovacuum. All added flags are correct and internally consistent (e.g. `wal_level=minimal` is paired with the required `max_wal_senders=0`).

- Disables statistics tracking (`track_activities`, `track_counts`, `track_functions`) and autovacuum, reducing background overhead in dev.
- Sets `fsync=off`, `synchronous_commit=off`, and `wal_level=minimal` to skip disk-flush guarantees, substantially speeding up writes at the cost of data durability on unclean shutdown.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for local development use; the settings are correct and well-understood PostgreSQL performance trade-offs.

The flags are internally consistent and appropriate for a local dev environment. The only noteworthy risk is that `fsync=off` with a persistent Docker volume means an unclean host shutdown could leave the database directory unrecoverable, requiring a full volume rebuild.

docker-compose.yaml — the `fsync=off` flag in combination with the persistent `erp_db_data` volume deserves a quick note in developer documentation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker-compose.yaml | Adds 9 PostgreSQL performance flags for local dev: disables fsync, synchronous commit, statistics tracking, and autovacuum; sets WAL to minimal level. Settings are correct and intentional, but `fsync=off` with a persistent volume means a Docker/host crash could corrupt the database directory. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Docker Compose Up] --> B[PostgreSQL starts with new flags]
    B --> C{Write operation}
    C -->|synchronous_commit=off| D[Return success before WAL flush]
    C -->|fsync=off| E[Skip disk sync entirely]
    D & E --> F[Higher write throughput in dev]
    B --> G{Background workers}
    G -->|track_counts=off| H[Autovacuum disabled — no stats]
    G -->|track_activities=off| I[pg_stat_activity.query hidden]
    G -->|track_functions=none| J[Function stats not collected]
    B --> K[wal_level=minimal + max_wal_senders=0]
    K --> L[Logical/streaming replication unavailable]
    F & H & I & J & L --> M[Leaner local dev DB]
    E -->|Unclean host crash| N[⚠️ Volume data may be corrupted]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Docker Compose Up] --> B[PostgreSQL starts with new flags]
    B --> C{Write operation}
    C -->|synchronous_commit=off| D[Return success before WAL flush]
    C -->|fsync=off| E[Skip disk sync entirely]
    D & E --> F[Higher write throughput in dev]
    B --> G{Background workers}
    G -->|track_counts=off| H[Autovacuum disabled — no stats]
    G -->|track_activities=off| I[pg_stat_activity.query hidden]
    G -->|track_functions=none| J[Function stats not collected]
    B --> K[wal_level=minimal + max_wal_senders=0]
    K --> L[Logical/streaming replication unavailable]
    F & H & I & J & L --> M[Leaner local dev DB]
    E -->|Unclean host crash| N[⚠️ Volume data may be corrupted]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["⚡️ improve performance postgres in local..."](https://github.com/som-energia/openerp_som_addons/commit/f8930005975a5faaf963f990f1f37e425fd1e128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39232300)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->