### PR TITLE
🐛 Fix 11 mesos mod 330

### DIFF
--- a/som_account_invoice_pending/models/update_pending_states.py
+++ b/som_account_invoice_pending/models/update_pending_states.py
@@ -1041,7 +1041,7 @@ class UpdatePendingStates(osv.osv_memory):
             date_fue = datetime.strptime(fact.pending_state_date, "%Y-%m-%d %H:%M:%S")
             date_diff = datetime.today() - date_fue
 
-            if date_diff.days % 330 == 0:
+            if date_diff.days and date_diff.days % 330 == 0:
                 ret_value = self.send_email(cursor, uid, factura_id, email_params)
                 if ret_value == -1:
                     logger.info(
@@ -1086,7 +1086,7 @@ class UpdatePendingStates(osv.osv_memory):
             date_r1 = datetime.strptime(fact.pending_state_date, "%Y-%m-%d %H:%M:%S")
             date_diff = datetime.today() - date_r1
 
-            if date_diff.days % 330 == 0:
+            if date_diff.days and date_diff.days % 330 == 0:
                 ret_value = self.send_email(cursor, uid, factura_id, email_params)
                 if ret_value == -1:
                     logger.info(


### PR DESCRIPTION
## Objectiu
Que s'enviin realment cada 11 mesos, i no avui i també cada 11 mesos xd

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8184586?folder_id=87

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a bug where the FUE and R1 reminder emails were incorrectly sent on day 0 (the same day an invoice entered the pending state) because `0 % 330 == 0` evaluates to `True` in Python.

- Both `send_fue_reminder_emails` and `send_r1_reminder_emails` now guard the modulo check with `date_diff.days and ...`, preventing the email from firing when `days == 0`.
- The existing tests use demo data at exactly 330 days, so they continue to pass; however, no new test was added to cover the day-0 regression case that this PR fixes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The two-line change is minimal and correct — the day-0 short-circuit is the right fix. No existing tests are broken.

The fix itself is straightforward and addresses the root cause cleanly. The only gap is that no test was added to pin the day-0 behaviour, leaving the corrected path unguarded against future regressions.

som_account_invoice_pending/models/update_pending_states.py — the fix is correct, but a complementary test covering the day-0 case would strengthen confidence.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_account_invoice_pending/models/update_pending_states.py | Two identical one-line fixes: both reminder methods now skip day-0 emails by short-circuiting `date_diff.days and date_diff.days % 330 == 0`. No regression in existing tests; day-0 regression path is not yet covered by a test. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[send_fue/r1_reminder_emails called] --> B[For each factura_id]
    B --> C[Compute date_diff = today - pending_state_date]
    C --> D{date_diff.days != 0?}
    D -- "No (day 0)\nBefore fix: email sent\nAfter fix: skip" --> E[Skip — no email]
    D -- Yes --> F{date_diff.days % 330 == 0?}
    F -- No --> G[Skip — not a 330-day interval]
    F -- Yes --> H[send_email]
    H --> I{Success?}
    I -- No --> J[Log error]
    I -- Yes --> K[Update factura comment]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[send_fue/r1_reminder_emails called] --> B[For each factura_id]
    B --> C[Compute date_diff = today - pending_state_date]
    C --> D{date_diff.days != 0?}
    D -- "No (day 0)\nBefore fix: email sent\nAfter fix: skip" --> E[Skip — no email]
    D -- Yes --> F{date_diff.days % 330 == 0?}
    F -- No --> G[Skip — not a 330-day interval]
    F -- Yes --> H[send_email]
    H --> I{Success?}
    I -- No --> J[Log error]
    I -- Yes --> K[Update factura comment]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 Fix 11 mesos mod 330"](https://github.com/som-energia/openerp_som_addons/commit/05a61a252460af676c3809bac94b609ec94ff89a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41312808)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->