### PR TITLE
🐛 (gurb) Fix get betas gurb

### DIFF
--- a/som_gurb/www/som_gurb_www.py
+++ b/som_gurb/www/som_gurb_www.py
@@ -113,6 +113,7 @@ class SomGurbWww(osv.osv_memory):
             for gcups in gcau.gurb_cups_ids:
                 if gcups.state in occupying_states:
                     beta_remaining -= gcups.beta_kw
+                    beta_remaining -= gcups.gift_beta_kw
                     beta_remaining -= gcups.future_beta_kw
                     beta_remaining -= gcups.future_gift_beta_kw
             available_betas.append(beta_remaining)


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the GURB web beta availability calculation.

- Subtracts active gift betas from remaining CAU capacity.
- Keeps future beta and future gift beta subtraction in the same loop.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The new availability formula can reject valid GURB signups when CAU selection ignores active gift betas.

- Active gift betas are now counted during beta validation.
- The CAU selector used just before validation still omits the same active gift beta capacity.
- That mismatch can choose the wrong CAU and return `BadBeta` instead of allocating to another CAU with room.

som_gurb/www/som_gurb_www.py and the CAU selection capacity calculation
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_gurb/www/som_gurb_www.py | Adds active gift beta consumption to the web availability calculation, creating a mismatch with the CAU selection formula used before new CUPS creation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 (gurb) Fix get betas gurb"](https://github.com/som-energia/openerp_som_addons/commit/96aefdccff40f874648fca1e34d5c3e217e4d546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40054939)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/som-energia/github/Som-Energia/openerp_som_addons/-/custom-context?memory=73910dc8-2bf7-4f16-a448-409dbfed562b))
- Context used - .agents/skill-registry.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=046da57a-a39f-4238-9b9a-7553fe2716e9))
- Context used - docs/external_repos.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=ed414071-cc85-485a-bd45-d7cf0caa01a8))
- Context used - docs/tech.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=06dde590-4bd4-4d07-8a39-88b9ac3063e2))
</details>

<!-- /greptile_comment -->