### PR TITLE
Make giscedata factura report python 3 compatible

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -42,7 +42,7 @@ mean_zipcode_consumption_dates = {
 
 show_iva_column_date = "2023-10-10"
 
-EXCESS_MAXIMETER_PRICE_CHANGE_DATE = datetime(2025, 4, 1)
+excess_maximeter_price_change_date = datetime(2025, 4, 1)
 
 auvi_logo_attachment_name = "auvi_logo.png"
 
@@ -3813,7 +3813,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 items["date_from"] = excess_lines["date_from"]
                 items["date_to"] = excess_lines["date_to"]
                 items["pre_2025_04_01"] = datetime.strptime(
-                    excess_lines["date_to"], "%d/%m/%Y") < EXCESS_MAXIMETER_PRICE_CHANGE_DATE
+                    excess_lines["date_to"], "%d/%m/%Y") < excess_maximeter_price_change_date
                 items["iva"] = excess_lines["iva"]
             excess_data.append(items)
         data = {

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -1,14 +1,24 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+# pylint: disable=old-division,round-builtin
+
+try:
+    from itertools import izip_longest as zip_longest
+except ImportError:
+    from itertools import zip_longest
+from operator import attrgetter
+
 from osv import osv
 from yamlns import namespace as ns
 from datetime import datetime, timedelta
 import inspect
 from tools.translate import _
 import json
-from operator import attrgetter
 from collections import Counter
 import base64
 from decimal import Decimal
+
+STRING_TYPES = (str, type(u""))
 
 SENSE_EXCEDENTS = ["31", "32", "33"]
 
@@ -42,7 +52,7 @@ compl_cas = "Facturación Complementaria imputada por parte de la Distribuidora"
 
 def get_lang_partner(fact):
     lang = fact.lang_partner
-    if isinstance(lang, basestring):
+    if isinstance(lang, STRING_TYPES):
         return lang
     return 'es_ES'
 
@@ -300,7 +310,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             if isinstance(data, (list, tuple)):
                 return [ns_to_dict(item) for item in data]
             if isinstance(data, (dict, ns)):
-                return {key: ns_to_dict(value) for key, value in data.iteritems()}
+                return {key: ns_to_dict(value) for key, value in data.items()}
             return data
 
         data = self.get_components_data(cursor, uid, f_id, context=context)[f_id]
@@ -886,7 +896,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
 
     def get_gkwh_owner(self, line):
         """Gets owner of gkwh line kwh"""
-        if not line.is_gkwh().values()[0]:
+        has_gkwh = line.is_gkwh()[line.id]
+        if not has_gkwh:
             return ""
 
         line_owner_obj = line.pool.get("generationkwh.invoice.line.owner")
@@ -2695,7 +2706,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         parametres = ["comptador", "data_anterior", "data_actual"]
         periodes_max_d = [p.read(parametres)[0] for p in periodes_max]
 
-        lectures = map(None, periodes_act_d, periodes_rea_d, periodes_max_d)
+        lectures = zip_longest(periodes_act_d, periodes_rea_d, periodes_max_d)
 
         comptador_actual = None
         comptador_anterior = None
@@ -4339,8 +4350,14 @@ class GiscedataFacturacioFacturaReport(osv.osv):
             lectures_m.append((lectura.name, lectura.pot_contract, lectura.pot_maximetre))
 
         fact_potencia = dict([(p, 0) for p in periodes_m])
-        for p in [(p.product_id.name, p.quantity) for p in excess_lines]:
-            fact_potencia.update({p[0]: max(fact_potencia.get(p[0], 0), p[1])})
+        for product_name, quantity in [
+            (line.product_id.name, line.quantity) for line in excess_lines
+        ]:
+            fact_potencia.update(
+                {
+                    product_name: max(fact_potencia.get(product_name, 0), quantity)
+                }
+            )
 
         for reading in lectures_m:
             data[reading[0]] = {

--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -32,6 +32,8 @@ mean_zipcode_consumption_dates = {
 
 show_iva_column_date = "2023-10-10"
 
+EXCESS_MAXIMETER_PRICE_CHANGE_DATE = datetime(2025, 4, 1)
+
 auvi_logo_attachment_name = "auvi_logo.png"
 
 compl_cat = "Facturació Complementaria imputada per part de la Distribuïdora"
@@ -3800,7 +3802,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
                 items["date_from"] = excess_lines["date_from"]
                 items["date_to"] = excess_lines["date_to"]
                 items["pre_2025_04_01"] = datetime.strptime(
-                    excess_lines["date_to"], "%d/%m/%Y") < datetime(2025, 04, 1)
+                    excess_lines["date_to"], "%d/%m/%Y") < EXCESS_MAXIMETER_PRICE_CHANGE_DATE
                 items["iva"] = excess_lines["iva"]
             excess_data.append(items)
         data = {

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 import mock
 from destral import testing

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import mock
-import unittest
 from destral import testing
 from destral.transaction import Transaction
 from yamlns import namespace as ns
@@ -177,40 +176,6 @@ class Tests_FacturacioFacturaReport_logo_component(Tests_FacturacioFacturaReport
             result,
             {"logo": "logo_som2.png", "has_agreement_partner": False, "has_auvi": False},
         )
-
-    @unittest.skip(reason="WIP using mock")
-    @mock.patch("som_polissa_soci.giscedata_polissa.GiscedataPolissa")
-    def test__som_report_comp_logo__energetica_mock(self, patch):
-        f_id = self.get_fixture("giscedata_facturacio", "factura_0001")
-        self.get_fixture("giscedata_polissa", "polissa_0001")
-
-        print "+-" * 50  # noqa: E999
-        print f.polissa_id  # noqa: F821
-        print f.polissa_id.soci  # noqa: F821
-        print f.polissa_id.id  # noqa: F821
-
-        p = self.partner_obj.browse(self.cursor, self.uid, 23)
-        self.partner_obj.write(self.cursor, self.uid, p.id, {"ref": "S019753"})
-        print "*" * 50
-        print p
-        print p.ref
-
-        with patch("soci") as polissa:
-            polissa.return_value = "S019753"
-
-            print "*" * 50
-            print f.polissa_id.soci  # noqa: F821
-
-            result = self.r_obj.get_component_logo_data(**self.bfp(f_id))
-            self.assertYamlfy(result)
-            self.assertEquals(
-                result,
-                {
-                    "logo": "logo_som2.png",
-                    "has_agreement_partner": True,
-                    "logo_agreement_partner": "logo_S019753.png",
-                },
-            )
 
     @mock.patch.object(
         giscedata_facturacio_report.GiscedataFacturacioFacturaReport, "get_auvi_data"


### PR DESCRIPTION
## Objectiu

Make the `giscedata_facturacio_comer_som` parser blockers compatible with Python 3.

## Targeta on es demana o Incidència

Closes #1365
Replaces #1373 to follow repository branch/commit conventions.

## Comportament antic

The module failed `python3 -m compileall -q -f giscedata_facturacio_comer_som` because it contained an invalid leading-zero integer literal and legacy Python 2 debug code in the touched test file.

## Comportament nou

The report code now uses a clearly named cutoff date constant with valid Python 3 syntax, and the dead skipped WIP test has been removed instead of keeping legacy debug code around.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

## Canvis

| File | Change |
|------|--------|
| `giscedata_facturacio_comer_som/giscedata_facturacio_report.py` | Replace the invalid integer literal with a named Python 3 compatible cutoff date |
| `giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py` | Remove the dead skipped WIP test that contained legacy Python 2 debug code |

## Verificació

- [x] `python3 -m compileall -q -f giscedata_facturacio_comer_som`
- [x] `PYENV_VERSION=erp pre-commit run --files giscedata_facturacio_comer_som/giscedata_facturacio_report.py giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py`
- [ ] Runtime module tests in a prepared ERP environment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `giscedata_facturacio_comer_som` compile and run under Python 3 by fixing all blocking incompatibilities in the report module and removing a dead skipped test that contained Python 2-only `print` statements.

- **`giscedata_facturacio_report.py`**: Replaces `basestring` with a compatible `STRING_TYPES` tuple, `iteritems()` with `items()`, `map(None, ...)` with `zip_longest(...)` (with a try/except import for Python 2/3), `dict.values()[0]` with an explicit `[line.id]` key lookup, and the invalid octal literal `datetime(2025, 04, 1)` with a named constant `EXCESS_MAXIMETER_PRICE_CHANGE_DATE`.
- **`tests_FacturacioFacturaReport_some.py`**: Removes the `@unittest.skip`-guarded WIP test that used Python 2 `print` statement syntax, which caused a `SyntaxError` on Python 3 at import time.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are minimal, targeted Python 3 compatibility fixes with no functional logic alterations.

Every fix is a well-understood Python 2→3 migration: `iteritems()` → `items()`, `map(None, ...)` → `zip_longest(...)`, `basestring` → a compatible tuple, and the removal of an invalid octal literal. The `is_gkwh()[line.id]` change is semantically more precise than the original `.values()[0]` and consistent with OpenERP's ORM dict-keyed-by-id convention. The removed test was permanently skipped and syntactically broken under Python 3, so its removal is strictly positive.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| giscedata_facturacio_comer_som/giscedata_facturacio_report.py | Python 3 compatibility fixes: replaced `basestring` with a `STRING_TYPES` tuple, `iteritems()` → `items()`, `map(None, ...)` → `zip_longest(...)`, `dict.values()[0]` → keyed lookup by `line.id`, and invalid octal literal `04` → named constant. All fixes are semantically equivalent and correct. |
| giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py | Removed dead skipped WIP test containing Python 2-only `print` statements (syntax errors in Python 3); added `from __future__ import absolute_import`. No active tests were removed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[giscedata_facturacio_report.py] --> B{Python version}
    B -->|Python 2| C1[izip_longest]
    B -->|Python 3| C2[zip_longest]
    C1 & C2 --> D["lectures = zip_longest(periodes_act_d, periodes_rea_d, periodes_max_d)"]

    A --> E[get_lang_partner]
    E --> F{"isinstance(lang, STRING_TYPES)"}
    F -->|True| G[return lang]
    F -->|False| H["return 'es_ES'"]

    A --> I[get_gkwh_owner]
    I --> J["has_gkwh = line.is_gkwh()[line.id]"]
    J -->|False| K[return empty string]
    J -->|True| L[lookup line owner]

    A --> M["ns_to_dict / data.items()"]

    A --> O[get_excess_maximeter_data]
    O --> P{"date_to < EXCESS_MAXIMETER_PRICE_CHANGE_DATE"}
    P -->|True| Q["pre_2025_04_01 = True"]
    P -->|False| R["pre_2025_04_01 = False"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[giscedata_facturacio_report.py] --> B{Python version}
    B -->|Python 2| C1[izip_longest]
    B -->|Python 3| C2[zip_longest]
    C1 & C2 --> D["lectures = zip_longest(periodes_act_d, periodes_rea_d, periodes_max_d)"]

    A --> E[get_lang_partner]
    E --> F{"isinstance(lang, STRING_TYPES)"}
    F -->|True| G[return lang]
    F -->|False| H["return 'es_ES'"]

    A --> I[get_gkwh_owner]
    I --> J["has_gkwh = line.is_gkwh()[line.id]"]
    J -->|False| K[return empty string]
    J -->|True| L[lookup line owner]

    A --> M["ns_to_dict / data.items()"]

    A --> O[get_excess_maximeter_data]
    O --> P{"date_to < EXCESS_MAXIMETER_PRICE_CHANGE_DATE"}
    P -->|True| Q["pre_2025_04_01 = True"]
    P -->|False| R["pre_2025_04_01 = False"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 fix py3k compatibility warnings"](https://github.com/som-energia/openerp_som_addons/commit/504627dfefae7a7995b2cc089dcd0869d0531598) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41348850)</sub>

<!-- /greptile_comment -->