### PR TITLE
Eliminar llistat de Detall de descomptes generats i aplicats del Flux solar

### DIFF
--- a/som_facturacio_flux_solar/giscedata_bateria_virtual.xml
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual.xml
@@ -56,5 +56,15 @@
         <record id="giscedata_facturacio_bateria_virtual.value_giscedata_import_bateria_virtual_polissa" model="ir.values">
             <field name="name">Detall sols generats i aplicats</field>
         </record>
+
+        <record id="giscedata_facturacio_bateria_virtual.act_detall_descompte_per_bat"
+                model="ir.actions.act_window">
+            <field name="src_model"/>
+        </record>
+
+        <record id="giscedata_facturacio_bateria_virtual.value_detall_descomptes_per_bateria"
+                model="ir.values">
+            <field name="model"/>
+        </record>
     </data>
 </openerp>

--- a/som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0001_update_view_to_remove_value.py
+++ b/som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0001_update_view_to_remove_value.py
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+from __future__ import absolute_import
+
 from tools import config
 from oopgrade.oopgrade import MigrationHelper
 

--- a/som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0001_update_view_to_remove_value.py
+++ b/som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0001_update_view_to_remove_value.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+from tools import config
+from oopgrade.oopgrade import MigrationHelper
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return None
+
+    module = 'som_facturacio_flux_solar'
+    xml_file = 'giscedata_bateria_virtual.xml'
+    mh = MigrationHelper(cursor, module_name=module)
+    mh.update_xml(xml_path=xml_file)
+    return True
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu

Eliminar llistat de Detall de descomptes generats i aplicats del Flux solar

## Targeta on es demana o Incidència

[256356]

## Comprovacions

- [x] Actualitzar mòdul - som_facturacio_switching
- [x] Script de migració - post-0001_update_view_to_remove_value


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the Flux Solar discount-detail related listing. The main changes are:

- Clears the related action source model in the battery virtual XML.
- Clears the related `ir.values` model binding.
- Adds a post-migration to reload the XML during upgrades.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small cleanup to fully disable the related value binding.

- The migration path follows an existing XML reload pattern.
- The remaining concern is limited to a stale `ir.values` binding that may still be discoverable in less strict lookup paths.

som_facturacio_flux_solar/giscedata_bateria_virtual.xml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_facturacio_flux_solar/giscedata_bateria_virtual.xml | Updates existing action and value records to remove the discount-detail related listing. |
| som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0001_update_view_to_remove_value.py | Adds a guarded post-migration that reloads the changed XML file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["removes value (link) from flux\_solar"](https://github.com/som-energia/openerp_som_addons/commit/d5e754953b0affdbd2d84e227e536e862484e9d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41057684)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/som-energia/github/Som-Energia/openerp_som_addons/-/custom-context?memory=73910dc8-2bf7-4f16-a448-409dbfed562b))
- Context used - docs/patterns/view-extend.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=6f795fce-9b26-4233-b182-e53e9fa08cc4))

<!-- /greptile_comment -->