### PR TITLE
Make estalvi invoice keys python 3 compatible

### DIFF
--- a/som_estalvi/models/report_backend_som_estalvi.py
+++ b/som_estalvi/models/report_backend_som_estalvi.py
@@ -22,6 +22,14 @@ class ReportBackendSomEstalvi(ReportBackend):
         ('potencia', 'optimizations', 'optimal_powers_P6'): 3,
     }
 
+    def _get_py2_py3_compatible_value(self, data_dict, key):
+        if key in data_dict:
+            return data_dict[key]
+        try:
+            return data_dict[key.encode('utf-8')]
+        except KeyError:
+            raise KeyError(key)
+
     def get_lang(self, cursor, uid, record_id, context=None):
         if context is None:
             context = {}
@@ -189,9 +197,12 @@ class ReportBackendSomEstalvi(ReportBackend):
         )[pol.id]
 
         data["energia"] = dades_factures['Energia activa'] + dades_factures['MAG']
-        data["exces"] = dades_factures[b'Excés potència']
-        data["potencia"] = dades_factures[b'Potència']
-        data["reactiva"] = dades_factures[b'Penalització reactiva']
+        data["exces"] = self._get_py2_py3_compatible_value(
+            dades_factures, u'Excés potència')
+        data["potencia"] = self._get_py2_py3_compatible_value(
+            dades_factures, u'Potència')
+        data["reactiva"] = self._get_py2_py3_compatible_value(
+            dades_factures, u'Penalització reactiva')
         data["descompte_generacio"] = dades_factures['Flux Solar'] + dades_factures['Excedents']
 
         return data


### PR DESCRIPTION
## Objectiu

Make the `som_estalvi` report backend compatible with Python 3 parsing.

## Targeta on es demana o Incidència

Closes #1364
Replaces #1372 to follow repository branch/commit conventions.

## Comportament antic

The report backend used non-ASCII bytes literals for invoice keys, which are invalid in Python 3 and caused the module to fail during parsing.

## Comportament nou

The report backend now uses a small unicode/bytes compatibility helper. If the bytes fallback also misses, the helper re-raises `KeyError` with the original unicode key so debugging stays readable.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

## Canvis

| File | Change |
|------|--------|
| `som_estalvi/models/report_backend_som_estalvi.py` | Replace invalid non-ASCII bytes key lookups with a Python 2 / Python 3 compatible helper that preserves readable `KeyError` diagnostics |

## Verificació

- [x] `python3 -m compileall -q -f som_estalvi`
- [x] `PYENV_VERSION=erp pre-commit run --files som_estalvi/models/report_backend_som_estalvi.py`
- [ ] Runtime module tests in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Python 3 parse-time `SyntaxError` in `som_estalvi` caused by bytes literals containing non-ASCII characters (e.g. `b'Excés potència'`), which are invalid in Python 3. It introduces a small `_get_py2_py3_compatible_value` helper that tries the unicode key first and falls back to the UTF-8 encoded bytes key, matching what `wizard.informe.dades_desagregades.find_invoices` produces in Python 2 (where it returns byte-string keys because that wizard has no `unicode_literals` import).

- **Non-ASCII bytes literals replaced**: The three `b'Excés potència'`, `b'Potència'`, and `b'Penalització reactiva'` lookups are replaced with helper calls using `u'...'` unicode keys, correctly covering both runtimes.
- **ASCII keys unchanged**: The remaining `'Energia activa'`, `'MAG'`, `'Flux Solar'`, and `'Excedents'` lookups are all-ASCII and continue to work without the helper in both Python 2 and Python 3.
- **`compileall` verified**: The fix is confirmed to pass `python3 -m compileall`, resolving the module-level import failure.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is a targeted syntax fix that restores module importability under Python 3 without altering runtime logic.

The helper correctly reflects how `wizard.informe.dades_desagregades.find_invoices` builds its dict: byte-string keys in Python 2 (no `unicode_literals`) and str keys in Python 3. The unicode-first / bytes-fallback strategy handles both environments, the ASCII-only keys are untouched and unaffected, and `compileall` confirms the parse-time error is resolved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_estalvi/models/report_backend_som_estalvi.py | Introduces `_get_py2_py3_compatible_value` helper and replaces three non-ASCII bytes-literal dict lookups with compatible unicode-first calls; logic is correct for both runtimes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get_costs() calls find_invoices()"] --> B["dades_factures dict returned\n(bytes keys in Py2, str keys in Py3)"]
    B --> C["_get_py2_py3_compatible_value(dades_factures, u'Excés potència')"]
    C --> D{key in data_dict?}
    D -- "Yes (Python 3: str key matches)" --> E["Return data_dict[key]"]
    D -- "No (Python 2: hash mismatch\nfor non-ASCII unicode vs bytes)" --> F["Try data_dict[key.encode('utf-8')]"]
    F -- "Found (Python 2: UTF-8 bytes key matches)" --> G["Return value"]
    F -- "KeyError" --> H["raise KeyError(key) — readable unicode key"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["get_costs() calls find_invoices()"] --> B["dades_factures dict returned\n(bytes keys in Py2, str keys in Py3)"]
    B --> C["_get_py2_py3_compatible_value(dades_factures, u'Excés potència')"]
    C --> D{key in data_dict?}
    D -- "Yes (Python 3: str key matches)" --> E["Return data_dict[key]"]
    D -- "No (Python 2: hash mismatch\nfor non-ASCII unicode vs bytes)" --> F["Try data_dict[key.encode('utf-8')]"]
    F -- "Found (Python 2: UTF-8 bytes key matches)" --> G["Return value"]
    F -- "KeyError" --> H["raise KeyError(key) — readable unicode key"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 make estalvi invoice keys python 3 co..."](https://github.com/som-energia/openerp_som_addons/commit/f0063c39cc7becda3af229d7bb6486860ae61af7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41347964)</sub>

<!-- /greptile_comment -->