### PR TITLE
Make attachment migration python 3 compatible

### DIFF
--- a/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
+++ b/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import
+
 import logging
 import pooler
 from psycopg2.extensions import AsIs

--- a/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
+++ b/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
@@ -57,7 +57,10 @@ def up(cursor, installed_version):
                 '''
                 cursor.execute(sql_select, (att_id,))
                 for data in cursor.dictfetchall():
-                    print data
+                    logger.debug(
+                        'Fetched ir_attachment row for attachment %s: %s',
+                        att_id, data
+                    )
                     datas_mongo = data['datas_mongo']
 
                 search_vals = [

--- a/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
+++ b/som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py
@@ -57,6 +57,7 @@ def up(cursor, installed_version):
                     FROM ir_attachment
                     WHERE id = %s
                 '''
+                datas_mongo = None
                 cursor.execute(sql_select, (att_id,))
                 for data in cursor.dictfetchall():
                     logger.debug(
@@ -82,7 +83,7 @@ def up(cursor, installed_version):
                     SET datas_mongo = '%s'
                     WHERE id = %s;
                 '''
-                if att_ids:
+                if att_ids and datas_mongo is not None:
                     cursor.execute(sql, (AsIs(datas_mongo), att_ids[0]))
                     logger.info(
                         'Attachments actualitzat de pobresa energètica {}.'.format(scp_id[0]))


### PR DESCRIPTION
## Objectiu

Make the `som_account_invoice_pending` migration script compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1363
Replaces #1369 to follow repository branch/commit conventions.

## Comportament antic

The migration script used a Python 2 style `print` statement, so `python3 -m compileall -q -f som_account_invoice_pending` failed to parse the module.

## Comportament nou

The migration now logs the fetched row through the existing module logger at DEBUG level, preserving the original observability while parsing correctly under Python 3.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

## Canvis

| File | Change |
|------|--------|
| `som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py` | Replace the Python 2 print statement with DEBUG logging that keeps the fetched row content |

## Verificació

- [x] `python3 -m compileall -q -f som_account_invoice_pending`
- [x] `PYENV_VERSION=erp pre-commit run --files som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py`
- [ ] Module runtime tests in a fully prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Python 3 parse failure in the `som_account_invoice_pending` migration script by replacing a Python 2-style `print data` statement with a `logger.debug(...)` call and adding `from __future__ import absolute_import`. The change is minimal, self-contained, and preserves the original observability intent at DEBUG level.

- The `print data` statement on the attachment fetch loop is replaced with `logger.debug('Fetched ir_attachment row for attachment %s: %s', att_id, data)`, making the module parseable by `python3 -m compileall`.
- `from __future__ import absolute_import` is added as a forward-compatibility guard; it is a no-op in Python 3 but ensures consistent import semantics if the file is ever executed under Python 2.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line fix replacing a Python 2 print statement with an equivalent logger.debug call, with no logic changes.

The only modification is swapping `print data` for `logger.debug(...)` and adding `from __future__ import absolute_import`. No control flow, data handling, or SQL logic was touched. The new logging call correctly forwards both `att_id` and the full `data` dict at DEBUG level, preserving the original observability intent without any behavioral side-effects.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_account_invoice_pending/migrations/5.0.23.9.0/post-0004_migrate_attachments_mongo_id.py | Replaces Python 2 `print data` with `logger.debug(...)` and adds `from __future__ import absolute_import`; the fix is correct and the change is minimal with no new logic introduced. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start migration up] --> B{installed_version?}
    B -- No --> Z[Return early]
    B -- Yes --> C[Get CRM cases with section_id]
    C --> D[For each crm_id]
    D --> E[Search ir.attachment for crm_id]
    E --> F{scp_id found?}
    F -- No --> D
    F -- Yes --> G[For each att_id]
    G --> H[SQL SELECT datas_mongo FROM ir_attachment]
    H --> I[for data in dictfetchall]
    I --> J[logger.debug - Python 3 compatible replacement for print]
    J --> K[Assign datas_mongo from data dict]
    K --> L[Search matching att in som.consulta.pobresa]
    L --> M{att_ids found?}
    M -- No --> G
    M -- Yes --> N[SQL UPDATE ir_attachment SET datas_mongo]
    N --> G
    G --> D
    D --> O[Log completion]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start migration up] --> B{installed_version?}
    B -- No --> Z[Return early]
    B -- Yes --> C[Get CRM cases with section_id]
    C --> D[For each crm_id]
    D --> E[Search ir.attachment for crm_id]
    E --> F{scp_id found?}
    F -- No --> D
    F -- Yes --> G[For each att_id]
    G --> H[SQL SELECT datas_mongo FROM ir_attachment]
    H --> I[for data in dictfetchall]
    I --> J[logger.debug - Python 3 compatible replacement for print]
    J --> K[Assign datas_mongo from data dict]
    K --> L[Search matching att in som.consulta.pobresa]
    L --> M{att_ids found?}
    M -- No --> G
    M -- Yes --> N[SQL UPDATE ir_attachment SET datas_mongo]
    N --> G
    G --> D
    D --> O[Log completion]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 add py3k absolute import to attachmen..."](https://github.com/som-energia/openerp_som_addons/commit/0d9217cda02653aa2e8bcb54ed6e4a509015e163) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41345876)</sub>

<!-- /greptile_comment -->