### PR TITLE
fix(som_gurb): make migration parse on python 3

### DIFF
--- a/som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py
+++ b/som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py
@@ -33,7 +33,7 @@ def up(cursor, installed_version):
         wf_service.trg_create(uid, 'som.gurb.cups', gurb_cups.id, cursor)
         gurb_cups.send_signal('button_create_cups')
         gurb_cups.send_signal('button_activate_cups')
-        print sgc_obj.read(cursor, uid, gurb_cups.id, ['state'])
+        print(sgc_obj.read(cursor, uid, gurb_cups.id, ['state']))
 
     # Update XMLs
     views = [


### PR DESCRIPTION
## Objectiu

Make the `som_gurb` migration script compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1367

## Comportament antic

The migration used a Python 2 style `print` statement, so `python3 -m compileall -q -f som_gurb` failed to parse the module.

## Comportament nou

The migration now uses Python 3 compatible print syntax, so the module parses correctly under Python 3.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

## Resum

- replace the legacy Python 2 print statement in the migration
- keep the scope limited to the reported parser blocker
- verify `python3 -m compileall -q -f som_gurb`

## Canvis

| File | Change |
|------|--------|
| `som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py` | Convert the legacy Python 2 print statement to Python 3 syntax |

## Verificació

- [x] `python3 -m compileall -q -f som_gurb`
- [x] `pre-commit run --files som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py`
- [ ] Module runtime tests in a fully prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Python 3 parse failure in a `som_gurb` migration script by converting a Python 2 bare `print` statement to a Python 3 `print()` function call.

- **Single-line change**: `print sgc_obj.read(...)` → `print(sgc_obj.read(...))` in `som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py`, making the module parseable under Python 3.
- **Scope**: Intentionally minimal — only the reported parser blocker is addressed; no other logic is altered.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line syntax fix with no impact on migration logic or data.

Only one line changes: a bare print statement becomes a print() call. The migration logic, workflow signals, and XML reloads are all untouched. The fix directly resolves the reported compileall failure and introduces no new risk.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py | Converts bare Python 2 `print` statement to `print()` function call; the rest of the migration logic is unchanged. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["up(cursor, installed_version)"] --> B{installed_version?}
    B -- No --> C[return]
    B -- Yes --> D[_auto_init som.gurb.cups & wizard]
    D --> E["SELECT ids without wkf_instance"]
    E --> F["Browse gurb_cups records"]
    F --> G["For each: trg_create workflow"]
    G --> H["send_signal button_create_cups"]
    H --> I["send_signal button_activate_cups"]
    I --> J["print state — Python 3 fix ✓"]
    J --> F
    F -- done --> K["load_data XML views"]
    K --> L[End]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["up(cursor, installed_version)"] --> B{installed_version?}
    B -- No --> C[return]
    B -- Yes --> D[_auto_init som.gurb.cups & wizard]
    D --> E["SELECT ids without wkf_instance"]
    E --> F["Browse gurb_cups records"]
    F --> G["For each: trg_create workflow"]
    G --> H["send_signal button_create_cups"]
    H --> I["send_signal button_activate_cups"]
    I --> J["print state — Python 3 fix ✓"]
    J --> F
    F -- done --> K["load_data XML views"]
    K --> L[End]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(som\_gurb): make migration parse on p..."](https://github.com/som-energia/openerp_som_addons/commit/56e9152623630387bb586f26ecb3b9de43e9bfb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41325107)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->