### PR TITLE
Make municipal taxes script python 3 compatible

### DIFF
--- a/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
+++ b/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import csv
 import sys
 from io import open

--- a/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
+++ b/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
@@ -1,5 +1,6 @@
 import csv
 import sys
+from io import open
 from erppeek import Client
 import dbconfig
 
@@ -51,7 +52,7 @@ def crear_ajuntament_config(fila):
 
     municipi_id = erp.ResMunicipi.search([('name', 'ilike', nom)])
     if not municipi_id:
-        print "No s'ha pogut crear: {}".format(fila['ajuntament'])
+        print("No s'ha pogut crear: {}".format(fila['ajuntament']))
         return False
 
     vals = {
@@ -84,7 +85,7 @@ def crear_ajuntament_config(fila):
 def carrega_ajuntaments(filename):
     creats = []
     no_creats = []
-    with open(filename, 'rb') as fitxer:
+    with open(filename, 'r', encoding='utf-8', newline='') as fitxer:
         lector = csv.DictReader(fitxer)
 
         # Iterem per les files del fitxer
@@ -93,19 +94,19 @@ def carrega_ajuntaments(filename):
                 result = crear_ajuntament_config(fila)
             except Exception as e:
                 result = False
-                print "No s'ha pogut crear: {}. Error: {}".format(fila['ajuntament'], str(e))
+                print("No s'ha pogut crear: {}. Error: {}".format(fila['ajuntament'], str(e)))
 
             if result:
                 creats.append(fila['ajuntament'])
             else:
                 no_creats.append(fila['ajuntament'])
 
-    print "Creats {}".format(len(creats))
-    print "No Creats {}".format(len(no_creats))
+    print("Creats {}".format(len(creats)))
+    print("No Creats {}".format(len(no_creats)))
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print u"Usage: {} <fitxer.csv>".format(sys.argv[0])
+        print(u"Usage: {} <fitxer.csv>".format(sys.argv[0]))
         sys.exit()
     carrega_ajuntaments(sys.argv[1])

--- a/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
+++ b/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import csv
 import sys
-from io import open
 from erppeek import Client
 import dbconfig
 

--- a/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
+++ b/som_municipal_taxes/migrations/script_creacio_ajuntaments.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import csv
 import sys
+from io import open
 from erppeek import Client
 import dbconfig
 


### PR DESCRIPTION
## Objectiu

Make the `som_municipal_taxes` migration helper script compatible with Python 3.

## Targeta on es demana o Incidència

Closes #1366
Replaces #1371 to follow repository branch/commit conventions.

## Comportament antic

The helper script used Python 2 print statements and opened the CSV file in binary mode, so it parsed poorly under Python 3 and would fail at runtime with `csv.DictReader`.

## Comportament nou

The helper script now uses Python 3 print syntax and opens the CSV in text mode with explicit UTF-8 encoding and `newline=''`, so it is compatible with Python 3 parsing and CSV iteration.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

## Canvis

| File | Change |
|------|--------|
| `som_municipal_taxes/migrations/script_creacio_ajuntaments.py` | Convert Python 2 print syntax and open the CSV file in Python 3 compatible text mode |

## Verificació

- [x] `python3 -m compileall -q -f som_municipal_taxes`
- [x] `PYENV_VERSION=erp pre-commit run --files som_municipal_taxes/migrations/script_creacio_ajuntaments.py`
- [ ] Runtime execution with a real CSV in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates a one-off migration helper script (`script_creacio_ajuntaments.py`) for Python 3 compatibility by converting bare `print` statements to `print()` calls and changing the CSV file open mode from `'rb'` (binary) to `'r'` with `encoding='utf-8'` and `newline=''`, which is the correct pattern for Python 3's `csv.DictReader`.

- **Print statements** — all five bare-`print` usages correctly wrapped in `print(...)`.
- **File open mode** — changed from binary `'rb'` to text `'r'` with explicit UTF-8 encoding and `newline=''`, matching the Python 3 CSV docs recommendation.
- **Compatibility shims** — three Python 2/3 shims (`from __future__ import absolute_import`, `from __future__ import print_function`, `from io import open`) were added; all are no-ops in Python 3 and can be dropped since dual compatibility is not a goal here.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are a straightforward Python 3 syntax migration with no logic or data-flow modifications.

All changes are mechanical Python 3 conversions (print functions and text-mode CSV open) that are correct and well-understood. The script is a standalone migration helper, not part of the core ERP module, so its blast radius is limited. The only note is three redundant Python 2 compatibility shims that were added but have no effect at runtime.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_municipal_taxes/migrations/script_creacio_ajuntaments.py | Python 3 migration: print statements converted to functions, CSV file opened in text mode with UTF-8 encoding and newline=''. Two redundant __future__ compatibility shims added alongside the already-flagged `from io import open`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([__main__]) --> B{argc < 2?}
    B -- Yes --> C[print usage\nsys.exit]
    B -- No --> D[carrega_ajuntaments\nfilename]
    D --> E["open(filename, 'r',\nencoding='utf-8',\nnewline='')"]
    E --> F[csv.DictReader]
    F --> G{for each row}
    G --> H[crear_ajuntament_config]
    H --> I{municipi found?}
    I -- No --> J[print warning\nreturn False]
    I -- Yes --> K{remesa?}
    K -- Yes --> L[crear_partner]
    L --> M[set partner_id in vals]
    K -- No --> N[build vals]
    M --> N
    N --> O[SomMunicipalTaxesConfig.create]
    O --> P[return True]
    J --> Q{result?}
    P --> Q
    Q -- True --> R[creats.append]
    Q -- False --> S[no_creats.append]
    R --> G
    S --> G
    G -- done --> T[print summary counts]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([__main__]) --> B{argc < 2?}
    B -- Yes --> C[print usage\nsys.exit]
    B -- No --> D[carrega_ajuntaments\nfilename]
    D --> E["open(filename, 'r',\nencoding='utf-8',\nnewline='')"]
    E --> F[csv.DictReader]
    F --> G{for each row}
    G --> H[crear_ajuntament_config]
    H --> I{municipi found?}
    I -- No --> J[print warning\nreturn False]
    I -- Yes --> K{remesa?}
    K -- Yes --> L[crear_partner]
    L --> M[set partner_id in vals]
    K -- No --> N[build vals]
    M --> N
    N --> O[SomMunicipalTaxesConfig.create]
    O --> P[return True]
    J --> Q{result?}
    P --> Q
    Q -- True --> R[creats.append]
    Q -- False --> S[no_creats.append]
    R --> G
    S --> G
    G -- done --> T[print summary counts]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 add py3k future imports to municipal ..."](https://github.com/som-energia/openerp_som_addons/commit/7d46fb4149ad760b8cdd02661c5879297ca14196) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41346830)</sub>

<!-- /greptile_comment -->