### PR TITLE
🐛 Invoice pending emails must only go to customer invoices

### DIFF
--- a/som_account_invoice_pending/models/update_pending_states.py
+++ b/som_account_invoice_pending/models/update_pending_states.py
@@ -63,10 +63,13 @@ class UpdatePendingStates(osv.osv_memory):
 
     def get_invoices_with_pending_state(self, cursor, uid, pending_state):
         """
-        Return invoices (giscedata factura) with the given pending state
+        Return customer invoices (giscedata factura) with the given pending state
         """
         fact_obj = self.pool.get("giscedata.facturacio.factura")
-        factura_ids = fact_obj.search(cursor, uid, [("pending_state", "=", pending_state)])
+        factura_ids = fact_obj.search(cursor, uid, [
+            ("pending_state", "=", pending_state),
+            ("type", "in", ["out_invoice", "out_refund"])
+        ])
         return factura_ids
 
     def get_from_email(self, cursor, uid, template_id):

--- a/som_account_invoice_pending/tests/update_pending_states_tests.py
+++ b/som_account_invoice_pending/tests/update_pending_states_tests.py
@@ -1061,3 +1061,49 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
         self.assertIn("(auto.): Enviat correu recordatori R1.", factura_dp.comment)
         factura_bs = fact_obj.browse(cursor, uid, fact_bs_id)
         self.assertIn("(auto.): Enviat correu recordatori R1.", factura_bs.comment)
+
+    def test__get_invoices_with_pending_state__excludes_in_invoice(self):
+        cursor = self.txn.cursor
+        uid = self.txn.user
+
+        imd_obj = self.pool.get("ir.model.data")
+        pending_obj = self.pool.get("update.pending.states")
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        fue_dp_state = imd_obj.get_object_reference(
+            cursor, uid, "som_account_invoice_pending", "fue_default_pending_state"
+        )[1]
+        fact_id = imd_obj.get_object_reference(
+            cursor, uid, "som_account_invoice_pending", "factura_00011"
+        )[1]
+        invoice_id = fact_obj.read(cursor, uid, fact_id, ["invoice_id"])["invoice_id"][0]
+
+        inv_obj.write(cursor, uid, [invoice_id], {"type": "in_invoice"})
+
+        factura_ids = pending_obj.get_invoices_with_pending_state(cursor, uid, fue_dp_state)
+
+        self.assertNotIn(fact_id, factura_ids)
+
+    def test__get_invoices_with_pending_state__includes_out_refund(self):
+        cursor = self.txn.cursor
+        uid = self.txn.user
+
+        imd_obj = self.pool.get("ir.model.data")
+        pending_obj = self.pool.get("update.pending.states")
+        inv_obj = self.pool.get("account.invoice")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+
+        r1_dp_state = imd_obj.get_object_reference(
+            cursor, uid, "som_account_invoice_pending", "default_reclamacio_en_curs_pending_state"
+        )[1]
+        fact_id = imd_obj.get_object_reference(
+            cursor, uid, "som_account_invoice_pending", "factura_00013"
+        )[1]
+        invoice_id = fact_obj.read(cursor, uid, fact_id, ["invoice_id"])["invoice_id"][0]
+
+        inv_obj.write(cursor, uid, [invoice_id], {"type": "out_refund"})
+
+        factura_ids = pending_obj.get_invoices_with_pending_state(cursor, uid, r1_dp_state)
+
+        self.assertIn(fact_id, factura_ids)


### PR DESCRIPTION
## Objectiu
Que només s'enviin els mails de factures pendents (pending_state, etc) a factures de client per evitar sustos

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8184116?folder_id=87

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR limits pending-invoice email selection to customer invoices. The main changes are:

- Adds an invoice type filter to pending-state invoice lookup.
- Keeps outgoing refunds included in the email flow.
- Adds tests for supplier-invoice exclusion and refund inclusion.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The changed lookup is mergeable after checking how factura `type` stays synchronized.

- The new filter matches the intended customer-invoice scope.
- A stale or missing factura-side `type` can make valid pending customer invoices disappear from reminder email flows.
- The tests cover changed invoice types through the linked accounting invoice, but production rows with stale stored values still need attention.

som_account_invoice_pending/models/update_pending_states.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_account_invoice_pending/models/update_pending_states.py | Adds a customer-invoice type filter to the pending-state invoice search. |
| som_account_invoice_pending/tests/update_pending_states_tests.py | Adds regression tests for excluding supplier invoices and including outgoing refunds. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 Invoice pending emails must only go t..."](https://github.com/som-energia/openerp_som_addons/commit/c46b50bb60587756fa77422ec2539a99551910e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41057591)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/som-energia/github/Som-Energia/openerp_som_addons/-/custom-context?memory=73910dc8-2bf7-4f16-a448-409dbfed562b))
- Context used - docs/external_repos.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=ed414071-cc85-485a-bd45-d7cf0caa01a8))
- Context used - docs/patterns/test-basic.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=e4d219c4-b316-4627-b039-956a82ce39a6))
</details>

<!-- /greptile_comment -->