### PR TITLE
fix(som_generationkwh): make parser blockers python 3 compatible

### DIFF
--- a/som_generationkwh/assignment.py
+++ b/som_generationkwh/assignment.py
@@ -27,7 +27,7 @@ def _sqlfromfile(sqlname):
     import os
     sqlfile = os.path.join(
         config['addons_path'], 'som_generationkwh',
-            'sql', sqlname+'.sql')
+        'sql', sqlname + '.sql')
     with open(sqlfile) as f:
         return f.read()
 
@@ -84,14 +84,14 @@ class GenerationkWhAssignment(osv.osv):
             'Contracte',
             required=True,
             help="Contracte que te els drets per utilitzar els kWh generats",
-            ),
+        ),
         member_id=fields.many2one(
             'somenergia.soci',
             'Soci',
             readonly=True,
             required=True,
             help="Soci que va comprar accions Generation kWh i els assigna",
-            ),
+        ),
         priority=fields.integer(
             'Prioritat',
             required=True,
@@ -100,38 +100,38 @@ class GenerationkWhAssignment(osv.osv):
                  "encara no han estat facturades a assignacions del mateix soci"
                  " que tinguin una prioritat mes alta."
                  "(a valor més petit, més prioritat)",
-            ),
+        ),
         end_date=fields.date(
             "Data d'Expiració",
             help="Data a partir de la qual l'assignació ja no serà activa",
-            ),
+        ),
         # Contract fields
         contract_state=fields.function(
             _ff_contract, string='Contract State', readonly=True, type='char',
             method=True, multi='contract',
             help="Estat del contracte seleccionat",
-            ),
+        ),
         contract_last_invoiced=fields.function(
             _ff_contract, string='Data última factura', readonly=True,
             type='date', method=True, multi='contract',
             help="Data Última lectura facturada",
-            ),
+        ),
         contract_tariff=fields.function(
             _ff_contract, string='Contract Tariff', readonly=True, type='char',
             method=True, multi='contract',
             help="Tarifa del contracte seleccionat",
-            ),
+        ),
         cups_direction=fields.function(
             _ff_contract, string='Direcció CUPS', readonly=True, type='char',
             method=True, multi='contract',
             help="Direcció del CUPS",
-            ),
+        ),
         cups_anual_use=fields.function(
             _ff_contract, string='Consum anual', readonly=True, type='integer',
             method=True, multi='contract',
             help="Consum anyal del CUPS. Pot ser estimat.",
-            ),
-        )
+        ),
+    )
 
     _defaults = dict(
         member_id=_default_member_id,
@@ -153,8 +153,8 @@ class GenerationkWhAssignment(osv.osv):
 
         Contract = self.pool.get('giscedata.polissa')
 
-        member_id = values.get('member_id',None)
-        contract_id = values.get('contract_id',None)
+        member_id = values.get('member_id', None)
+        contract_id = values.get('contract_id', None)
         priority = values.get('priority', 0)
 
         self.expire(cr, uid, contract_id, member_id, context=context)
@@ -201,7 +201,6 @@ class GenerationkWhAssignment(osv.osv):
             header = _(u"MODIFICADA assignació ({0}):").format(assignment_id)
 
             current_assignment = current_assignments[assignment_id]
-            fields_txt = ''
             for field in assignment_fields:
                 current_value = current_assignment[field]
                 new_value = assignment[field]
@@ -224,7 +223,7 @@ class GenerationkWhAssignment(osv.osv):
         return res
 
     def unlink(self, cr, uid, ids, context=None):
-        print "customized unlink..."
+        print("customized unlink...")
         assignment_vals = self.read(cr, uid, ids, ['contract_id', 'priority'])
         for assignment in assignment_vals:
             assignment_id = assignment['id']
@@ -242,22 +241,24 @@ class GenerationkWhAssignment(osv.osv):
         )
 
     def expire(self, cr, uid, contract_id, member_id, context=None):
-        if contract_id is None: return
-        if member_id is None: return
+        if contract_id is None:
+            return
+        if member_id is None:
+            return
         same_polissa_member = self.search(cr, uid, [
-            #'|', ('end_date', '<', str(datetime.date.today())),
-                ('end_date','=',False),
+            # '|', ('end_date', '<', str(datetime.date.today())),
+            ('end_date', '=', False),
             ('contract_id', '=', contract_id),
             ('member_id', '=', member_id),
-        ], context = context)
+        ], context=context)
         if same_polissa_member:
-            self.write(cr,uid,
-                same_polissa_member,
-                dict(
-                    end_date=str(datetime.date.today()),
-                ),
-                context=context,
-            )
+            self.write(cr, uid,
+                       same_polissa_member,
+                       dict(
+                           end_date=str(datetime.date.today()),
+                       ),
+                       context=context,
+                       )
 
     def createDefaultForMembers(self, cr, uid, member_ids, context=None):
         """ Creates default contract assignments for the given members.
@@ -274,40 +275,41 @@ class GenerationkWhAssignment(osv.osv):
             - Within both groups the ones with more anual use first.
             - If all criteria match, use contract creation order
         """
-        if not member_ids: return []
+        if not member_ids:
+            return []
         sql = _sqlfromfile('default_contracts_to_assign')
         cr.execute(sql, dict(socis=tuple(member_ids)))
         return [
-            (contract,member)
-            for contract,member,_,_ in cr.fetchall()
+            (contract, member)
+            for contract, member, _, _ in cr.fetchall()
             if contract
-            ]
+        ]
 
     def createOnePrioritaryAndManySecondaries(self, cr, uid, assignments, context=None):
         """ PRIVATE.
             Creates assignments from a list of pairs of contract_id, member_id.
-            The first pair of a member is the priority 0 and the 
+            The first pair of a member is the priority 0 and the
             remaining contracts of the same member are inserted as priority zero.
             @pre contracts of the same member are together
             """
-        formerMember=None
-        members = list(set(member for contract,member in assignments))
+        formerMember = None
+        members = list(set(member for contract, member in assignments))
         ids = self.search(cr, uid, [
-            ('member_id','in',members),
-            ],context=context)
+            ('member_id', 'in', members),
+        ], context=context)
         self.unlink(cr, uid, ids, context=context)
         for contract, member in assignments:
             self.create(cr, uid, dict(
-                contract_id = contract,
-                member_id = member,
-                priority = 0 if member!=formerMember else 1,
-                ), context=context)
-            formerMember=member
-    
+                contract_id=contract,
+                member_id=member,
+                priority=0 if member != formerMember else 1,
+            ), context=context)
+            formerMember = member
+
     def dropAll(self, cr, uid, context=None):
         """Remove all records"""
         ids = self.search(cr, uid, [
-            ],context=context)
+        ], context=context)
         super(GenerationkWhAssignment, self).unlink(
             cr, uid, ids, context=context
         )
@@ -321,10 +323,10 @@ class GenerationkWhAssignment(osv.osv):
             cursor,
             uid,
             [
-                ('contract_id','=',contract_id),
-                ('end_date','=',False),
+                ('contract_id', '=', contract_id),
+                ('end_date', '=', False),
             ], context=context
-            ))>=1
+        )) >= 1
 
     def contractSources(self, cursor, uid, contract_id, context=None):
         sql = _sqlfromfile('right_sources_for_contract')
@@ -333,11 +335,11 @@ class GenerationkWhAssignment(osv.osv):
             (member_id, last_usable_date)
             for member_id, last_usable_date, _
             in cursor.fetchall()
-            ]
+        ]
 
     def send_mail(self, cursor, uid,
-            obj_id, mail_from, model, template_name,
-            context=None):
+                  obj_id, mail_from, model, template_name,
+                  context=None):
 
         ModelData = self.pool.get('ir.model.data')
         Template = self.pool.get('poweremail.templates')
@@ -347,7 +349,7 @@ class GenerationkWhAssignment(osv.osv):
             try:
                 template_id = int(template_name)
             except ValueError:
-                #Busquem la plantilla de mail d'activació
+                # Busquem la plantilla de mail d'activació
                 ignored, template_id = ModelData.get_object_reference(
                     cursor, uid,
                     'som_generationkwh',
@@ -368,50 +370,49 @@ class GenerationkWhAssignment(osv.osv):
                 'from': mail_from,
                 'state': 'single',
                 'priority': '0',
-                }
+            }
             params = {
                 'state': 'single',
                 'priority': '0',
                 'from': mail_from,
-                }
+            }
 
             pwswz_id = Wizard.create(cursor, uid, params, ctx)
             Wizard.send_mail(cursor, uid, [pwswz_id], ctx)
 
-        except osv.except_osv, e:
-                info = u'%s' % unicode(e.value)
-                return (_(u'ERROR'), info)
+        except osv.except_osv as e:
+            info = u'%s' % e.value
+            return (_(u'ERROR'), info)
 
-        except Exception, e:
-                raise Exception(e)
-
+        except Exception as e:
+            raise Exception(e)
 
     def generationMailAccount(self, cursor, uid):
         PEAccounts = self.pool.get('poweremail.core_accounts')
-        return PEAccounts.search(cursor,uid,[
-            ('email_id','=','generationkwh@somenergia.coop'),
-            ])[0]
+        return PEAccounts.search(cursor, uid, [
+            ('email_id', '=', 'generationkwh@somenergia.coop'),
+        ])[0]
 
     def notifyAssignmentByMail(self, cursor, uid, members, context=None):
         for member in members:
             self.send_mail(cursor, uid,
-                member,
-                self.generationMailAccount(cursor,uid),
-                'somenergia.soci',
-                'generationkwh_assignment_notification_mail',
-                context or {})
+                           member,
+                           self.generationMailAccount(cursor, uid),
+                           'somenergia.soci',
+                           'generationkwh_assignment_notification_mail',
+                           context or {})
 
     def notifyAdvancedEffectiveDate(self, cursor, uid, members, context=None):
         for member in members:
             self.send_mail(cursor, uid,
-                member,
-                self.generationMailAccount(cursor,uid),
-                'somenergia.soci',
-                70, # TODO this id changes from installation to another!!
-                context or {})
+                           member,
+                           self.generationMailAccount(cursor, uid),
+                           'somenergia.soci',
+                           70,  # TODO this id changes from installation to another!!
+                           context or {})
 
-
-    def unassignedInvestors(self, cursor, uid, effectiveOn, purchasedUntil, force, insist, context=None):
+    def unassignedInvestors(self, cursor, uid, effectiveOn, purchasedUntil,
+                            force, insist, context=None):
         """
             Returns all the members that have investments but no assignment
             has been made.
@@ -461,29 +462,28 @@ class GenerationkWhAssignment(osv.osv):
             ORDER BY
                 investment.member_id
             """, dict(
-                force = force or None,
-                insist = insist or None,
-                lastPurchaseDate = purchasedUntil and isodate(purchasedUntil),
-                lastFirstEffectiveDate = effectiveOn and isodate(effectiveOn),
-            ))
-        result = [ id for id, in cursor.fetchall() ]
+            force=force or None,
+            insist=insist or None,
+            lastPurchaseDate=purchasedUntil and isodate(purchasedUntil),
+            lastFirstEffectiveDate=effectiveOn and isodate(effectiveOn),
+        ))
+        result = [id for id, in cursor.fetchall()]
         return result
 
     def get_generationkwh_monthly_use(self, cursor, uid, res_partner_id, month):
         """Month must be in the format YYYY-MM"""
         month_start = datetime.datetime.strptime(month, '%Y-%m')
-        next_month = month_start+relativedelta(months=1)
+        next_month = month_start + relativedelta(months=1)
         date_domain = [
             ('factura_id.invoice_id.date_invoice', '>=', month_start.strftime('%Y-%m-%d')),
             ('factura_id.invoice_id.date_invoice', '<', next_month.strftime('%Y-%m-%d'))
         ]
         return self._get_generationkwh_use(cursor, uid, res_partner_id, date_domain)
 
-
     def get_generationkwh_yearly_use(self, cursor, uid, res_partner_id, year):
         """Year must be in the format YYYY"""
         year_start = datetime.datetime.strptime(year, '%Y')
-        next_year = year_start+relativedelta(years=1)
+        next_year = year_start + relativedelta(years=1)
         date_domain = [
             ('factura_id.invoice_id.date_invoice', '>=', year_start.strftime('%Y-%m-%d')),
             ('factura_id.invoice_id.date_invoice', '<', next_year.strftime('%Y-%m-%d'))
@@ -494,7 +494,8 @@ class GenerationkWhAssignment(osv.osv):
         GenerationkWhInvoiceLineOwner = self.pool.get('generationkwh.invoice.line.owner')
         q = OOQuery(GenerationkWhInvoiceLineOwner, cursor, uid)
 
-        sql = q.select(['id']).where([('factura_id.polissa_id.titular.id', '=', res_partner_id)]+date_domain)
+        sql = q.select(['id']).where(
+            [('factura_id.polissa_id.titular.id', '=', res_partner_id)] + date_domain)
         cursor.execute(*sql)
         res = cursor.fetchall()
         generation_line_ids = [line[0] for line in res]
@@ -507,7 +508,7 @@ class GenerationkWhAssignment(osv.osv):
             multiplier = 1 if invoice.type in ('out_invoice', 'in_refund') else -1
             response[str(contract.name)]['address'] = contract.cups_direccio
             response[str(contract.name)][str(line.product_id.name)] += (
-                line.quantity*multiplier)
+                line.quantity * multiplier)
 
         # clean defaultdict for serialization
         response = {k: dict(v) for k, v in response.items()}
@@ -535,7 +536,7 @@ class AssignmentProvider(ErpWrapper):
                 self.cursor, self.uid,
                 contract_id,
                 context=self.context)
-            ]
+        ]
 
     def anyForContract(self, contract_id):
         Assignment = self.erp.pool.get('generationkwh.assignment')
@@ -543,27 +544,25 @@ class AssignmentProvider(ErpWrapper):
             self.cursor, self.uid,
             contract_id,
             context=self.context,
-            )
+        )
 
 
 class Generationkwh_Assignment_TestHelper(osv.osv_memory):
     _name = 'generationkwh.assignment.testhelper'
     _auto = False
-    
+
     def contractSources(self, cursor, uid, contract_id, context=None):
         provider = AssignmentProvider(self, cursor, uid, context)
         return [
             dict(
                 member_id=val.member_id,
                 last_usable_date=val.last_usable_date.isoformat(),
-                )
+            )
             for val in provider.contractSources(contract_id)
-            ]
+        ]
+
 
 Generationkwh_Assignment_TestHelper()
-
-
-
 
 
 # vim: et ts=4 sw=4

--- a/som_generationkwh/investment_strategy.py
+++ b/som_generationkwh/investment_strategy.py
@@ -4,7 +4,7 @@ import pooler
 from generationkwh.isodates import isodate
 import generationkwh.investmentmodel as gkwh
 from generationkwh.investmentstate import InvestmentState
-from datetime import datetime, date
+from datetime import datetime
 from time import sleep
 from yamlns import namespace as ns
 from tools.translate import _
@@ -14,8 +14,11 @@ from threading import Thread
 
 class PartnerException(Exception):
     pass
+
+
 class InvestmentException(Exception):
     pass
+
 
 class InvestmentActions(ErpWrapper):
 
@@ -32,47 +35,48 @@ class InvestmentActions(ErpWrapper):
         pass
 
     def create_from_form(self, cursor, uid, partner_id, order_date, amount_in_euros, ip, iban,
-            emission=None, context=None):
+                         emission=None, context=None):
         GenerationkwhInvestment = self.erp.pool.get('generationkwh.investment')
         Emission = self.erp.pool.get('generationkwh.emission')
 
         if amount_in_euros <= 0 or amount_in_euros % gkwh.shareValue > 0:
-                raise InvestmentException("Invalid amount")
+            raise InvestmentException("Invalid amount")
         iban = GenerationkwhInvestment.check_iban(cursor, uid, iban)
 
         if not iban:
-                raise PartnerException("Wrong iban")
+            raise PartnerException("Wrong iban")
         if not emission:
             emission = 'emissio_genkwh'
 
-        #Compatibility 'emission_apo'
+        # Compatibility 'emission_apo'
         imd_model = self.erp.pool.get('ir.model.data')
-        imd_emission_id = imd_model.search(cursor, uid, [('module','=', 'som_generationkwh'),('name','=',emission)])
+        imd_emission_id = imd_model.search(
+            cursor, uid, [('module', '=', 'som_generationkwh'), ('name', '=', emission)])
         if imd_emission_id:
             emission_id = imd_model.read(cursor, uid, imd_emission_id[0], ['res_id'])['res_id']
         else:
-            emission_id = Emission.search(cursor, uid, [('code','=',emission)])[0]
+            emission_id = Emission.search(cursor, uid, [('code', '=', emission)])[0]
 
         Soci = self.erp.pool.get('somenergia.soci')
         member_ids = Soci.search(cursor, uid, [
-                ('partner_id','=',partner_id)
-                ])
+            ('partner_id', '=', partner_id)
+        ])
         if not member_ids:
             raise PartnerException("Not a member")
 
         bank_id = GenerationkwhInvestment.get_or_create_partner_bank(cursor, uid,
-                    partner_id, iban)
+                                                                     partner_id, iban)
         ResPartner = self.erp.pool.get('res.partner')
         ResPartner.write(cursor, uid, partner_id, dict(
-            bank_inversions = bank_id,),context)
+            bank_inversions=bank_id,), context)
 
         return member_ids, emission_id
-
 
     def attach_signature(self, cursor, uid, investment_id, signaturit_data, context=None):
         pass  # For now, this is only for GenerationkWh
 
-    def create_from_transfer(self, cursor, uid, investment_id, new_partner_id, transmission_date, iban, context=None):
+    def create_from_transfer(self, cursor, uid, investment_id, new_partner_id,
+                             transmission_date, iban, context=None):
         pass
 
     def divest(self, cursor, uid, id, invoice_ids, errors, date_invoice):
@@ -85,8 +89,8 @@ class InvestmentActions(ErpWrapper):
         return False
 
     def create_divestment_invoice(self, cursor, uid,
-            investment_id, date_invoice, to_be_divested,
-            irpf_amount_current_year=0, irpf_amount=0, context=None):
+                                  investment_id, date_invoice, to_be_divested,
+                                  irpf_amount_current_year=0, irpf_amount=0, context=None):
 
         Partner = self.erp.pool.get('res.partner')
         Product = self.erp.pool.get('product.product')
@@ -94,7 +98,7 @@ class InvestmentActions(ErpWrapper):
         InvoiceLine = self.erp.pool.get('account.invoice.line')
         PaymentType = self.erp.pool.get('payment.type')
         Journal = self.erp.pool.get('account.journal')
-        Investment =  self.erp.pool.get('generationkwh.investment')
+        Investment = self.erp.pool.get('generationkwh.investment')
 
         investment = Investment.browse(cursor, uid, investment_id)
 
@@ -106,33 +110,38 @@ class InvestmentActions(ErpWrapper):
         account_inv_id = self.get_or_create_investment_account(cursor, uid, partner_id)
         # The product
         product_id = Product.search(cursor, uid, [
-            ('default_code','=', self.productCode),
-            ])[0]
+            ('default_code', '=', self.productCode),
+        ])[0]
 
         product = Product.browse(cursor, uid, product_id)
         product_uom_id = product.uom_id.id
 
         # The journal
         journal_id = Journal.search(cursor, uid, [
-            ('code','=',self.purchaseJournalCode),
-            ])[0]
+            ('code', '=', self.purchaseJournalCode),
+        ])[0]
 
         # The payment type
         payment_type_id = PaymentType.search(cursor, uid, [
             ('code', '=', 'TRANSFERENCIA_CSB'),
-            ])[0]
+        ])[0]
 
         errors = []
+
         def error(message):
             errors.append(message)
 
         # Check if exist bank account
         if not partner.bank_inversions:
-            return 0, u"Inversió {0}: El partner {1} no té informat un compte corrent\n".format(investment.id, partner.name)
+            return 0, (
+                u"Inversió {0}: El partner {1} no té informat un compte corrent\n"
+                .format(investment.id, partner.name)
+            )
 
         # Memento of mutable data
         investmentMemento = ns()
-        investmentMemento.pendingCapital = investment.nshares * gkwh.shareValue - investment.amortized_amount - to_be_divested
+        investmentMemento.pendingCapital = investment.nshares * \
+            gkwh.shareValue - investment.amortized_amount - to_be_divested
         investmentMemento.divestmentDate = date_invoice
         investmentMemento.investmentId = investment_id
         investmentMemento.investmentName = investment.name
@@ -143,14 +152,15 @@ class InvestmentActions(ErpWrapper):
         invoice_name = '%s-DES' % (
             # TODO: Remove the GENKWHID stuff when fully migrated, error instead
             investment.name or 'GENKWHID{}'.format(investment.id),
-            )
+        )
         # Ensure unique amortization
-        existingInvoice = Invoice.search(cursor,uid,[
-            ('name','=', invoice_name),
-            ])
+        existingInvoice = Invoice.search(cursor, uid, [
+            ('name', '=', invoice_name),
+        ])
 
         if existingInvoice:
-            return 0, u"Inversió {0}: La desinversió {1} ja existeix".format(investment.id, invoice_name)
+            return 0, u"Inversió {0}: La desinversió {1} ja existeix".format(
+                investment.id, invoice_name)
 
         # Default invoice fields for given partner
         vals = {}
@@ -167,7 +177,7 @@ class InvestmentActions(ErpWrapper):
             'account_id': partner.property_account_liquidacio.id,
             'partner_bank': partner.bank_inversions.id,
             'payment_type': payment_type_id,
-            #'check_total': to_be_divested,
+            # 'check_total': to_be_divested,
             # TODO: Remove the GENKWHID stuff when fully migrated, error instead
             'origin': investment.name or 'GENKWHID{}'.format(investment.id),
             'origin_date_invoice': date_invoice,
@@ -176,26 +186,26 @@ class InvestmentActions(ErpWrapper):
         })
 
         invoice_id = Invoice.create(cursor, uid, vals)
-        Invoice.write(cursor,uid, invoice_id,{'sii_to_send':False})
+        Invoice.write(cursor, uid, invoice_id, {'sii_to_send': False})
 
         line = dict(
             InvoiceLine.product_id_change(cursor, uid, [],
-                product=product_id,
-                uom=product_uom_id,
-                partner_id=partner_id,
-                type='in_invoice',
-                ).get('value', {}),
-            invoice_id = invoice_id,
-            name = _('Desinversió total de {investment} a {date} ').format(
-                investment = investment.name,
-                date = str(date_invoice),
-                ),
-            note = investmentMemento.dump(),
-            quantity = 1,
-            price_unit = to_be_divested,
-            product_id = product_id,
+                                          product=product_id,
+                                          uom=product_uom_id,
+                                          partner_id=partner_id,
+                                          type='in_invoice',
+                                          ).get('value', {}),
+            invoice_id=invoice_id,
+            name=_('Desinversió total de {investment} a {date} ').format(
+                investment=investment.name,
+                date=str(date_invoice),
+            ),
+            note=investmentMemento.dump(),
+            quantity=1,
+            price_unit=to_be_divested,
+            product_id=product_id,
             # partner specific account, was generic from product
-            account_id = account_inv_id,
+            account_id=account_inv_id,
         )
 
         # no taxes apply
@@ -205,16 +215,20 @@ class InvestmentActions(ErpWrapper):
 
         InvoiceLine.create(cursor, uid, line)
         if irpf_amount_current_year:
-            irpf_amount_current_year = round(irpf_amount_current_year,2)
-            Investment.irpfRetentionLine(cursor, uid, investment, irpf_amount_current_year, invoice_id, isodate(date_invoice), investmentMemento)
+            irpf_amount_current_year = round(irpf_amount_current_year, 2)
+            Investment.irpfRetentionLine(
+                cursor, uid, investment, irpf_amount_current_year, invoice_id,
+                isodate(date_invoice), investmentMemento)
         if irpf_amount:
             irpf_amount = round(irpf_amount, 2)
-            Investment.irpfRetentionLine(cursor, uid, investment, irpf_amount, invoice_id, isodate(date_invoice)-relativedelta(years=1), investmentMemento)
+            Investment.irpfRetentionLine(cursor, uid, investment, irpf_amount, invoice_id, isodate(
+                date_invoice) - relativedelta(years=1), investmentMemento)
 
         Invoice.write(cursor, uid, invoice_id, dict(
             check_total=to_be_divested - irpf_amount_current_year - irpf_amount,
-            ))
+        ))
         return invoice_id, errors
+
 
 class GenerationkwhActions(InvestmentActions):
 
@@ -231,34 +245,36 @@ class GenerationkwhActions(InvestmentActions):
         return 'GENKWH_AMOR'
 
     def create_from_form(self, cursor, uid, partner_id, order_date, amount_in_euros, ip, iban,
-            emission=None, context=None):
-        member_ids, emission_id = super(GenerationkwhActions, self).create_from_form(cursor, uid, partner_id, order_date, amount_in_euros, ip, iban,emission, context)
+                         emission=None, context=None):
+        member_ids, emission_id = super(GenerationkwhActions, self).create_from_form(
+            cursor, uid, partner_id, order_date, amount_in_euros, ip, iban, emission, context)
 
         GenerationkwhInvestment = self.erp.pool.get('generationkwh.investment')
         ResUser = self.erp.pool.get('res.users')
         user = ResUser.read(cursor, uid, uid, ['name'])
         IrSequence = self.erp.pool.get('ir.sequence')
-        name = IrSequence.get_next(cursor,uid,'som.inversions.gkwh')
+        name = IrSequence.get_next(cursor, uid, 'som.inversions.gkwh')
 
         inv = InvestmentState(user['name'], datetime.now())
         inv.order(
-            name = name,
-            date = order_date,
-            amount = amount_in_euros,
-            iban = iban,
-            ip = ip,
-            )
+            name=name,
+            date=order_date,
+            amount=amount_in_euros,
+            iban=iban,
+            ip=ip,
+        )
         investment_id = GenerationkwhInvestment.create(cursor, uid, dict(
             inv.erpChanges(),
-            member_id = member_ids[0],
-            emission_id = emission_id,
+            member_id=member_ids[0],
+            emission_id=emission_id,
         ), context)
 
-        GenerationkwhInvestment.get_or_create_payment_mandate(cursor, uid,
-            partner_id, iban, gkwh.mandateName, gkwh.creditorCode, context)
+        GenerationkwhInvestment.get_or_create_payment_mandate(
+            cursor, uid, partner_id, iban, gkwh.mandateName,
+            gkwh.creditorCode, context)
 
         GenerationkwhInvestment.send_mail(cursor, uid, investment_id,
-            'generationkwh.investment', '_mail_creacio')
+                                          'generationkwh.investment', '_mail_creacio')
 
         return investment_id
 
@@ -318,28 +334,30 @@ class GenerationkwhActions(InvestmentActions):
         try:
             SignaturaProcess.update(cursor, uid, [process_id], context=context)
             cursor.commit()
-        except Exception, e:
+        except Exception:
             cursor.rollback()
         finally:
             cursor.close()
 
-    def create_from_transfer(self, cursor, uid, investment_id, new_partner_id, transmission_date, iban, context=None):
+    def create_from_transfer(self, cursor, uid, investment_id, new_partner_id,
+                             transmission_date, iban, context=None):
         GenerationkwhInvestment = self.erp.pool.get('generationkwh.investment')
 
-        #Obtenir dades inversio (total invertit, total amortiztzat/pendent, data original...)
+        # Obtenir dades inversio (total invertit, total amortiztzat/pendent, data original...)
         old_investment = GenerationkwhInvestment.read(cursor, uid, investment_id)
-        if old_investment['draft'] :
+        if old_investment['draft']:
             raise Exception("Investment in draft, so not transferible")
         if not old_investment['active']:
             raise Exception("Investment not active")
-        if old_investment['amortized_amount'] >= old_investment['nshares']*gkwh.shareValue :
+        if old_investment['amortized_amount'] >= old_investment['nshares'] * gkwh.shareValue:
             raise Exception("Amount to return = 0, not transferible")
 
-        #Comprovar dades del partner al qual es vol tranferir (existeix, soci, iban, compte inversions..)
+        # Comprovar dades del partner al qual es vol tranferir
+        # (existeix, soci, iban, compte inversions..)
         Soci = self.erp.pool.get('somenergia.soci')
         member_ids = Soci.search(cursor, uid, [
-                ('partner_id','=', new_partner_id)
-                ])
+            ('partner_id', '=', new_partner_id)
+        ])
         if not member_ids:
             raise Exception("Destination partner is not a member")
 
@@ -348,77 +366,81 @@ class GenerationkwhActions(InvestmentActions):
         if not new_partner.property_account_gkwh.id:
             new_partner.button_assign_acc_1635()
             new_partner = ResPartner.browse(cursor, uid, new_partner_id)
-            print("Nou partner: Creat compte comptable de Generation: {}".format(new_partner.property_account_gkwh.code))
+            print("Nou partner: Creat compte comptable de Generation: {}".format(
+                new_partner.property_account_gkwh.code))
         if not new_partner.bank_inversions:
             print("Nou banc per aquest partner: Cal definir un IBAN de banc inversions")
             bank_id = GenerationkwhInvestment.get_or_create_partner_bank(cursor, uid,
-                        new_partner_id, iban)
+                                                                         new_partner_id, iban)
             ResPartner.write(cursor, uid, new_partner_id, dict(
-                bank_inversions = bank_id,),context)
+                bank_inversions=bank_id,), context)
 
-        #Crear inversio
+        # Crear inversio
         ResUser = self.erp.pool.get('res.users')
         user = ResUser.read(cursor, uid, uid, ['name'])
         IrSequence = self.erp.pool.get('ir.sequence')
 
-        name = IrSequence.get_next(cursor,uid,'som.inversions.gkwh')
+        name = IrSequence.get_next(cursor, uid, 'som.inversions.gkwh')
 
         inv = InvestmentState(user['name'], datetime.now(),
-                name = old_investment['name'],
-                purchase_date = old_investment['purchase_date'],
-                first_effective_date = old_investment['first_effective_date'],
-                last_effective_date = old_investment['last_effective_date'],
-                order_date = old_investment['order_date'],
-                log = old_investment['log'],
-                actions_log = old_investment['actions_log'],
-        )
+                              name=old_investment['name'],
+                              purchase_date=old_investment['purchase_date'],
+                              first_effective_date=old_investment['first_effective_date'],
+                              last_effective_date=old_investment['last_effective_date'],
+                              order_date=old_investment['order_date'],
+                              log=old_investment['log'],
+                              actions_log=old_investment['actions_log'],
+                              )
         inv_old = InvestmentState(user['name'], datetime.now(),
-                name = old_investment['name'],
-                purchase_date = isodate(old_investment['purchase_date']),
-                first_effective_date = isodate(old_investment['first_effective_date']),
-                paid_amount = old_investment['nshares']*gkwh.shareValue,
-                nominal_amount = old_investment['nshares']*gkwh.shareValue,
-                amortized_amount = old_investment['amortized_amount'],
-                last_effective_date = old_investment['last_effective_date'],
-                order_date = old_investment['order_date'],
-                log = old_investment['log'],
-                actions_log = old_investment['actions_log'],
-        )
-        amount = old_investment['nshares']*gkwh.shareValue - old_investment['amortized_amount']
-        to_partner_name = new_partner_id #TODO Get partner name from id
+                                  name=old_investment['name'],
+                                  purchase_date=isodate(old_investment['purchase_date']),
+                                  first_effective_date=isodate(
+                                      old_investment['first_effective_date']),
+                                  paid_amount=old_investment['nshares'] * gkwh.shareValue,
+                                  nominal_amount=old_investment['nshares'] * gkwh.shareValue,
+                                  amortized_amount=old_investment['amortized_amount'],
+                                  last_effective_date=old_investment['last_effective_date'],
+                                  order_date=old_investment['order_date'],
+                                  log=old_investment['log'],
+                                  actions_log=old_investment['actions_log'],
+                                  )
+        amount = old_investment['nshares'] * gkwh.shareValue - old_investment['amortized_amount']
         move_line_id = 1
         origin = GenerationkwhInvestment.browse(cursor, uid, investment_id)
         origin_partner_name = origin.member_id.name
 
-        transferred = inv.receiveTransfer(
-            name = name,
-            date = isodate(transmission_date),
-            amount = amount,
-            origin = inv_old,
-            origin_partner_name = origin_partner_name,
-            move_line_id = move_line_id
+        inv.receiveTransfer(
+            name=name,
+            date=isodate(transmission_date),
+            amount=amount,
+            origin=inv_old,
+            origin_partner_name=origin_partner_name,
+            move_line_id=move_line_id
         )
         new_investment_id = GenerationkwhInvestment.create(cursor, uid, dict(
             inv.erpChanges(),
-            member_id = member_ids[0],
-            nshares = old_investment['nshares'],
-            emission_id = old_investment['emission_id'][0]
+            member_id=member_ids[0],
+            nshares=old_investment['nshares'],
+            emission_id=old_investment['emission_id'][0]
         ), context)
 
         new_investment = GenerationkwhInvestment.browse(cursor, uid, new_investment_id)
 
-        emited = inv_old.emitTransfer(
-            date = isodate(transmission_date),
-            amount = amount,
-            to_name = new_investment.name,
-            to_partner_name = new_investment.member_id.name,
-            move_line_id = move_line_id,
+        inv_old.emitTransfer(
+            date=isodate(transmission_date),
+            amount=amount,
+            to_name=new_investment.name,
+            to_partner_name=new_investment.member_id.name,
+            move_line_id=move_line_id,
         )
         GenerationkwhInvestment.write(cursor, uid, investment_id, inv_old.erpChanges())
 
         GenerationkwhInvestment.mark_as_invoiced(cursor, uid, new_investment_id)
         old_partner = Soci.browse(cursor, uid, old_investment['member_id'][0]).partner_id
-        GenerationkwhInvestment.move_line_when_tranfer(cursor, uid, old_partner.id, new_partner_id, old_partner.property_account_gkwh.id , new_partner.property_account_gkwh.id, amount, transmission_date)
+        GenerationkwhInvestment.move_line_when_tranfer(
+            cursor, uid, old_partner.id, new_partner_id,
+            old_partner.property_account_gkwh.id,
+            new_partner.property_account_gkwh.id, amount, transmission_date)
 
         return new_investment_id
 
@@ -470,8 +492,8 @@ class GenerationkwhActions(InvestmentActions):
             'move_line_id',
             'member_id'
         ])
-        nominal_amount = inversio['nshares']*gkwh.shareValue
-        pending_amount = nominal_amount-inversio['amortized_amount']
+        nominal_amount = inversio['nshares'] * gkwh.shareValue
+        pending_amount = nominal_amount - inversio['amortized_amount']
         daysFromPayment = (isodate(date_invoice) - isodate(inversio['purchase_date'])).days
 
         if daysFromPayment < gkwh.waitDaysBeforeDivest:
@@ -479,43 +501,48 @@ class GenerationkwhActions(InvestmentActions):
             return
 
         irpf_amount_last_year = 0
-        if not Investment.is_last_year_amortized(cursor, uid, inversio['name'], datetime.now().year):
-            irpf_amount_last_year = Investment.get_irpf_amounts(cursor, uid, id, inversio['member_id'][0])['irpf_amount']
-        irpf_amount_current_year = Investment.get_irpf_amounts(cursor, uid, id, inversio['member_id'][0], datetime.now().year)['irpf_amount']
+        if not Investment.is_last_year_amortized(
+                cursor, uid, inversio['name'], datetime.now().year):
+            irpf_amount_last_year = Investment.get_irpf_amounts(
+                cursor, uid, id, inversio['member_id'][0])['irpf_amount']
+        irpf_amount_current_year = Investment.get_irpf_amounts(
+            cursor, uid, id, inversio['member_id'][0], datetime.now().year)['irpf_amount']
 
-        invoice_id, error = self.create_divestment_invoice(cursor, uid, id,
-            date_invoice, pending_amount, irpf_amount_current_year, irpf_amount_last_year)
+        invoice_id, error = self.create_divestment_invoice(
+            cursor, uid, id, date_invoice, pending_amount,
+            irpf_amount_current_year, irpf_amount_last_year)
 
         if error:
             errors.append(error)
             return
 
         Investment.open_invoices(cursor, uid, [invoice_id])
-        Investment.invoices_to_payment_order(cursor, uid,
-                [invoice_id], self.get_divest_payment_mode(cursor, uid))
+        Investment.invoices_to_payment_order(
+            cursor, uid, [invoice_id], self.get_divest_payment_mode(cursor, uid))
         invoice_ids.append(invoice_id)
 
-        #Get moveline id
+        # Get moveline id
         invoice_obj = Invoice.read(cursor, uid, invoice_id, [
             'move_id',
         ])
-        ml_invoice = invoice_obj['move_id'][0]
+        invoice_obj['move_id'][0]
         movementline_id = MoveLine.search(cursor, uid,
-            [('move_id','=',invoice_obj['move_id'][0])])[0]
+                                          [('move_id', '=', invoice_obj['move_id'][0])])[0]
 
         inv = InvestmentState(user['name'], datetime.now(),
-            log = inversio['log'],
-            nominal_amount = nominal_amount,
-            purchase_date = inversio['purchase_date'],
-            amortized_amount = inversio['amortized_amount'],
-            first_effective_date = inversio['first_effective_date'],
-        )
+                              log=inversio['log'],
+                              nominal_amount=nominal_amount,
+                              purchase_date=inversio['purchase_date'],
+                              amortized_amount=inversio['amortized_amount'],
+                              first_effective_date=inversio['first_effective_date'],
+                              )
         inv.divest(
-            date = str(date_invoice),
-            amount = pending_amount,
-            move_line_id = movementline_id,
+            date=str(date_invoice),
+            amount=pending_amount,
+            move_line_id=movementline_id,
         )
         Investment.write(cursor, uid, id, inv.erpChanges())
+
 
 class AportacionsActions(InvestmentActions):
 
@@ -531,74 +558,83 @@ class AportacionsActions(InvestmentActions):
     def productCode(self):
         return 'APO_AE'
 
-    def create_from_form(self, cursor, uid, partner_id, order_date, amount_in_euros, ip, iban, emission=None, context=None):
-        member_ids, emission_id = super(AportacionsActions, self).create_from_form(cursor, uid, partner_id, order_date, amount_in_euros, ip, iban,emission, context)
+    def create_from_form(self, cursor, uid, partner_id, order_date,
+                         amount_in_euros, ip, iban, emission=None,
+                         context=None):
+        member_ids, emission_id = super(AportacionsActions, self).create_from_form(
+            cursor, uid, partner_id, order_date, amount_in_euros, ip, iban, emission, context)
         GenerationkwhInvestment = self.erp.pool.get('generationkwh.investment')
 
-
         Emission = self.erp.pool.get('generationkwh.emission')
-        emi_obj = Emission.read(cursor, uid, emission_id, ['mandate_name','code'])
+        emi_obj = Emission.read(cursor, uid, emission_id, ['mandate_name', 'code'])
 
-        if not GenerationkwhInvestment.check_investment_creation(cursor, uid, partner_id, emi_obj['code'], amount_in_euros):
+        if not GenerationkwhInvestment.check_investment_creation(
+                cursor, uid, partner_id, emi_obj['code'], amount_in_euros):
             raise InvestmentException("Impossible to create investment")
 
         Soci = self.erp.pool.get('somenergia.soci')
         member_ids = Soci.search(cursor, uid, [
-                ('partner_id','=',partner_id)
-                ])
+            ('partner_id', '=', partner_id)
+        ])
         ResUser = self.erp.pool.get('res.users')
         user = ResUser.read(cursor, uid, uid, ['name'])
         IrSequence = self.erp.pool.get('ir.sequence')
-        name = IrSequence.get_next(cursor,uid,'seq.som.aportacions')
+        name = IrSequence.get_next(cursor, uid, 'seq.som.aportacions')
 
         inv = InvestmentState(user['name'], datetime.now())
         inv.order(
-            name = name,
-            date = order_date,
-            amount = amount_in_euros,
-            iban = iban,
-            ip = ip,
-            )
+            name=name,
+            date=order_date,
+            amount=amount_in_euros,
+            iban=iban,
+            ip=ip,
+        )
         investment_id = GenerationkwhInvestment.create(cursor, uid, dict(
             inv.erpChanges(),
-            member_id = member_ids[0],
-            emission_id = emission_id,
+            member_id=member_ids[0],
+            emission_id=emission_id,
         ), context)
 
+        GenerationkwhInvestment.get_or_create_payment_mandate(
+            cursor, uid, partner_id, iban, emi_obj['mandate_name'],
+            gkwh.creditorCode, context)
 
-        GenerationkwhInvestment.get_or_create_payment_mandate(cursor, uid,
-            partner_id, iban, emi_obj['mandate_name'], gkwh.creditorCode, context)
-
-        total_amount_in_emission = GenerationkwhInvestment.get_investments_amount(cursor, uid, member_ids[0], emission_id=emission_id)
+        total_amount_in_emission = GenerationkwhInvestment.get_investments_amount(
+            cursor, uid, member_ids[0], emission_id=emission_id)
 
         mail_context = {}
         if total_amount_in_emission > gkwh.amountForlegalAtt:
-            attachment_id = self.get_investment_legal_attachment(cursor, uid, partner_id, emission_id)
+            attachment_id = self.get_investment_legal_attachment(
+                cursor, uid, partner_id, emission_id)
             if attachment_id:
                 mail_context.update({'attachment_ids': [(6, 0, [attachment_id])]})
 
         GenerationkwhInvestment.send_mail(cursor, uid, investment_id,
-            'generationkwh.investment', '_mail_creacio', context=mail_context)
+                                          'generationkwh.investment',
+                                          '_mail_creacio', context=mail_context)
 
         return investment_id
 
-    def create_from_transfer(self, cursor, uid, investment_id, new_partner_id, transmission_date, iban, context=None):
-        #Obtenir dades inversio (total invertit, total amortiztzat/pendent, data original...)
+    def create_from_transfer(self, cursor, uid, investment_id, new_partner_id,
+                             transmission_date, iban, context=None):
+        # Obtenir dades inversio (total invertit, total amortiztzat/pendent,
+        # data original...)
         GenerationkwhInvestment = self.erp.pool.get('generationkwh.investment')
 
         old_investment = GenerationkwhInvestment.read(cursor, uid, investment_id)
-        if old_investment['draft'] :
+        if old_investment['draft']:
             raise Exception("Investment in draft, so not transferible")
         if not old_investment['active']:
             raise Exception("Investment not active")
-        if old_investment['amortized_amount'] >= old_investment['nshares']*gkwh.shareValue :
+        if old_investment['amortized_amount'] >= old_investment['nshares'] * gkwh.shareValue:
             raise Exception("Amount to return = 0, not transferible")
 
-        #Comprovar dades del partner al qual es vol tranferir (existeix, soci, iban, compte inversions..)
+        # Comprovar dades del partner al qual es vol tranferir
+        # (existeix, soci, iban, compte inversions..)
         Soci = self.erp.pool.get('somenergia.soci')
         member_ids = Soci.search(cursor, uid, [
-                ('partner_id','=', new_partner_id)
-                ])
+            ('partner_id', '=', new_partner_id)
+        ])
         if not member_ids:
             raise Exception("Destination partner is not a member")
 
@@ -607,77 +643,82 @@ class AportacionsActions(InvestmentActions):
         if not new_partner.property_account_aportacions.id:
             new_partner.button_assign_acc_163()
             new_partner = ResPartner.browse(cursor, uid, new_partner_id)
-            print("Nou partner: Creat/assignat compte comptable d'aportacions {}".format(new_partner.property_account_aportacions.code))
+            print("Nou partner: Creat/assignat compte comptable d'aportacions {}".format(
+                new_partner.property_account_aportacions.code))
         if not new_partner.bank_inversions:
             print("Nou banc per aquest partner: Cal definir un IBAN de banc inversions")
             bank_id = GenerationkwhInvestment.get_or_create_partner_bank(cursor, uid,
-                        new_partner_id, iban)
+                                                                         new_partner_id, iban)
             ResPartner.write(cursor, uid, new_partner_id, dict(
-                bank_inversions = bank_id,),context)
+                bank_inversions=bank_id,), context)
 
-        #Crear inversio
+        # Crear inversio
         ResUser = self.erp.pool.get('res.users')
         user = ResUser.read(cursor, uid, uid, ['name'])
         IrSequence = self.erp.pool.get('ir.sequence')
 
-        name = IrSequence.get_next(cursor,uid,'seq.som.aportacions')
+        name = IrSequence.get_next(cursor, uid, 'seq.som.aportacions')
 
         inv = InvestmentState(user['name'], datetime.now(),
-                name = old_investment['name'],
-                purchase_date = old_investment['purchase_date'],
-                first_effective_date = old_investment['first_effective_date'],
-                last_effective_date = old_investment['last_effective_date'],
-                order_date = old_investment['order_date'],
-                log = old_investment['log'],
-                actions_log = old_investment['actions_log'],
-        )
+                              name=old_investment['name'],
+                              purchase_date=old_investment['purchase_date'],
+                              first_effective_date=old_investment['first_effective_date'],
+                              last_effective_date=old_investment['last_effective_date'],
+                              order_date=old_investment['order_date'],
+                              log=old_investment['log'],
+                              actions_log=old_investment['actions_log'],
+                              )
         inv_old = InvestmentState(user['name'], datetime.now(),
-                name = old_investment['name'],
-                purchase_date = isodate(old_investment['purchase_date']),
-                first_effective_date = isodate(old_investment['first_effective_date']),
-                paid_amount = old_investment['nshares']*gkwh.shareValue,
-                nominal_amount = old_investment['nshares']*gkwh.shareValue,
-                amortized_amount = old_investment['amortized_amount'],
-                last_effective_date = old_investment['last_effective_date'],
-                order_date = old_investment['order_date'],
-                log = old_investment['log'],
-                actions_log = old_investment['actions_log'],
-        )
-        amount = old_investment['nshares']*gkwh.shareValue - old_investment['amortized_amount']
-        to_partner_name = new_partner_id #TODO Get partner name from id
+                                  name=old_investment['name'],
+                                  purchase_date=isodate(old_investment['purchase_date']),
+                                  first_effective_date=isodate(
+                                      old_investment['first_effective_date']),
+                                  paid_amount=old_investment['nshares'] * gkwh.shareValue,
+                                  nominal_amount=old_investment['nshares'] * gkwh.shareValue,
+                                  amortized_amount=old_investment['amortized_amount'],
+                                  last_effective_date=old_investment['last_effective_date'],
+                                  order_date=old_investment['order_date'],
+                                  log=old_investment['log'],
+                                  actions_log=old_investment['actions_log'],
+                                  )
+        amount = old_investment['nshares'] * gkwh.shareValue - old_investment['amortized_amount']
         move_line_id = 1
         origin = GenerationkwhInvestment.browse(cursor, uid, investment_id)
         origin_partner_name = origin.member_id.name
 
-        transferred = inv.receiveTransfer(
-            name = name,
-            date = isodate(transmission_date),
-            amount = amount,
-            origin = inv_old,
-            origin_partner_name = origin_partner_name,
-            move_line_id = move_line_id
+        inv.receiveTransfer(
+            name=name,
+            date=isodate(transmission_date),
+            amount=amount,
+            origin=inv_old,
+            origin_partner_name=origin_partner_name,
+            move_line_id=move_line_id
         )
         new_investment_id = GenerationkwhInvestment.create(cursor, uid, dict(
             inv.erpChanges(),
-            member_id = member_ids[0],
-            nshares = old_investment['nshares'],
-            emission_id = old_investment['emission_id'][0]
+            member_id=member_ids[0],
+            nshares=old_investment['nshares'],
+            emission_id=old_investment['emission_id'][0]
         ), context)
 
         new_investment = GenerationkwhInvestment.browse(cursor, uid, new_investment_id)
 
-        emited = inv_old.emitTransfer(
-            date = isodate(transmission_date),
-            amount = amount,
-            to_name = new_investment.name,
-            to_partner_name = new_investment.member_id.name,
-            move_line_id = move_line_id,
+        inv_old.emitTransfer(
+            date=isodate(transmission_date),
+            amount=amount,
+            to_name=new_investment.name,
+            to_partner_name=new_investment.member_id.name,
+            move_line_id=move_line_id,
         )
         GenerationkwhInvestment.write(cursor, uid, investment_id, inv_old.erpChanges())
 
         GenerationkwhInvestment.mark_as_invoiced(cursor, uid, new_investment_id)
         old_partner = Soci.browse(cursor, uid, old_investment['member_id'][0]).partner_id
-        GenerationkwhInvestment.move_line_when_tranfer(cursor, uid, old_partner.id, new_partner_id, old_partner.property_account_aportacions.id, new_partner.property_account_aportacions.id, amount, transmission_date)
+        GenerationkwhInvestment.move_line_when_tranfer(
+            cursor, uid, old_partner.id, new_partner_id,
+            old_partner.property_account_aportacions.id,
+            new_partner.property_account_aportacions.id, amount,
+            transmission_date)
 
         return new_investment_id
 
@@ -688,7 +729,8 @@ class AportacionsActions(InvestmentActions):
         # Attaching legal docs for higher than 5k APOS
         search_params = [('res_model', '=', 'generationkwh.emission'),
                          ('res_id', '=', emission_id),
-                         ('name', 'ilike', '%_{}'.format('CA' if partner_lang == 'ca_ES' else 'ES'))]
+                         ('name', 'ilike', '%_{}'.format(
+                             'CA' if partner_lang == 'ca_ES' else 'ES'))]
         attachment_id = IrAttachment.search(cursor, uid, search_params)
         if attachment_id:
             return attachment_id[0]
@@ -750,51 +792,50 @@ class AportacionsActions(InvestmentActions):
             'move_line_id',
             'member_id'
         ])
-        nominal_amount = inversio['nshares']*gkwh.shareValue
+        nominal_amount = inversio['nshares'] * gkwh.shareValue
         daysFromPayment = (isodate(date_invoice) - isodate(inversio['purchase_date'])).days
 
         if daysFromPayment < gkwh.waitDaysBeforeDivest:
             errors.append("%s: Too early to divest (< 30 days from purchase)" % inversio['name'])
             return
 
-        invoice_id, error = Investment.create_divestment_invoice(cursor, uid, id,
-            date_invoice, nominal_amount, 0, 0, 0)
+        invoice_id, error = Investment.create_divestment_invoice(
+            cursor, uid, id, date_invoice, nominal_amount, 0, 0, 0)
 
         if error:
             errors.append(error)
             return
 
         Investment.open_invoices(cursor, uid, [invoice_id])
-        Investment.invoices_to_payment_order(cursor, uid,
-                [invoice_id], self.get_divest_payment_mode(cursor, uid))
+        Investment.invoices_to_payment_order(
+            cursor, uid, [invoice_id], self.get_divest_payment_mode(cursor, uid))
         invoice_ids.append(invoice_id)
 
-        #Get moveline id
+        # Get moveline id
         invoice_obj = Invoice.read(cursor, uid, invoice_id, [
             'move_id',
         ])
-        ml_invoice = invoice_obj['move_id'][0]
+        invoice_obj['move_id'][0]
         movementline_id = MoveLine.search(cursor, uid,
-            [('move_id','=',invoice_obj['move_id'][0])])[0]
+                                          [('move_id', '=', invoice_obj['move_id'][0])])[0]
 
         inv = InvestmentState(user['name'], datetime.now(),
-            log = inversio['log'],
-            nominal_amount = nominal_amount,
-            purchase_date = inversio['purchase_date'],
-            amortized_amount = inversio['amortized_amount'],
-            first_effective_date = inversio['first_effective_date'],
-        )
+                              log=inversio['log'],
+                              nominal_amount=nominal_amount,
+                              purchase_date=inversio['purchase_date'],
+                              amortized_amount=inversio['amortized_amount'],
+                              first_effective_date=inversio['first_effective_date'],
+                              )
         inv.divest(
-            date = str(date_invoice),
-            amount = nominal_amount,
-            move_line_id = movementline_id,
+            date=str(date_invoice),
+            amount=nominal_amount,
+            move_line_id=movementline_id,
         )
         Investment.write(cursor, uid, id, inv.erpChanges())
 
-
     def create_interest_invoice(self, cursor, uid,
-            investment_id, vals,
-            context=None):
+                                investment_id, vals,
+                                context=None):
         if isinstance(investment_id, list):
             investment_id = investment_id[0]
 
@@ -803,7 +844,7 @@ class AportacionsActions(InvestmentActions):
         Invoice = self.erp.pool.get('account.invoice')
         InvoiceLine = self.erp.pool.get('account.invoice.line')
         PaymentType = self.erp.pool.get('payment.type')
-        Journal = self.erp.pool.get('account.journal')
+        self.erp.pool.get('account.journal')
         Investment = self.erp.pool.get('generationkwh.investment')
 
         investment = Investment.browse(cursor, uid, investment_id)
@@ -824,8 +865,8 @@ class AportacionsActions(InvestmentActions):
 
         # The product
         product_id = Product.search(cursor, uid, [
-            ('default_code','=', 'APO_INT'),
-            ])[0]
+            ('default_code', '=', 'APO_INT'),
+        ])[0]
 
         product = Product.browse(cursor, uid, product_id)
         product_uom_id = product.uom_id.id
@@ -837,15 +878,19 @@ class AportacionsActions(InvestmentActions):
         # The payment type
         payment_type_id = PaymentType.search(cursor, uid, [
             ('code', '=', 'TRANSFERENCIA_CSB'),
-            ])[0]
+        ])[0]
 
         errors = []
+
         def error(message):
             errors.append(message)
 
         # Check if exist bank account
         if not partner.bank_inversions:
-            return 0, u"Aportació {0}: El partner {1} no té informat un compte corrent\n".format(investment.id, partner.name)
+            return 0, (
+                u"Aportació {0}: El partner {1} no té informat un compte corrent\n"
+                .format(investment.id, partner.name)
+            )
 
         # Memento of mutable data
         investmentMemento = ns()
@@ -869,7 +914,7 @@ class AportacionsActions(InvestmentActions):
         invoice_name = '%s-INT%s' % (
             investment.name,
             year,
-            )
+        )
 
         # Default invoice fields for given partne
         vals = {}
@@ -886,7 +931,7 @@ class AportacionsActions(InvestmentActions):
             'account_id': partner.property_account_liquidacio.id,
             'partner_bank': partner.bank_inversions.id,
             'payment_type': payment_type_id,
-            #'check_total': to_be_interized + (irpf_amount * -1),
+            # 'check_total': to_be_interized + (irpf_amount * -1),
             # TODO: Remove the GENKWHID stuff when fully migrated, error instead
             'origin': investment.name or 'GENKWHID{}'.format(investment.id),
             'origin_date_invoice': date_invoice,
@@ -895,27 +940,30 @@ class AportacionsActions(InvestmentActions):
         })
 
         invoice_id = Invoice.create(cursor, uid, vals)
-        Invoice.write(cursor,uid, invoice_id,{'sii_to_send':False})
+        Invoice.write(cursor, uid, invoice_id, {'sii_to_send': False})
 
         line = dict(
             InvoiceLine.product_id_change(cursor, uid, [],
-                product=product_id,
-                uom=product_uom_id,
-                partner_id=partner_id,
-                type='in_invoice',
-                ).get('value', {}),
-            invoice_id = invoice_id,
-            name = _('Interessos des de {date_start:%d/%m/%Y} fins a {date_end:%d/%m/%Y} de {investment} ').format(
-                investment = investment.name,
-                date_end = datetime.strptime(date_end,'%Y-%m-%d'),
-                date_start = datetime.strptime(date_start,'%Y-%m-%d'),
-                ),
-            note = investmentMemento.dump(),
-            quantity = 1,
-            price_unit = to_be_interized,
-            product_id = product_id,
+                                          product=product_id,
+                                          uom=product_uom_id,
+                                          partner_id=partner_id,
+                                          type='in_invoice',
+                                          ).get('value', {}),
+            invoice_id=invoice_id,
+            name=_(
+                'Interessos des de {date_start:%d/%m/%Y} '
+                'fins a {date_end:%d/%m/%Y} de {investment} '
+            ).format(
+                investment=investment.name,
+                date_end=datetime.strptime(date_end, '%Y-%m-%d'),
+                date_start=datetime.strptime(date_start, '%Y-%m-%d'),
+            ),
+            note=investmentMemento.dump(),
+            quantity=1,
+            price_unit=to_be_interized,
+            product_id=product_id,
             # partner specific account, was generic from product
-            account_id = account_inv_id,
+            account_id=account_inv_id,
         )
 
         # Force apply taxes. Taxes from product doesn't work.
@@ -927,8 +975,8 @@ class AportacionsActions(InvestmentActions):
 
         Invoice.button_reset_taxes(cursor, uid, [invoice_id])
         inv = Invoice.browse(cursor, uid, invoice_id)
-        Invoice.write(cursor,uid, invoice_id, dict(
-            check_total = inv.amount_total,
+        Invoice.write(cursor, uid, invoice_id, dict(
+            check_total=inv.amount_total,
         ))
 
         return invoice_id, errors

--- a/som_generationkwh/som_generationkwh.py
+++ b/som_generationkwh/som_generationkwh.py
@@ -16,7 +16,6 @@ from generationkwh.memberrightsusage import MemberRightsUsage
 from generationkwh.fareperiodcurve import FarePeriodCurve
 from generationkwh.usagetracker import UsageTracker
 from generationkwh.isodates import isodate
-from .emission import GenerationkwhEmission
 from .assignment import AssignmentProvider
 from .remainder import RemainderProvider
 from .investment import InvestmentProvider
@@ -48,8 +47,8 @@ class GenerationkWhDealer(osv.osv):
             contract_id, first_date, last_date)
 
     def _get_available_kwh(self, cursor, uid,
-                          contract_id, first_date, last_date, fare_id, period_id,
-                          context=None):
+                           contract_id, first_date, last_date, fare_id, period_id,
+                           context=None):
         """ Returns generationkwh [kWh] available for contract_id during the
             date interval, fare and period"""
         dealer = self._createDealer(cursor, uid, context)
@@ -61,33 +60,33 @@ class GenerationkWhDealer(osv.osv):
 
     def get_members_by_partners(self, cursor, uid, partner_ids, context=None):
         Soci = self.pool.get('somenergia.soci')
-        member_ids = Soci.search(cursor, uid, [('partner_id','in',partner_ids)], context=context)
+        member_ids = Soci.search(cursor, uid, [('partner_id', 'in', partner_ids)], context=context)
         res = Soci.read(cursor, uid, member_ids, ['partner_id'], context=context)
-        return [ (r['partner_id'][0], r['id'])
-            for r in res
-            ]
+        return [(r['partner_id'][0], r['id'])
+                for r in res
+                ]
 
     def get_members_by_codes(self, cursor, uid, codes, context=None):
         completedCodes = [
-            "S"+str(code).zfill(6)
+            "S" + str(code).zfill(6)
             for code in codes
-            ]
+        ]
         Soci = self.pool.get('somenergia.soci')
-        member_ids = Soci.search(cursor, uid, [('ref','in',completedCodes)], context=context)
+        member_ids = Soci.search(cursor, uid, [('ref', 'in', completedCodes)], context=context)
         res = Soci.read(cursor, uid, member_ids, ['ref'], context=context)
-        return [ (r['ref'], r['id'])
-            for r in res
-            ]
+        return [(r['ref'], r['id'])
+                for r in res
+                ]
 
     def get_members_by_vats(self, cursor, uid, vats, context=None):
         # TODO: Prepend ES just when detected as NIF
-        vats = ['ES'+vat for vat in vats]
+        vats = ['ES' + vat for vat in vats]
         Soci = self.pool.get('somenergia.soci')
-        member_ids = Soci.search(cursor, uid, [('vat','in',vats)], context=context)
+        member_ids = Soci.search(cursor, uid, [('vat', 'in', vats)], context=context)
         res = Soci.read(cursor, uid, member_ids, ['vat'], context=context)
-        return [ (r['vat'][0], r['id'])
-            for r in res
-            ]
+        return [(r['vat'][0], r['id'])
+                for r in res
+                ]
 
     def get_partners_by_members(self, cursor, uid, member_ids, context=None):
         Soci = self.pool.get('somenergia.soci')
@@ -95,18 +94,18 @@ class GenerationkWhDealer(osv.osv):
         return [
             (r['id'], r['partner_id'][0])
             for r in res
-            ]
+        ]
 
     def get_contracts_by_ref(self, cursor, uid, contract_refs, context=None):
         contract_refs = map(str, contract_refs)
         Contract = self.pool.get('giscedata.polissa')
         contract_ids = Contract.search(cursor, uid, [
             ('name', 'in', contract_refs),
-            ], context=context)
+        ], context=context)
         res = Contract.read(cursor, uid, contract_ids, ['name'], context=context)
-        return [ (r['name'], r['id'])
-            for r in res
-            ]
+        return [(r['name'], r['id'])
+                for r in res
+                ]
 
     def get_fare_name_by_id(self, cursor, uid, fare_id, period_id, context=None):
         Fare = self.pool.get('giscedata.polissa.tarifa')
@@ -133,7 +132,7 @@ class GenerationkWhDealer(osv.osv):
         res = dealer.use_kwh(
             contract_id, isodate(first_date), isodate(last_date), fare, period, kwh)
 
-        socis = [ line['member_id'] for line in res ]
+        socis = [line['member_id'] for line in res]
         members2partners = dict(self.get_partners_by_members(cursor, uid, socis, context=context))
 
         def soci2partner(soci):
@@ -142,24 +141,23 @@ class GenerationkWhDealer(osv.osv):
         for line in res:
             txt = (u'{kwh} Generation kwh of member {member} to {contract} '
                    u'for period {period} between {start} and {end}').format(
-                    kwh=line['kwh'],
-                    member=line['member_id'],
-                    contract=contract_id,
-                    period=period,
-                    start=first_date,
-                    end=last_date,
+                kwh=line['kwh'],
+                member=line['member_id'],
+                contract=contract_id,
+                period=period,
+                start=first_date,
+                end=last_date,
             )
             logger.notifyChannel('gkwh_dealer USE', netsvc.LOG_INFO, txt)
 
         return [
             dict(
-                member_id = soci2partner(line['member_id']),
-                kwh = line['kwh'],
+                member_id=soci2partner(line['member_id']),
+                kwh=line['kwh'],
                 usage=line['usage']
-                )
+            )
             for line in res
         ]
-
 
     def refund_kwh(self, cursor, uid,
                    contract_id, first_date, last_date, fare_id, period_id, kwh,
@@ -172,7 +170,8 @@ class GenerationkWhDealer(osv.osv):
 
         fare, period = self.get_fare_name_by_id(cursor, uid, fare_id, period_id)
 
-        partner2member = dict(self.get_members_by_partners(cursor, uid, [partner_id], context=context))
+        partner2member = dict(self.get_members_by_partners(
+            cursor, uid, [partner_id], context=context))
         try:
             member_id = partner2member[partner_id]
         except KeyError:
@@ -180,12 +179,12 @@ class GenerationkWhDealer(osv.osv):
 
         txt = (u'{kwh} Generation kwh of member {member} to {contract} '
                u'for period {period} between {start} and {end}').format(
-             contract=contract_id,
-             period=period,
-             start=first_date,
-             end=last_date,
-             member=member_id,
-             kwh=kwh
+            contract=contract_id,
+            period=period,
+            start=first_date,
+            end=last_date,
+            member=member_id,
+            kwh=kwh
         )
         logger.notifyChannel('gkwh_dealer REFUND', netsvc.LOG_INFO, txt)
 
@@ -209,7 +208,7 @@ class GenerationkWhDealer(osv.osv):
             rightsPerShare=rightsPerShare,
             remainders=remainders,
             eager=True,
-            )
+        )
 
         rightsUsage = MemberRightsUsage(mdbpool.get_db())
 
@@ -225,6 +224,7 @@ class GenerationkWhDealer(osv.osv):
         assignments = AssignmentProvider(self, cursor, uid, context)
         return Dealer(usageTracker, assignments, investments)
 
+
 GenerationkWhDealer()
 
 
@@ -238,50 +238,50 @@ class GenerationkWhTestHelper(osv.osv):
     _auto = False
 
     def holidays(self, cursor, uid,
-            start, stop,
-            context=None):
+                 start, stop,
+                 context=None):
         holidaysProvider = HolidaysProvider(self, cursor, uid, context)
         return holidaysProvider.get(start, stop)
 
     def memberrightsusage_update(self, cursor, uid,
-            member,start,data,
-            context=None):
+                                 member, start, data,
+                                 context=None):
         usage_provider = MemberRightsUsage(mdbpool.get_db())
         usage_provider.updateUsage(
             member=member,
             start=isodate(start),
             data=data
-            )
+        )
 
     def setup_rights_per_share(self, cursor, uid,
-            nshares, firstDate, data,
-            context=None):
+                               nshares, firstDate, data,
+                               context=None):
         rightsPerShare = RightsPerShare(mdbpool.get_db())
         rightsPerShare.updateRightsPerShare(nshares, isodate(firstDate), data)
         remainders = RemainderProvider(self, cursor, uid, context)
-        lastDate = isodate(firstDate) + datetime.timedelta(days=(len(data)+24)//25)
+        lastDate = isodate(firstDate) + datetime.timedelta(days=(len(data) + 24) // 25)
         remainders.updateRemainders([
             (nshares, isodate(firstDate), 0),
             (nshares, lastDate, 0),
-            ])
+        ])
 
     def rights_per_share(self, cursor, uid,
-            nshares, firstDate, lastDate,
-            context=None):
+                         nshares, firstDate, lastDate,
+                         context=None):
         rights = RightsPerShare(mdbpool.get_db())
         return list(int(i) for i in rights.rightsPerShare(nshares,
-                isodate(firstDate),
-                isodate(lastDate)
-                ))
+                                                          isodate(firstDate),
+                                                          isodate(lastDate)
+                                                          ))
 
     def rights_correction(self, cursor, uid,
-            nshares, firstDate, lastDate,
-            context=None):
+                          nshares, firstDate, lastDate,
+                          context=None):
         correction = RightsCorrection(mdbpool.get_db())
         return list(int(i) for i in correction.rightsCorrection(nshares,
-                isodate(firstDate),
-                isodate(lastDate)
-                ))
+                                                                isodate(firstDate),
+                                                                isodate(lastDate)
+                                                                ))
 
     def clear_mongo_collections(self, cursor, uid, collections, context=None):
 
@@ -303,32 +303,29 @@ class GenerationkWhTestHelper(osv.osv):
             rightsPerShare=rightsPerShare,
             remainders=remainders,
             eager=True,
-            )
-        return [ int(num) for num in generatedRights.rights_kwh(member,
-            isodate(start),
-            isodate(stop),
-            )]
+        )
+        return [int(num) for num in generatedRights.rights_kwh(member,
+                                                               isodate(start),
+                                                               isodate(stop),
+                                                               )]
 
     def member_shares(self, cursor, uid, member, start, stop, context=None):
         investment = InvestmentProvider(self, cursor, uid, context)
         memberActiveShares = MemberSharesCurve(investment)
-        return [ int(num) for num in memberActiveShares.hourly(
+        return [int(num) for num in memberActiveShares.hourly(
             isodate(start),
             isodate(stop),
             member,
-            )]
-        
-
+        )]
 
     def trace_rigths_compilation(self, cursor, uid,
-            member, start, stop, fare, period,
-            context=None):
+                                 member, start, stop, fare, period,
+                                 context=None):
         """
             Helper function to show data related to computation of available
             rights.
         """
-        print "Dropping results for", member, start, stop, fare, period
-
+        print("Dropping results for", member, start, stop, fare, period)
         investment = InvestmentProvider(self, cursor, uid, context)
         memberActiveShares = MemberSharesCurve(investment)
         rightsPerShare = RightsPerShare(mdbpool.get_db())
@@ -339,53 +336,54 @@ class GenerationkWhTestHelper(osv.osv):
             rightsPerShare=rightsPerShare,
             remainders=remainders,
             eager=True,
-            )
-        rightsUsage = MemberRightsUsage(mdbpool.get_db())
+        )
+        MemberRightsUsage(mdbpool.get_db())
         holidays = HolidaysProvider(self, cursor, uid, context)
         farePeriod = FarePeriodCurve(holidays)
 
-        print 'remainders', remainders.lastRemainders()
-        print 'investment', investment.items(
+        print('remainders', remainders.lastRemainders())
+        print('investment', investment.items(
             start=isodate(start),
             end=isodate(stop),
-            member=member)
-        print 'active', memberActiveShares.hourly(
+            member=member))
+        print('active', memberActiveShares.hourly(
             isodate(start),
             isodate(stop),
-            member)
+            member))
         for nshares in set(memberActiveShares.hourly(
-            isodate(start),
-            isodate(stop),
-            member)):
-            print 'rightsPerShare', nshares, rightsPerShare.rightsPerShare(nshares,
                 isodate(start),
                 isodate(stop),
-                )
-        print 'rights', generatedRights.rights_kwh(member,
-            isodate(start),
-            isodate(stop),
-            )
+                member)):
+            print('rightsPerShare', nshares, rightsPerShare.rightsPerShare(
+                nshares,
+                isodate(start),
+                isodate(stop),
+            ))
+        print('rights', generatedRights.rights_kwh(member,
+                                                   isodate(start),
+                                                   isodate(stop),
+                                                   ))
 
-        print 'periodmask', farePeriod.periodMask(
+        print('periodmask', farePeriod.periodMask(
             fare, period,
             isodate(start),
             isodate(stop),
-            )
+        ))
 
     def usage(self, cursor, uid,
-            member_id, first_date, last_date,
-            context=None):
+              member_id, first_date, last_date,
+              context=None):
         rightsUsage = MemberRightsUsage(mdbpool.get_db())
         result = list(int(i) for i in rightsUsage.usage(
             member_id,
             isodate(first_date),
             isodate(last_date)
-            ))
+        ))
         return result
 
     def usagetracker_available_kwh(self, cursor, uid,
-            member, start, stop, fare, period,
-            context=None):
+                                   member, start, stop, fare, period,
+                                   context=None):
 
         GenerationkWhDealer = self.pool.get('generationkwh.dealer')
         usageTracker = GenerationkWhDealer._createTracker(cursor, uid, context)
@@ -395,12 +393,12 @@ class GenerationkWhTestHelper(osv.osv):
             isodate(stop),
             fare,
             period
-            )
+        )
         return result
 
     def usagetracker_use_kwh(self, cursor, uid,
-            member, start, stop, fare, period, kwh,
-            context=None):
+                             member, start, stop, fare, period, kwh,
+                             context=None):
 
         GenerationkWhDealer = self.pool.get('generationkwh.dealer')
         usageTracker = GenerationkWhDealer._createTracker(cursor, uid, context)
@@ -411,12 +409,12 @@ class GenerationkWhTestHelper(osv.osv):
             fare,
             period,
             kwh,
-            )
+        )
         return int(result)
 
     def usagetracker_refund_kwh(self, cursor, uid,
-            member, start, stop, fare, period, kwh,
-            context=None):
+                                member, start, stop, fare, period, kwh,
+                                context=None):
 
         GenerationkWhDealer = self.pool.get('generationkwh.dealer')
         usageTracker = GenerationkWhDealer._createTracker(cursor, uid, context)
@@ -427,12 +425,12 @@ class GenerationkWhTestHelper(osv.osv):
             fare,
             period,
             kwh,
-            )
+        )
         return int(result)
 
     def dealer_use_kwh(self, cursor, uid,
-            contract, start, stop, fare, period, kwh,
-            context=None):
+                       contract, start, stop, fare, period, kwh,
+                       context=None):
 
         GenerationkWhDealer = self.pool.get('generationkwh.dealer')
         dealer = GenerationkWhDealer._createDealer(cursor, uid, context)
@@ -443,12 +441,12 @@ class GenerationkWhTestHelper(osv.osv):
             fare,
             period,
             kwh,
-            )
+        )
         return result
 
     def dealer_refund_kwh(self, cursor, uid,
-            contract_id, start, stop, fare, period, kwh, member,
-            context=None):
+                          contract_id, start, stop, fare, period, kwh, member,
+                          context=None):
 
         GenerationkWhDealer = self.pool.get('generationkwh.dealer')
         dealer = GenerationkWhDealer._createDealer(cursor, uid, context)
@@ -460,12 +458,12 @@ class GenerationkWhTestHelper(osv.osv):
             period,
             kwh,
             member,
-            )
+        )
         return int(result)
 
     def dealer_is_active(self, cursor, uid,
-            contract_id, start, stop,
-            context=None):
+                         contract_id, start, stop,
+                         context=None):
 
         GenerationkWhDealer = self.pool.get('generationkwh.dealer')
         dealer = GenerationkWhDealer._createDealer(cursor, uid, context)
@@ -473,13 +471,11 @@ class GenerationkWhTestHelper(osv.osv):
             contract_id,
             isodate(start),
             isodate(stop),
-            )
+        )
         return result
 
 
 GenerationkWhTestHelper()
-
-
 
 
 class GenerationkWhInvoiceLineOwner(osv.osv):
@@ -498,7 +494,7 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
         return res
 
     def _ff_invoice_number(self, cursor, uid, ids, field_name, arg,
-                           context=None ):
+                           context=None):
         """Invoice Number"""
         if not ids:
             return []
@@ -524,7 +520,7 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
         fare_period = gff_obj.get_fare_period(cr, uid, line['product_id'])
         product_id_nogen = per_obj.read(cr, uid, fare_period, ['product_id'])['product_id'][0]
         line_s_gen_id = gffl_obj.search(cr, uid, [
-            ('invoice_id','=', line['invoice_id'][0]),('product_id','=',product_id_nogen),
+            ('invoice_id', '=', line['invoice_id'][0]), ('product_id', '=', product_id_nogen),
             ('data_desde', '=', line['data_desde']),
         ])
         line_s_gen = gffl_obj.read(cr, uid, line_s_gen_id[0])
@@ -555,15 +551,14 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
 
         if ai_obj.read(cr, uid, line['invoice_id'][0], ['type'])['type'] == 'out_refund':
             return round(profit * -1, 2)
-        return round(profit ,2)
-
+        return round(profit, 2)
 
     def _ff_saving_generation(self, cursor, uid, ids, field_name, arg,
-                           context=None ):
+                              context=None):
         """Invoice Number"""
         if not ids:
             return []
-        gilo_obj = self.pool.get('generationkwh.invoice.line.owner')
+        self.pool.get('generationkwh.invoice.line.owner')
         gffl_obj = self.pool.get('giscedata.facturacio.factura.linia')
 
         res = {k: {} for k in ids}
@@ -601,6 +596,7 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
         )
     }
 
+
 GenerationkWhInvoiceLineOwner()
 
 
@@ -613,7 +609,7 @@ class GenerationkWhRightUsageLine(osv.osv):
 
     _columns = {
         'datetime': fields.datetime(
-            'Data generació drets',required=True, readonly=True
+            'Data generació drets', required=True, readonly=True
         ),
         'quantity': fields.integer(
             'KWh utilitzats', required=True, readonly=True
@@ -622,15 +618,16 @@ class GenerationkWhRightUsageLine(osv.osv):
             'generationkwh.invoice.line.owner', 'Propietari drets GkWh factura',
             required=True, readonly=True, ondelete='cascade'
         ),
-        'owner_id' : fields.related(
+        'owner_id': fields.related(
             'line_owner', 'owner_id', type='many2one', relation='res.partner',
             string="Propietari", readonly=True
         ),
-        'factura_id' : fields.related(
+        'factura_id': fields.related(
             'line_owner', 'factura_id', type='many2one',
             relation='giscedata.facturacio.factura', string="Factura", readonly=True
         ),
     }
+
 
 GenerationkWhRightUsageLine()
 

--- a/som_generationkwh/test/rightsgranter_test.py
+++ b/som_generationkwh/test/rightsgranter_test.py
@@ -1,19 +1,15 @@
 # -*- coding: utf-8 -*-
+from somutils.testutils import destructiveTest
 import os
 import unittest
 import datetime
-from yamlns import namespace as ns
 dbconfig = None
 try:
     import dbconfig
     import erppeek_wst
 except ImportError:
     pass
-from generationkwh.isodates import (
-    addDays,
-    isodate,
-    )
-from somutils.testutils import destructiveTest
+
 
 def datespan(startDate, endDate, delta=datetime.timedelta(hours=1)):
     currentDate = startDate
@@ -21,10 +17,12 @@ def datespan(startDate, endDate, delta=datetime.timedelta(hours=1)):
         yield currentDate
         currentDate += delta
 
+
 @unittest.skipIf(not dbconfig, "depends on ERP")
 @destructiveTest
 class RightsGranter_Test(unittest.TestCase):
     from plantmeter.testutils import assertNsEqual
+
     def setUp(self):
         self.erp = erppeek_wst.ClientWST(**dbconfig.erppeek)
         self.erp.begin()
@@ -36,14 +34,14 @@ class RightsGranter_Test(unittest.TestCase):
         self.TestHelper = self.erp.GenerationkwhTesthelper
         self.ProductionHelper = self.erp.GenerationkwhProductionAggregatorTesthelper
         self.setUpAggregator()
-        self.clearMongoCollections() # Rights and measurements
+        self.clearMongoCollections()  # Rights and measurements
         self.setUpTemp()
-        self.clearRemainders() # db
+        self.clearRemainders()  # db
 
     def tearDown(self):
-        self.clearAggregator() # db
-        self.clearMongoCollections() # Rights and measurements
-        self.clearRemainders() # db
+        self.clearAggregator()  # db
+        self.clearMongoCollections()  # Rights and measurements
+        self.clearRemainders()  # db
         self.clearTemp()
         self.erp.rollback()
         self.erp.close()
@@ -82,15 +80,13 @@ class RightsGranter_Test(unittest.TestCase):
             first_active_date='2014-01-01'))
 
     def updatePlant(self, plantName, **kwd):
-        id = self.Plant.search([('name','=',plantName)])
+        id = self.Plant.search([('name', '=', plantName)])
         self.Plant.write(id, kwd)
 
     def updateMeter(self, meterName, **kwd):
-        id = self.Meter.search([('name','=',meterName)])
+        id = self.Meter.search([('name', '=', meterName)])
         self.Meter.write(id, kwd)
-        from yamlns import namespace as ns
-        print self.Meter.read(id,[])
-
+        print(self.Meter.read(id, []))
 
     def setupMeter(self, plant_id, plant, meter):
         return self.Meter.create(dict(
@@ -129,147 +125,147 @@ class RightsGranter_Test(unittest.TestCase):
 
     def test_computeAvailableRights_singleDay(self):
         aggr_id = self.setupAggregator(
-                nplants=1,
-                nmeters=1,
-                nshares=[1]).read(['id'])['id']
-        self.setupLocalMeter('mymeter00',[
-            ('2015-08-16', 18*[0]+[1000]+6*[0])
-            ])
-        remainder = self.setupRemainders([(1,'2015-08-16',0)])
+            nplants=1,
+            nmeters=1,
+            nshares=[1]).read(['id'])['id']
+        self.setupLocalMeter('mymeter00', [
+            ('2015-08-16', 18 * [0] + [1000] + 6 * [0])
+        ])
+        remainder = self.setupRemainders([(1, '2015-08-16', 0)])
 
         self.RightsGranter.computeAvailableRights(aggr_id)
 
         result = self.TestHelper.rights_per_share(1, '2015-08-16', '2015-08-16')
-        self.assertEqual(result, +18*[0]+[1000]+6*[0])
+        self.assertEqual(result, +18 * [0] + [1000] + 6 * [0])
         self.assertEqual(remainder.lastRemainders(), [
             [1, '2015-08-17', 0],
-            ])
+        ])
 
     def test_computeAvailableRights_withManyPlantShares_divides(self):
         aggr_id = self.setupAggregator(
-                nplants=1,
-                nmeters=1,
-                nshares=[4]).read(['id'])['id']
-        self.setupLocalMeter('mymeter00',[
-            ('2015-08-16', 18*[0]+[20000]+6*[0])
-            ])
-        remainder = self.setupRemainders([(1,'2015-08-16',0)])
+            nplants=1,
+            nmeters=1,
+            nshares=[4]).read(['id'])['id']
+        self.setupLocalMeter('mymeter00', [
+            ('2015-08-16', 18 * [0] + [20000] + 6 * [0])
+        ])
+        remainder = self.setupRemainders([(1, '2015-08-16', 0)])
 
         self.RightsGranter.computeAvailableRights(aggr_id)
 
-        result = self.TestHelper.rights_per_share(1,'2015-08-16','2015-08-16')
-        self.assertEqual(result, +18*[0]+[5000]+6*[0])
+        result = self.TestHelper.rights_per_share(1, '2015-08-16', '2015-08-16')
+        self.assertEqual(result, +18 * [0] + [5000] + 6 * [0])
         self.assertEqual(remainder.lastRemainders(), [
             [1, '2015-08-17', 0],
-            ])
+        ])
 
     def test_computeAvailableRights_withManyPlantShares_twoDays(self):
         aggr_id = self.setupAggregator(
-                nplants=1,
-                nmeters=1,
-                nshares=[4]).read(['id'])['id']
-        self.setupLocalMeter('mymeter00',[
-            ('2015-08-16', 18*[0]+[20000]+6*[0]),
-            ('2015-08-17', 18*[0]+[20000]+6*[0]),
-            ])
-        remainder = self.setupRemainders([(1,'2015-08-16',0)])
+            nplants=1,
+            nmeters=1,
+            nshares=[4]).read(['id'])['id']
+        self.setupLocalMeter('mymeter00', [
+            ('2015-08-16', 18 * [0] + [20000] + 6 * [0]),
+            ('2015-08-17', 18 * [0] + [20000] + 6 * [0]),
+        ])
+        remainder = self.setupRemainders([(1, '2015-08-16', 0)])
 
         self.RightsGranter.computeAvailableRights(aggr_id)
 
-        result = self.TestHelper.rights_per_share(1,'2015-08-16','2015-08-17')
-        self.assertEqual(result, 2*(18*[0]+[5000]+6*[0]))
+        result = self.TestHelper.rights_per_share(1, '2015-08-16', '2015-08-17')
+        self.assertEqual(result, 2 * (18 * [0] + [5000] + 6 * [0]))
         self.assertEqual(remainder.lastRemainders(), [
             [1, '2015-08-18', 0],
-            ])
+        ])
 
     def test_computeAvailableRights_withManyPlants_dividesByTotalShares(self):
         aggr_id = self.setupAggregator(
-                nplants=2,
-                nmeters=1,
-                nshares=[2,2]).read(['id'])['id']
-        self.setupLocalMeter('mymeter00',[
-            ('2015-08-16', 18*[0]+[4000]+6*[0])
-            ])
-        self.setupLocalMeter('mymeter10',[
-            ('2015-08-16', 18*[0]+[16000]+6*[0])
-            ])
-        remainder = self.setupRemainders([(1,'2015-08-16',0)])
+            nplants=2,
+            nmeters=1,
+            nshares=[2, 2]).read(['id'])['id']
+        self.setupLocalMeter('mymeter00', [
+            ('2015-08-16', 18 * [0] + [4000] + 6 * [0])
+        ])
+        self.setupLocalMeter('mymeter10', [
+            ('2015-08-16', 18 * [0] + [16000] + 6 * [0])
+        ])
+        remainder = self.setupRemainders([(1, '2015-08-16', 0)])
 
         self.RightsGranter.computeAvailableRights(aggr_id)
 
-        result = self.TestHelper.rights_per_share(1,'2015-08-16','2015-08-16')
-        self.assertEqual(result, +18*[0]+[5000]+6*[0])
+        result = self.TestHelper.rights_per_share(1, '2015-08-16', '2015-08-16')
+        self.assertEqual(result, +18 * [0] + [5000] + 6 * [0])
         self.assertEqual(remainder.lastRemainders(), [
             [1, '2015-08-17', 0],
-            ])
+        ])
 
     def test_computeAvailableRights_plantsEnteringLater(self):
         aggr_id = self.setupAggregator(
-                nplants=2,
-                nmeters=1,
-                nshares=[1,3]).read(['id'])['id']
+            nplants=2,
+            nmeters=1,
+            nshares=[1, 3]).read(['id'])['id']
         self.updatePlant('myplant0', first_active_date='2014-01-01')
-        #self.updateMeter('mymeter00', first_active_date='2014-01-01')
+        # self.updateMeter('mymeter00', first_active_date='2014-01-01')
         self.updatePlant('myplant1', first_active_date='2015-08-17')
         self.updateMeter('mymeter10', first_active_date='2015-08-17')
 
-        self.setupLocalMeter('mymeter00',[
-            ('2015-08-16', 18*[0]+[4000]+6*[0]),
-            ('2015-08-17', 18*[0]+[4000]+6*[0]),
-            ])
-        self.setupLocalMeter('mymeter10',[
-            ('2015-08-16', 18*[0]+[16000]+6*[0]),
-            ('2015-08-17', 18*[0]+[16000]+6*[0]),
-            ])
-        remainder = self.setupRemainders([(1,'2015-08-16',0)])
+        self.setupLocalMeter('mymeter00', [
+            ('2015-08-16', 18 * [0] + [4000] + 6 * [0]),
+            ('2015-08-17', 18 * [0] + [4000] + 6 * [0]),
+        ])
+        self.setupLocalMeter('mymeter10', [
+            ('2015-08-16', 18 * [0] + [16000] + 6 * [0]),
+            ('2015-08-17', 18 * [0] + [16000] + 6 * [0]),
+        ])
+        remainder = self.setupRemainders([(1, '2015-08-16', 0)])
 
         self.RightsGranter.computeAvailableRights(aggr_id)
 
-        result = self.TestHelper.rights_per_share(1,'2015-08-16','2015-08-17')
+        result = self.TestHelper.rights_per_share(1, '2015-08-16', '2015-08-17')
         self.assertEqual(result,
-            +18*[0]+[4000]+6*[0] # from 1sh*(4000kwh+0kwh)/(1sh+0sh) = 4000kwh
-            +18*[0]+[5000]+6*[0]  # from 1sh*(4000kwh+16000)/(1sh+4sh) = 5000kwh
-        )
+                         +18 * [0] + [4000] + 6 * [0]  # from 1sh*(4000kwh+0kwh)/(1sh+0sh) = 4000kwh
+                         # from 1sh*(4000kwh+16000)/(1sh+4sh) = 5000kwh
+                         + 18 * [0] + [5000] + 6 * [0]
+                         )
         self.assertEqual(remainder.lastRemainders(), [
             [1, '2015-08-18', 0],
-            ])
-
+        ])
 
     def test_recomputeRights_singleDay(self):
-        self.maxDiff=None
+        self.maxDiff = None
         remainder = self.setupRemainders([])
         aggr_id = self.setupAggregator(
-                nplants=1,
-                nmeters=1,
-                nshares=[10]).read(['id'])['id']
-        self.setupLocalMeter('mymeter00',[
-            ('2016-08-16', +24*[50]+[0]), # Same
-            ('2016-08-17', +24*[60]+[0]), # Higher
-            ('2016-08-18', +24*[40]+[0]), # Lower
-            ('2016-08-19', +23*[70]+[35]+[0]), # Higher after lower
-            ])
+            nplants=1,
+            nmeters=1,
+            nshares=[10]).read(['id'])['id']
+        self.setupLocalMeter('mymeter00', [
+            ('2016-08-16', +24 * [50] + [0]),  # Same
+            ('2016-08-17', +24 * [60] + [0]),  # Higher
+            ('2016-08-18', +24 * [40] + [0]),  # Lower
+            ('2016-08-19', +23 * [70] + [35] + [0]),  # Higher after lower
+        ])
         self.TestHelper.setup_rights_per_share(
-            1, '2016-08-16', 4*(24*[5]+[0]))
+            1, '2016-08-16', 4 * (24 * [5] + [0]))
 
         self.RightsGranter.recomputeRights(aggr_id, '2016-08-16', '2016-08-19')
 
         result = self.TestHelper.rights_per_share(1, '2016-08-16', '2016-08-19')
-        self.assertEqual(result, 
-            +24*[5]+[0] # Same
-            +24*[6]+[0] # Higher
-            +24*[5]+[0] # Lower
-            +12*[5]+11*[7]+[5]+[0] # Higher after lower
-            )
+        self.assertEqual(result,
+                         +24 * [5] + [0]  # Same
+                         + 24 * [6] + [0]  # Higher
+                         + 24 * [5] + [0]  # Lower
+                         + 12 * [5] + 11 * [7] + [5] + [0]  # Higher after lower
+                         )
         result = self.TestHelper.rights_correction(1, '2016-08-16', '2016-08-19')
         self.assertEqual(result,
-            +24*[0]+[0] # Same
-            +24*[0]+[0] # Higher
-            +24*[1]+[0] # Lower
-            +12*[-2]+11*[0]+[2]+[0] # Higher after lower
-            )
+                         +24 * [0] + [0]  # Same
+                         + 24 * [0] + [0]  # Higher
+                         + 24 * [1] + [0]  # Lower
+                         + 12 * [-2] + 11 * [0] + [2] + [0]  # Higher after lower
+                         )
         self.assertEqual(remainder.lastRemainders(), [
             [1, '2016-08-20', -1500],
-            ])
+        ])
 
 
 unittest.TestCase.__str__ = unittest.TestCase.id

--- a/som_generationkwh/wizard/wizard_investment_amortization.py
+++ b/som_generationkwh/wizard/wizard_investment_amortization.py
@@ -3,9 +3,8 @@ from __future__ import division
 from datetime import date, datetime, timedelta
 from osv import osv, fields
 from tools.translate import _
-import netsvc
-from som_generationkwh import investment
 import pickle
+
 
 class WizardInvestmentAmortization(osv.osv_memory):
     """Assistent per amortitzar la inversió.
@@ -26,11 +25,11 @@ class WizardInvestmentAmortization(osv.osv_memory):
             'Missatges d\'error',
             readonly=True,
         ),
-        'results':fields.text(
+        'results': fields.text(
             'resultats',
             readonly=True,
         ),
-        'validation':fields.text(
+        'validation': fields.text(
             '',
             readonly=True,
         ),
@@ -38,7 +37,7 @@ class WizardInvestmentAmortization(osv.osv_memory):
             'Estat',
             50
         ),
-        'amortizeds':fields.text(
+        'amortizeds': fields.text(
             'test',
         ),
     }
@@ -51,44 +50,44 @@ class WizardInvestmentAmortization(osv.osv_memory):
     def preview(self, cursor, uid, ids, context=None):
         wiz = self.browse(cursor, uid, ids[0], context)
         Investment = self.pool.get('generationkwh.investment')
-        current_date =  wiz.date_end
+        current_date = wiz.date_end
         investment_ids = context.get('active_ids', [])
         if context.get('search_all'):
-            investment_ids = Investment.search(cursor, uid, [('active', '=', True),('emission_id.type','=','genkwh')])
+            investment_ids = Investment.search(
+                cursor, uid, [('active', '=', True), ('emission_id.type', '=', 'genkwh')])
 
         limit_date = date.today() + timedelta(days=31)
         if datetime.strptime(str(current_date)[:10], '%Y-%m-%d').date() > limit_date:
             wiz.write(dict(
-                validation=
-                    'Data no permesa, ha de ser inferior a {limit} per poder amortitzar.\n'
-                    .format(
-                        limit = limit_date,
-                    ),
+                validation='Data no permesa, ha de ser inferior a {limit} per poder amortitzar.\n'
+                .format(
+                    limit=limit_date,
+                ),
                 state='init',
-                ))
+            ))
         else:
-            nAmortizations, totalAmount = Investment.pending_amortization_summary(cursor, uid, current_date, investment_ids)
+            nAmortizations, totalAmount = Investment.pending_amortization_summary(
+                cursor, uid, current_date, investment_ids)
 
             wiz.write(dict(
-                output=
-                    '- Amortitzacions pendents: {pending}\n\n'
-                    '- Import total: {pending_amount} €\n'
-                    .format(
-                        pending = nAmortizations,
-                        pending_amount = totalAmount,
-                    ),
+                output='- Amortitzacions pendents: {pending}\n\n'
+                '- Import total: {pending_amount} €\n'
+                .format(
+                    pending=nAmortizations,
+                    pending_amount=totalAmount,
+                ),
                 state='pre_calc',
-                ))
+            ))
 
     def generate(self, cursor, uid, ids, context=None):
-    
+
         def generate_error_string(errors):
-            print errors
+            print(errors)
             if not errors:
                 return ""
             result = "Les següents {} inversions no s'han pogut amortitzar:\n\n".format(len(errors))
             for error in errors:
-                result += "- "+str(error)
+                result += "- " + str(error)
             return result
 
         wiz = self.browse(cursor, uid, ids[0], context)
@@ -100,16 +99,18 @@ class WizardInvestmentAmortization(osv.osv_memory):
         amortized_invoice_errors = []
         investment_ids = context.get('active_ids', [])
         if context.get('search_all'):
-            investment_ids = Investment.search(cursor, uid, [('active', '=', True),('emission_id.type','=','genkwh')])
+            investment_ids = Investment.search(
+                cursor, uid, [('active', '=', True), ('emission_id.type', '=', 'genkwh')])
 
-        amortized_invoice_ids, amortized_invoice_errors = Investment.amortize(cursor, uid, current_date, investment_ids, context)
+        amortized_invoice_ids, amortized_invoice_errors = Investment.amortize(
+            cursor, uid, current_date, investment_ids, context)
 
         wiz.write(dict(
-            results= "{} inversions amortitzades.\n".format(len(amortized_invoice_ids)),
+            results="{} inversions amortitzades.\n".format(len(amortized_invoice_ids)),
             errors=generate_error_string(amortized_invoice_errors),
-            amortizeds = pickle.dumps(amortized_invoice_ids),
+            amortizeds=pickle.dumps(amortized_invoice_ids),
             state='close',
-            ))
+        ))
 
     def close_and_show(self, cursor, uid, ids, context=None):
         wiz = self.browse(cursor, uid, ids[0], context)
@@ -128,13 +129,13 @@ class WizardInvestmentAmortization(osv.osv_memory):
         amortized_ids = pickle.loads(wiz.amortizeds)
 
         AccountInvoice = self.pool.get('account.invoice')
-        PaymentOrder = self.pool.get('payment.order')
+        self.pool.get('payment.order')
         PaymentLine = self.pool.get('payment.line')
 
         payment_order_id = 0
         if amortized_ids:
             invoice = AccountInvoice.read(cursor, uid, amortized_ids[0])
-            lines = PaymentLine.search(cursor, uid, [('communication','ilike',invoice['name'])])
+            lines = PaymentLine.search(cursor, uid, [('communication', 'ilike', invoice['name'])])
             line = PaymentLine.read(cursor, uid, lines[0])
             payment_order_id = line['order_id'][0]
 
@@ -147,5 +148,6 @@ class WizardInvestmentAmortization(osv.osv_memory):
             'type': 'ir.actions.act_window',
         }
 
+
 WizardInvestmentAmortization()
-# vim: et ts=4 sw=4 
+# vim: et ts=4 sw=4

--- a/som_generationkwh/wizard/wizard_llibre_registre_socis.py
+++ b/som_generationkwh/wizard/wizard_llibre_registre_socis.py
@@ -10,6 +10,7 @@ from osv import osv, fields
 from report import report_sxw
 from zipfile import ZipFile
 
+
 class WizardLlibreRegistreSocis(osv.osv_memory):
     """Assistent per generar registre de socis"""
 
@@ -27,7 +28,7 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
 
     @job(queue="print_report", timeout=3000)
     def generate_one_report(self, cursor, uid, ids, context=None):
-        wiz = self.browse(cursor, uid, ids[0])
+        self.browse(cursor, uid, ids[0])
 
         dades = self.get_report_data(cursor, uid, ids, context)
         summary_dades = self.get_report_summary(dades)
@@ -37,7 +38,8 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
         header['date_to'] = context['date_to']
 
         document_binary = self.generate_report_pdf(cursor, uid, ids, dades, header, context)
-        document_binary_summary = self.generate_report_summary_pdf(cursor, uid, ids, summary_dades, header, context)
+        document_binary_summary = self.generate_report_summary_pdf(
+            cursor, uid, ids, summary_dades, header, context)
 
         path = "/tmp/reports"
         if not os.path.exists(path):
@@ -46,8 +48,10 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
             except OSError:
                 print ("Creation of the directory %s failed" % path)
 
-        path_filename, filename = self.create_file(path, "llibre_registre_socis_", header['date_to'][:4],document_binary[0])
-        path_filenamesummary, filenamesummary = self.create_file(path, "resum_llibre_registre_socis_", header['date_to'][:4],document_binary_summary[0])
+        path_filename, filename = self.create_file(
+            path, "llibre_registre_socis_", header['date_to'][:4], document_binary[0])
+        path_filenamesummary, filenamesummary = self.create_file(
+            path, "resum_llibre_registre_socis_", header['date_to'][:4], document_binary_summary[0])
 
         filename_zip = path + "/llibre_registre_socis_" + str(header['date_to'][:4]) + ".zip"
         zipObj = ZipFile(filename_zip, 'w')
@@ -57,20 +61,21 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
 
         ar_obj = self.pool.get('async.reports')
         datas = ar_obj.get_datas_email_params(cursor, uid, {}, context)
-        ar_obj.send_mail(cursor, uid, datas['from'], filename_zip, datas['email_to'], filename_zip.split("/")[-1])
+        ar_obj.send_mail(cursor, uid, datas['from'], filename_zip,
+                         datas['email_to'], filename_zip.split("/")[-1])
 
     def create_file(self, path, file_header, date, document):
         filename = file_header + str(date) + ".pdf"
         path_filename = path + "/" + filename
 
-        f = open(path_filename, 'wb+' )
+        f = open(path_filename, 'wb+')
         try:
             bits = base64.b64decode(base64.b64encode(document))
             f.write(bits)
         finally:
             f.close()
 
-        return path_filename,filename
+        return path_filename, filename
 
     def generate_report_pdf(self, cursor, uid, ids, dades, header, context):
         report_printer = webkit_report.WebKitParser(
@@ -79,18 +84,22 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
             'som_generationkwh/report/report_llibre_registre_socis.mako',
             parser=report_sxw.rml_parse
         )
-        return self.generate_report_document(cursor, uid, ids, dades, header, report_printer, context)
+        return self.generate_report_document(
+            cursor, uid, ids, dades, header, report_printer, context)
 
-    def generate_report_summary_pdf(self, cursor, uid, ids, summary_dades, header, context):
+    def generate_report_summary_pdf(self, cursor, uid, ids, summary_dades,
+                                    header, context):
         report_printer = webkit_report.WebKitParser(
             'report.somenergia.soci.report_llibre_registre_socis_summary',
             'somenergia.soci',
             'som_generationkwh/report/report_llibre_registre_socis_summary.mako',
             parser=report_sxw.rml_parse
         )
-        return self.generate_report_document(cursor, uid, ids, summary_dades, header, report_printer, context)
+        return self.generate_report_document(
+            cursor, uid, ids, summary_dades, header, report_printer, context)
 
-    def generate_report_document(self, cursor, uid, ids, dades, header, report_printer, context):
+    def generate_report_document(self, cursor, uid, ids, dades, header,
+                                 report_printer, context):
         data = {
             'model': 'giscedata.facturacio.factura',
             'report_type': 'webkit',
@@ -126,15 +135,15 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
                     else:
                         total_import_voluntari_retirat += inversio['import'] * -1
         return {
-                'numero_altes': numero_altes,
-                'numero_baixes': numero_baixes,
-                'total_import_voluntari': total_import_voluntari,
-                'total_import_voluntari_retirat':total_import_voluntari_retirat,
-                }
+            'numero_altes': numero_altes,
+            'numero_baixes': numero_baixes,
+            'total_import_voluntari': total_import_voluntari,
+            'total_import_voluntari_retirat': total_import_voluntari_retirat,
+        }
 
     def get_report_data(self, cursor, uid, ids, context=None):
         soci_obj = self.pool.get('somenergia.soci')
-        socis = soci_obj.search(cursor, uid, [('active','=',True)])
+        socis = soci_obj.search(cursor, uid, [('active', '=', True)])
         socis.sort()
         values = []
         for soci in socis:
@@ -149,13 +158,14 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
             header.update({'inversions': quadre_moviments})
             values.append(header)
 
-	return values
+        return values
 
     def get_soci_values(self, cursor, uid, soci, context=None):
         soci_obj = self.pool.get('somenergia.soci')
-        data = soci_obj.read(cursor, uid, soci, ['ref','name','vat',
-            'www_email', 'www_street','www_zip', 'www_provincia',
-            'date','data_baixa_soci', 'www_municipi'])
+        data = soci_obj.read(
+            cursor, uid, soci, ['ref', 'name', 'vat', 'www_email',
+                                'www_street', 'www_zip', 'www_provincia',
+                                'date', 'data_baixa_soci', 'www_municipi'])
         singles_soci_values = {
             'tipus': 'Consumidor',
             'num_soci': data['ref'],
@@ -180,7 +190,9 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
                 'concepte': u'Obligatoria',
                 'import': 100
             })
-        if data['data_baixa_soci'] and data['data_baixa_soci'] >= context['date_from'] and data['data_baixa_soci'] <= context['date_to']:
+        if (data['data_baixa_soci']
+                and data['data_baixa_soci'] >= context['date_from']
+                and data['data_baixa_soci'] <= context['date_to']):
             inversions.append({
                 'data': data['data_baixa_soci'],
                 'concepte': u'Obligatoria',
@@ -190,33 +202,39 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
 
     def get_aportacions_voluntaries_values(self, cursor, uid, soci, context=None):
         inv_obj = self.pool.get('generationkwh.investment')
-        inv_list = inv_obj.search(cursor, uid, [('member_id', '=', soci),('emission_id','>',1)])
+        inv_list = inv_obj.search(
+            cursor, uid, [('member_id', '=', soci), ('emission_id', '>', 1)])
         inversions = []
         for inv in inv_list:
-            data = inv_obj.read(cursor, uid, inv, ['purchase_date',
-                   'last_effective_date','last_effective_date','nshares',
-                   'amortized_amount'])
-            if data['purchase_date'] and data['purchase_date'] >= context['date_from'] and data['purchase_date'] <= context['date_to']:
+            data = inv_obj.read(
+                cursor, uid, inv, ['purchase_date', 'last_effective_date',
+                                   'last_effective_date', 'nshares',
+                                   'amortized_amount'])
+            if (data['purchase_date']
+                    and data['purchase_date'] >= context['date_from']
+                    and data['purchase_date'] <= context['date_to']):
                 inversions.append({
                     'data': data['purchase_date'],
                     'concepte': u'Voluntaria',
-                    'import': data['nshares']*100,
-                    'import_amortitzat':  data['amortized_amount']
+                    'import': data['nshares'] * 100,
+                    'import_amortitzat': data['amortized_amount']
                 })
-            if data['last_effective_date'] and data['last_effective_date'] >= context['date_from'] and data['last_effective_date'] <= context['date_to']:
+            if (data['last_effective_date']
+                    and data['last_effective_date'] >= context['date_from']
+                    and data['last_effective_date'] <= context['date_to']):
                 inversions.append({
                     'data': data['last_effective_date'],
                     'concepte': u'Voluntaria',
-                    'import': data['nshares']*100*-1,
-                    'import_amortitzat': data['amortized_amount']*-1
+                    'import': data['nshares'] * 100 * -1,
+                    'import_amortitzat': data['amortized_amount'] * -1
                 })
         return inversions
 
     _columns = {
         'name': fields.char('Nom fitxer', size=32),
         'state': fields.char('State', size=16),
-        'date_to': fields.date('Data final',required=True),
-        'date_from': fields.date('Data inicial',required=True),
+        'date_to': fields.date('Data final', required=True),
+        'date_from': fields.date('Data inicial', required=True),
     }
 
     _defaults = {
@@ -224,5 +242,6 @@ class WizardLlibreRegistreSocis(osv.osv_memory):
         'date_to': lambda *a: str(datetime.today()),
         'date_from': '2010-12-01',
     }
+
 
 WizardLlibreRegistreSocis()


### PR DESCRIPTION
## Objectiu

Make the `som_generationkwh` parser blockers compatible with Python 3.

## Targeta on es demana o Incidència

Closes #1368

## Comportament antic

`python3 -m compileall -q -f som_generationkwh` failed because the module contained Python 2 print statements, Python 2 exception syntax, and one tab/space indentation error.

## Comportament nou

The module now parses under Python 3. The PR keeps the parser fixes local to the affected files and also includes the smallest hook-driven lint cleanup required for pre-commit to pass on those touched files.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

## Resum

- convert Python 2 parser blockers to Python 3 compatible syntax across the affected files
- fix the mixed tab/space indentation error
- include the required local flake8 cleanup in touched files so repository hooks pass without skipping them

## Canvis

| File | Change |
|------|--------|
| `som_generationkwh/assignment.py` | Convert Python 2 print/exception syntax and apply local lint cleanup required by hooks |
| `som_generationkwh/investment_strategy.py` | Convert Python 2 exception syntax and apply local lint cleanup required by hooks |
| `som_generationkwh/som_generationkwh.py` | Convert Python 2 print statements to Python 3 syntax |
| `som_generationkwh/test/rightsgranter_test.py` | Convert Python 2 print syntax and apply local lint cleanup required by hooks |
| `som_generationkwh/wizard/wizard_investment_amortization.py` | Convert Python 2 print syntax |
| `som_generationkwh/wizard/wizard_llibre_registre_socis.py` | Fix the indentation error and apply local lint cleanup required by hooks |

## Verificació

- [x] `python3 -m compileall -q -f som_generationkwh`
- [x] `PYENV_VERSION=erp pre-commit run --files som_generationkwh/assignment.py som_generationkwh/investment_strategy.py som_generationkwh/som_generationkwh.py som_generationkwh/test/rightsgranter_test.py som_generationkwh/wizard/wizard_investment_amortization.py som_generationkwh/wizard/wizard_llibre_registre_socis.py`
- [ ] Runtime module tests in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR converts Python 2-only syntax (bare `print` statements, `except X, e` exception syntax, `unicode()` calls) to Python 3-compatible equivalents across six files in `som_generationkwh`, and fixes a mixed tab/space indentation error in `wizard_llibre_registre_socis.py`. The changes also include flake8-driven cleanup of unused imports, unused variables, and whitespace normalization required by pre-commit hooks.

- **Python 3 parser fixes** (`assignment.py`, `investment_strategy.py`, `som_generationkwh.py`, `rightsgranter_test.py`, `wizard_investment_amortization.py`, `wizard_llibre_registre_socis.py`): `print` calls, `except` syntax, and `unicode()` converted; verified passing `python3 -m compileall`.
- **Indentation fix** (`wizard_llibre_registre_socis.py`): tab on `return values` replaced with spaces, eliminating the `TabError` that was the primary Python 3 blocker.
- **Cleanup** (all files): unused imports (`netsvc`, `investment`, `date`, `addDays`, `isodate`, `ns`), unused variable assignments (`transferred`, `emited`, `ml_invoice`, `PaymentOrder`, `Journal`, `gilo_obj`), and trailing whitespace removed to satisfy pre-commit hooks.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge only after restoring the `emission.py` import; without it the `generationkwh.emission` model will not register and investment/emission flows will break at runtime.

The vast majority of the changes are mechanical Python 2→3 syntax conversions that are correct and low risk. However, the removal of `from .emission import GenerationkwhEmission` in `som_generationkwh.py` eliminates the only code path that loads `emission.py`. Since `__init__.py` does not contain `import emission`, the `generationkwh.emission` ORM model will never be instantiated or registered, breaking any ERP operation that looks up that model via `pool.get('generationkwh.emission')`.

som_generationkwh/som_generationkwh.py — the removed `from .emission import GenerationkwhEmission` line needs to be restored or `import emission` needs to be added to `__init__.py`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_generationkwh/som_generationkwh.py | Python 2 print statements converted to Python 3 and formatting cleanup applied, but the `from .emission import GenerationkwhEmission` side-effect import was also removed, which breaks `generationkwh.emission` model registration since `emission.py` is not imported anywhere else. |
| som_generationkwh/assignment.py | Python 2 `print` statement, `except X, e` syntax, and `unicode()` call converted to Python 3; unused variable initialisation (`fields_txt = ''`) removed; flake8 style fixes applied. No logic changes. |
| som_generationkwh/investment_strategy.py | Python 2 `except X, e` syntax converted to `except X as e` (or bare `except X:` where `e` was unused); unused `date` import, unused return-value assignments (`transferred`, `emited`, `ml_invoice`, `Journal`), and unused `to_partner_name` variable removed; whitespace/formatting aligned. |
| som_generationkwh/test/rightsgranter_test.py | Python 2 `print` statement in `updateMeter` converted; unused imports (`yamlns.ns`, `addDays`, `isodate`) removed; formatting cleaned up. All test logic intact. |
| som_generationkwh/wizard/wizard_investment_amortization.py | Python 2 `print errors` statement converted to `print(errors)`; unused imports (`netsvc`, `som_generationkwh.investment`) and unused `PaymentOrder` variable removed; formatting cleaned up. |
| som_generationkwh/wizard/wizard_llibre_registre_socis.py | Fixed mixed tab/space indentation on the `return values` line (the core Python 3 blocker); unused `wiz` and `Journal` variables removed; long lines broken up and whitespace normalised. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[som_generationkwh/__init__.py] --> B[import som_generationkwh\n→ som_generationkwh.py]
    A --> C[import investment_sign\n→ investment_sign.py]
    A --> D[import rightsgranter\n→ rightsgranter.py]
    B --> E[from .assignment import AssignmentProvider]
    B --> F[from .remainder import RemainderProvider]
    B --> G[from .investment import InvestmentProvider]
    B -. "removed by this PR" .-> H[from .emission import GenerationkwhEmission\n❌ REMOVED]
    H --> I[emission.py\nGenerationkwhEmission&#40;&#41; — registers model]
    I --> J[generationkwh.emission ORM model\nused by investment_strategy.py]
    style H fill:#ffcccc,stroke:#cc0000
    style I fill:#ffcccc,stroke:#cc0000
    style J fill:#ffcccc,stroke:#cc0000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[som_generationkwh/__init__.py] --> B[import som_generationkwh\n→ som_generationkwh.py]
    A --> C[import investment_sign\n→ investment_sign.py]
    A --> D[import rightsgranter\n→ rightsgranter.py]
    B --> E[from .assignment import AssignmentProvider]
    B --> F[from .remainder import RemainderProvider]
    B --> G[from .investment import InvestmentProvider]
    B -. "removed by this PR" .-> H[from .emission import GenerationkwhEmission\n❌ REMOVED]
    H --> I[emission.py\nGenerationkwhEmission&#40;&#41; — registers model]
    I --> J[generationkwh.emission ORM model\nused by investment_strategy.py]
    style H fill:#ffcccc,stroke:#cc0000
    style I fill:#ffcccc,stroke:#cc0000
    style J fill:#ffcccc,stroke:#cc0000
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(som\_generationkwh): make parser bloc..."](https://github.com/som-energia/openerp_som_addons/commit/09d14baa6d36ba881632a6a56f14ea59252f4465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41331578)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->