### PR TITLE
fix(som_estalvi): make accented keys parse on python 3

### DIFF
--- a/som_estalvi/models/report_backend_som_estalvi.py
+++ b/som_estalvi/models/report_backend_som_estalvi.py
@@ -22,6 +22,11 @@ class ReportBackendSomEstalvi(ReportBackend):
         ('potencia', 'optimizations', 'optimal_powers_P6'): 3,
     }
 
+    def _get_py2_py3_compatible_value(self, data_dict, key):
+        if key in data_dict:
+            return data_dict[key]
+        return data_dict[key.encode('utf-8')]
+
     def get_lang(self, cursor, uid, record_id, context=None):
         if context is None:
             context = {}
@@ -189,9 +194,10 @@ class ReportBackendSomEstalvi(ReportBackend):
         )[pol.id]
 
         data["energia"] = dades_factures['Energia activa'] + dades_factures['MAG']
-        data["exces"] = dades_factures[b'Excés potència']
-        data["potencia"] = dades_factures[b'Potència']
-        data["reactiva"] = dades_factures[b'Penalització reactiva']
+        data["exces"] = self._get_py2_py3_compatible_value(dades_factures, u'Excés potència')
+        data["potencia"] = self._get_py2_py3_compatible_value(dades_factures, u'Potència')
+        data["reactiva"] = self._get_py2_py3_compatible_value(
+            dades_factures, u'Penalització reactiva')
         data["descompte_generacio"] = dades_factures['Flux Solar'] + dades_factures['Excedents']
 
         return data


### PR DESCRIPTION
## Objectiu

Make the `som_estalvi` report backend compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1364

## Comportament antic

The report backend accessed invoice fields through non-ASCII bytes literals, which are invalid in Python 3 and caused `python3 -m compileall -q -f som_estalvi` to fail.

## Comportament nou

The report backend now performs an explicit Python 2 / Python 3 compatible lookup for those invoice field keys, so the module parses correctly under Python 3 while keeping the existing field access behavior.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

## Resum

- replace the invalid non-ASCII bytes key lookups
- add a small compatibility helper for unicode/bytes key access
- verify `python3 -m compileall -q -f som_estalvi`

## Canvis

| File | Change |
|------|--------|
| `som_estalvi/models/report_backend_som_estalvi.py` | Replace invalid non-ASCII bytes key lookups with an explicit Python 2 / Python 3 compatible helper |

## Verificació

- [x] `python3 -m compileall -q -f som_estalvi`
- [x] `pre-commit run --files som_estalvi/models/report_backend_som_estalvi.py`
- [ ] Runtime module tests in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Python 3 compile-time error in `som_estalvi`: the old code used non-ASCII bytes literals (`b'Excés potència'` etc.) which are a `SyntaxError` in Python 3, causing `python3 -m compileall` to fail. The fix introduces a small compatibility helper that tries the unicode key first (works in Python 3 where `find_invoices` returns `str` keys) and falls back to the UTF-8-encoded bytes representation (needed in Python 2 where the same wizard returns `bytes` keys).

- Replaces three `b'...'` non-ASCII bytes key lookups with calls to `_get_py2_py3_compatible_value`, which is correct: in Python 2 the hash mismatch between the unicode key and the bytes keys means `key in data_dict` returns `False` safely, and the `.encode('utf-8')` fallback produces the matching bytes key.
- The `find_invoices` source in `som_facturacio_comer/wizard/wizard_informe_factures_dades_desagregades.py` confirms the dict is built with plain string literals (no `unicode_literals` import), so under Python 2 its keys are `bytes` and under Python 3 they are `str` — matching both branches of the helper.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a narrow, targeted fix to a compile-time parse failure; the helper logic is correct for both Python runtimes and the only gap is a minor debuggability concern on missing keys.

The compatibility helper works correctly in both Python 2 and Python 3: in Python 2 the hash mismatch between the unicode key and the bytes dict keys means `key in data_dict` safely returns `False` without raising, and `key.encode('utf-8')` produces the exact bytes stored by `find_invoices`. In Python 3 the first branch succeeds directly. The only open item is that a missing-key `KeyError` exposes a bytes object instead of the readable unicode string, which could slow down debugging if a key drifts in `find_invoices`.

No files require special attention beyond the single-line suggestion on the helper.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_estalvi/models/report_backend_som_estalvi.py | Adds `_get_py2_py3_compatible_value` helper and replaces three non-ASCII bytes key lookups; logic is correct but the fallback path surfaces a bytes `KeyError` on missing keys which is harder to debug. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get_costs() calls find_invoices()"] --> B["dades_factures dict returned\n(bytes keys in Py2, str keys in Py3)"]
    B --> C["_get_py2_py3_compatible_value(dades_factures, u'Excés potència')"]
    C --> D{key in data_dict?}
    D -- "Yes (Python 3: str keys match)" --> E["return data_dict[key]"]
    D -- "No (Python 2: bytes keys, hash mismatch)" --> F["return data_dict[key.encode('utf-8')]"]
    F --> G["Returns bytes-keyed value"]
    E --> H["Assigns to data['exces'] / data['potencia'] / data['reactiva']"]
    G --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["get_costs() calls find_invoices()"] --> B["dades_factures dict returned\n(bytes keys in Py2, str keys in Py3)"]
    B --> C["_get_py2_py3_compatible_value(dades_factures, u'Excés potència')"]
    C --> D{key in data_dict?}
    D -- "Yes (Python 3: str keys match)" --> E["return data_dict[key]"]
    D -- "No (Python 2: bytes keys, hash mismatch)" --> F["return data_dict[key.encode('utf-8')]"]
    F --> G["Returns bytes-keyed value"]
    E --> H["Assigns to data['exces'] / data['potencia'] / data['reactiva']"]
    G --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(som\_estalvi): make accented keys par..."](https://github.com/som-energia/openerp_som_addons/commit/5a710feb8fabbcff4d15d55f8d6953b1a5481be5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41326595)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->