### PR TITLE
fix(som_municipal_taxes): make migration script parse on python 3

### DIFF
--- a/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
+++ b/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
@@ -51,7 +51,7 @@ def crear_ajuntament_config(fila):
 
     municipi_id = erp.ResMunicipi.search([('name', 'ilike', nom)])
     if not municipi_id:
-        print "No s'ha pogut crear: {}".format(fila['ajuntament'])
+        print("No s'ha pogut crear: {}".format(fila['ajuntament']))
         return False
 
     vals = {
@@ -93,19 +93,19 @@ def carrega_ajuntaments(filename):
                 result = crear_ajuntament_config(fila)
             except Exception as e:
                 result = False
-                print "No s'ha pogut crear: {}. Error: {}".format(fila['ajuntament'], str(e))
+                print("No s'ha pogut crear: {}. Error: {}".format(fila['ajuntament'], str(e)))
 
             if result:
                 creats.append(fila['ajuntament'])
             else:
                 no_creats.append(fila['ajuntament'])
 
-    print "Creats {}".format(len(creats))
-    print "No Creats {}".format(len(no_creats))
+    print("Creats {}".format(len(creats)))
+    print("No Creats {}".format(len(no_creats)))
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print u"Usage: {} <fitxer.csv>".format(sys.argv[0])
+        print(u"Usage: {} <fitxer.csv>".format(sys.argv[0]))
         sys.exit()
     carrega_ajuntaments(sys.argv[1])


### PR DESCRIPTION
## Objectiu

Make the `som_municipal_taxes` migration helper script compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1366

## Comportament antic

The helper script used Python 2 style `print` statements, so `python3 -m compileall -q -f som_municipal_taxes` failed to parse the module.

## Comportament nou

The helper script now uses Python 3 compatible print syntax, so the module parses correctly under Python 3.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

## Resum

- convert the legacy Python 2 print statements in the helper script
- keep the scope limited to parser compatibility
- verify `python3 -m compileall -q -f som_municipal_taxes`

## Canvis

| File | Change |
|------|--------|
| `som_municipal_taxes/migrations/script_creacio_ajuntaments.py` | Convert legacy Python 2 print statements to Python 3 syntax |

## Verificació

- [x] `python3 -m compileall -q -f som_municipal_taxes`
- [x] `pre-commit run --files som_municipal_taxes/migrations/script_creacio_ajuntaments.py`
- [ ] Runtime execution with a real CSV in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ports the `script_creacio_ajuntaments.py` migration helper from Python 2 print statements to Python 3 `print()` calls, fixing parse failures under `python3 -m compileall`. The scope is correctly limited to syntax-level compatibility.

- Five `print` statements are converted to `print()` function calls — all conversions are correct.
- The `open(filename, 'rb')` binary-mode call was not updated; `csv.DictReader` requires a text-mode file object in Python 3, so runtime execution would raise a `TypeError` on the very first iteration of the CSV.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The print-statement conversions are correct and achieve compile-time compatibility, but the untouched open(..., 'rb') call means the script will crash immediately at runtime under Python 3 — the goal stated in the PR is only partially met.

Binary-mode file opening with csv.DictReader is a known Python 3 incompatibility that will raise a TypeError on the first CSV row. The PR converts print statements but misses this equally necessary change, leaving runtime execution broken even after the fix is merged.

som_municipal_taxes/migrations/script_creacio_ajuntaments.py — the open call on line 87 needs to switch from 'rb' to 'r' (with newline='' and an explicit encoding).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| som_municipal_taxes/migrations/script_creacio_ajuntaments.py | Converts five Python 2 print statements to print() calls (correct), but leaves open(filename, 'rb') which causes a TypeError when csv.DictReader iterates bytes under Python 3 — runtime execution will fail. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `som_municipal_taxes/migrations/script_creacio_ajuntaments.py`, line 87 ([link](https://github.com/som-energia/openerp_som_addons/blob/963a621d27ddeac61d445252e5b6e5c6fa91bf99/som_municipal_taxes/migrations/script_creacio_ajuntaments.py#L87)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The file is still opened in binary mode (`'rb'`), which causes a `TypeError` when `csv.DictReader` tries to iterate it under Python 3 — the csv module expects text-mode file objects, not `bytes` iterators. Since the rest of the PR is already porting to Python 3, this should be fixed here too. The `encoding` keyword and `newline=''` (as recommended by the Python 3 csv docs) should be specified explicitly.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(som\_municipal\_taxes): make migration..."](https://github.com/som-energia/openerp_som_addons/commit/963a621d27ddeac61d445252e5b6e5c6fa91bf99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41325516)</sub>

<!-- /greptile_comment -->