### PR TITLE
Make gurb migration python 3 compatible

### DIFF
--- a/som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py
+++ b/som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py
@@ -33,7 +33,7 @@ def up(cursor, installed_version):
         wf_service.trg_create(uid, 'som.gurb.cups', gurb_cups.id, cursor)
         gurb_cups.send_signal('button_create_cups')
         gurb_cups.send_signal('button_activate_cups')
-        print sgc_obj.read(cursor, uid, gurb_cups.id, ['state'])
+        logger.info(sgc_obj.read(cursor, uid, gurb_cups.id, ['state']))
 
     # Update XMLs
     views = [

--- a/som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py
+++ b/som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import logging
 import pooler
 from oopgrade.oopgrade import load_data


### PR DESCRIPTION
## Objectiu

Make the `som_gurb` migration script compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1367
Replaces #1370 to follow repository branch/commit conventions.

## Comportament antic

The migration used a Python 2 style `print` statement, so `python3 -m compileall -q -f som_gurb` failed to parse the module.

## Comportament nou

The migration now logs the state diagnostic through the existing migration logger, so the module parses correctly under Python 3 and the message stays in the OpenERP log stream.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

## Canvis

| File | Change |
|------|--------|
| `som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py` | Replace the Python 2 print statement with the existing migration logger |

## Verificació

- [x] `python3 -m compileall -q -f som_gurb`
- [x] `PYENV_VERSION=erp pre-commit run --files som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py`
- [ ] Module runtime tests in a fully prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the `som_gurb` migration script (`5.0.24.5/post-0001_add_gurb_wizard.py`) Python 3 compatible by replacing the bare `print` statement (a syntax error under Python 3) with a `logger.info()` call using the existing `openerp.migration` logger.

- Replaces `print sgc_obj.read(...)` (Python 2 syntax) with `logger.info(sgc_obj.read(...))`, routing the state diagnostic into the OpenERP log stream.
- Adds `from __future__ import absolute_import` as a standard Python 2/3 compatibility header; it is a no-op under Python 3 but harmless.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line substitution in a migration script with no logic alterations.

The only change is replacing a bare Python 2 print statement with an equivalent logger.info() call and adding a no-op from __future__ import. No business logic, no data mutations, and no new code paths are introduced; the diagnostic output previously printed to stdout is now sent to the existing migration logger.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_gurb/migrations/5.0.24.5/post-0001_add_gurb_wizard.py | Replaces the Python 2 bare `print` statement with `logger.info()` and adds `from __future__ import absolute_import`; change is correct and minimal. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Migrator
    participant ORM as OpenERP ORM
    participant WF as netsvc Workflow
    participant Logger as openerp.migration logger

    Migrator->>ORM: _auto_init (som.gurb.cups)
    Migrator->>ORM: _auto_init (wizard.deactivate.gurb.cups)
    Migrator->>WF: trg_create per each gurb_cups
    WF-->>Migrator: workflow created
    Migrator->>ORM: send_signal('button_create_cups')
    Migrator->>ORM: send_signal('button_activate_cups')
    Migrator->>ORM: read(cursor, uid, gurb_cups.id, ['state'])
    ORM-->>Migrator: state dict
    Migrator->>Logger: "info(state dict) # was: print statement (Python 2 only)"
    Migrator->>ORM: load_data for each XML view
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Migrator
    participant ORM as OpenERP ORM
    participant WF as netsvc Workflow
    participant Logger as openerp.migration logger

    Migrator->>ORM: _auto_init (som.gurb.cups)
    Migrator->>ORM: _auto_init (wizard.deactivate.gurb.cups)
    Migrator->>WF: trg_create per each gurb_cups
    WF-->>Migrator: workflow created
    Migrator->>ORM: send_signal('button_create_cups')
    Migrator->>ORM: send_signal('button_activate_cups')
    Migrator->>ORM: read(cursor, uid, gurb_cups.id, ['state'])
    ORM-->>Migrator: state dict
    Migrator->>Logger: "info(state dict) # was: print statement (Python 2 only)"
    Migrator->>ORM: load_data for each XML view
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 add py3k absolute import to gurb migr..."](https://github.com/som-energia/openerp_som_addons/commit/7d5093638dfc236984ee840565bbd699451ea727) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41346236)</sub>

<!-- /greptile_comment -->