### PR TITLE
fix(giscedata_facturacio_comer_som): make parser blockers python 3 compatible

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -3784,6 +3784,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
         excess_data = []
         showing_periods = self.get_matrix_show_periods(pol)
+        power_excess_change_date = datetime(2025, 4, 1)
 
         for excess_lines in excess_lines_data:
             items = {}
@@ -3800,7 +3801,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 items["date_from"] = excess_lines["date_from"]
                 items["date_to"] = excess_lines["date_to"]
                 items["pre_2025_04_01"] = datetime.strptime(
-                    excess_lines["date_to"], "%d/%m/%Y") < datetime(2025, 04, 1)
+                    excess_lines["date_to"], "%d/%m/%Y") < power_excess_change_date
                 items["iva"] = excess_lines["iva"]
             excess_data.append(items)
         data = {

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -184,22 +184,11 @@ class Tests_FacturacioFacturaReport_logo_component(Tests_FacturacioFacturaReport
         f_id = self.get_fixture("giscedata_facturacio", "factura_0001")
         self.get_fixture("giscedata_polissa", "polissa_0001")
 
-        print "+-" * 50  # noqa: E999
-        print f.polissa_id  # noqa: F821
-        print f.polissa_id.soci  # noqa: F821
-        print f.polissa_id.id  # noqa: F821
-
         p = self.partner_obj.browse(self.cursor, self.uid, 23)
         self.partner_obj.write(self.cursor, self.uid, p.id, {"ref": "S019753"})
-        print "*" * 50
-        print p
-        print p.ref
 
         with patch("soci") as polissa:
             polissa.return_value = "S019753"
-
-            print "*" * 50
-            print f.polissa_id.soci  # noqa: F821
 
             result = self.r_obj.get_component_logo_data(**self.bfp(f_id))
             self.assertYamlfy(result)


### PR DESCRIPTION
## Objectiu

Make the `giscedata_facturacio_comer_som` parser blockers compatible with Python 3.

## Targeta on es demana o Incidència

Closes #1365

## Comportament antic

The module failed `python3 -m compileall -q -f giscedata_facturacio_comer_som` because it contained a leading-zero integer literal in the report code and legacy Python 2 print statements in the targeted test file.

## Comportament nou

The cutoff date keeps the same business behavior with a named constant using valid Python 3 syntax, and the skipped test no longer contains legacy Python 2 print statements or debug noise.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

## Resum

- replace the invalid leading-zero integer literal in the report code
- name the power excess cutoff date to keep the touched logic reviewable
- remove legacy debug print statements from the skipped test and keep the file parseable under Python 3

## Canvis

| File | Change |
|------|--------|
| `giscedata_facturacio_comer_som/giscedata_facturacio_report.py` | Replace the invalid integer literal with a named Python 3 compatible cutoff date |
| `giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py` | Remove legacy Python 2 debug print statements from the skipped test |

## Verificació

- [x] `python3 -m compileall -q -f giscedata_facturacio_comer_som`
- [x] `pre-commit run --files giscedata_facturacio_comer_som/giscedata_facturacio_report.py giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py`
- [ ] Runtime module tests in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two Python 3 compilation blockers in `giscedata_facturacio_comer_som`: an invalid leading-zero integer literal in a `datetime` call and legacy Python 2 `print` statements in a skipped test. No business logic is changed.

- **`giscedata_facturacio_report.py`**: `datetime(2025, 04, 1)` (octal-style `04` is a `SyntaxError` in Python 3) is replaced by extracting `power_excess_change_date = datetime(2025, 4, 1)` as a named constant before the loop, keeping the `pre_2025_04_01` comparison semantically identical.
- **`tests/tests_FacturacioFacturaReport_some.py`**: Eleven Python 2 bare-`print` debug lines are removed from the `@unittest.skip`-ped `test__som_report_comp_logo__energetica_mock`; no assertions are affected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are mechanical syntax fixes with no business-logic impact; safe to merge.

The report fix correctly replaces the octal-style literal with a valid Python 3 constant whose value is identical, and moves its construction outside the loop. The test cleanup only removes debug prints from an already-skipped test, leaving all assertions intact. No regressions are possible from either change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| giscedata_facturacio_comer_som/giscedata_facturacio_report.py | Extracts the invalid leading-zero octal literal datetime(2025, 04, 1) into a named power_excess_change_date constant — fixes the Python 3 syntax error and moves object construction out of the loop. |
| giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py | Removes eleven Python 2 print statement lines from a @unittest.skip-ped test, making the file parseable under Python 3 without changing any test assertions or logic. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_sub_component_power_excess_data] --> B[get_sub_component_invoice_details_td]
    B --> C{excess_lines_data}
    A --> D[power_excess_change_date = datetime 2025-04-01]
    C -->|iterate| E[build items dict]
    E --> F["datetime.strptime(date_to) < power_excess_change_date"]
    F -->|True| G["pre_2025_04_01 = True"]
    F -->|False| H["pre_2025_04_01 = False"]
    G --> I[append to excess_data]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[get_sub_component_power_excess_data] --> B[get_sub_component_invoice_details_td]
    B --> C{excess_lines_data}
    A --> D[power_excess_change_date = datetime 2025-04-01]
    C -->|iterate| E[build items dict]
    E --> F["datetime.strptime(date_to) < power_excess_change_date"]
    F -->|True| G["pre_2025_04_01 = True"]
    F -->|False| H["pre_2025_04_01 = False"]
    G --> I[append to excess_data]
    H --> I
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(giscedata\_facturacio\_comer\_som): mak..."](https://github.com/som-energia/openerp_som_addons/commit/c24b15e7050210859758cf7c5c126f245ea399d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41327512)</sub>

<!-- /greptile_comment -->