### PR TITLE
fix(som_account_invoice_pending): make migration parse on python 3

### DIFF
--- a/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
+++ b/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
@@ -57,7 +57,7 @@ def up(cursor, installed_version):
                 '''
                 cursor.execute(sql_select, (att_id,))
                 for data in cursor.dictfetchall():
-                    print data
+                    logger.debug('Attachment datas_mongo fetched for %s', att_id)
                     datas_mongo = data['datas_mongo']
 
                 search_vals = [


### PR DESCRIPTION
## Objectiu

Make the `som_account_invoice_pending` migration script compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1363

## Comportament antic

The migration script used a Python 2 style `print` statement, so `python3 -m compileall -q -f som_account_invoice_pending` failed to parse the module.

## Comportament nou

The migration keeps the same behavior but now uses module logging instead of a Python 2 `print` statement, so the module parses correctly under Python 3.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

## Resum

- replace the Python 2 print statement in the migration script
- keep the change scoped to the reported Python 3 blocker
- verify `python3 -m compileall -q -f som_account_invoice_pending`

## Canvis

| File | Change |
|------|--------|
| `som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py` | Replace the Python 2 print statement with module logging for Python 3 parsing compatibility |

## Verificació

- [x] `python3 -m compileall -q -f som_account_invoice_pending`
- [x] `pre-commit run --files som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py`
- [ ] Module runtime tests in a fully prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes Python 3 parsing compatibility in the `som_account_invoice_pending` migration script by replacing a bare `print data` statement (Python 2 syntax) with a `logger.debug(...)` call, allowing `python3 -m compileall` to parse the module without errors.

- The module-level `logger` was already defined on line 5 (`logging.getLogger('openerp.' + __name__)`), so no new imports are required.
- The new log message records that a fetch occurred for a given `att_id`, but unlike the original `print data`, it does not log the fetched dictionary contents.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line swap that restores Python 3 parseability with no logic impact.

The only change is replacing a Python 2 print statement with a logger.debug call. The module-level logger was already in place, so no new infrastructure is needed and the migration logic is untouched. The replacement message omits the fetched row data that the original print showed, which is a minor observability regression worth noting but not blocking.

No files require special attention; the single changed line is straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py | Replaces a Python 2 `print data` statement with a `logger.debug(...)` call; logger was already initialised at module level, so no new imports are needed. The new message logs `att_id` but omits the actual fetched `data` dict that the old print showed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Migration as up()
    participant DB as PostgreSQL cursor
    participant Logger as logging

    Migration->>DB: "dictfetchall() SELECT datas_mongo WHERE id = att_id"
    DB-->>Migration: rows
    alt row returned
        Migration->>Logger: debug(Attachment datas_mongo fetched for att_id)
        Note over Migration: datas_mongo = data[datas_mongo]
        Migration->>DB: "UPDATE ir_attachment SET datas_mongo WHERE id = att_ids[0]"
        Migration->>Logger: info(Attachments actualitzat)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Migration as up()
    participant DB as PostgreSQL cursor
    participant Logger as logging

    Migration->>DB: "dictfetchall() SELECT datas_mongo WHERE id = att_id"
    DB-->>Migration: rows
    alt row returned
        Migration->>Logger: debug(Attachment datas_mongo fetched for att_id)
        Note over Migration: datas_mongo = data[datas_mongo]
        Migration->>DB: "UPDATE ir_attachment SET datas_mongo WHERE id = att_ids[0]"
        Migration->>Logger: info(Attachments actualitzat)
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(som\_account\_invoice\_pending): make m..."](https://github.com/som-energia/openerp_som_addons/commit/da437bcb45b03cda59b3e84ff64711dc87ea5965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41324482)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->