### PR TITLE
🐛 Arreglar comparador de pdf's quan els documents tenen diferent número de planes

### DIFF
--- a/report_tester/scripts/pdfcmp.sh
+++ b/report_tester/scripts/pdfcmp.sh
@@ -62,6 +62,28 @@ rasterjoin() {
 	convert "${@:2}" "$1"
 }
 
+count_pages() {
+    ls "$1"/page_*.pdf 2>/dev/null | wc -l
+}
+
+create_blank_page() {
+    page_num=$(printf "%03d" "$2")
+    png_path="$1/page_${page_num}.png"
+    pdf_path="$1/page_${page_num}.pdf"
+
+    run convert -size 595x842 xc:white "$png_path"
+    run convert "$png_path" "$pdf_path"
+}
+
+pad_with_blank_pages() {
+    current_pages=$(count_pages "$1")
+
+    while [ "$current_pages" -lt "$2" ]; do
+        current_pages=$((current_pages + 1))
+        create_blank_page "$1" "$current_pages"
+    done
+}
+
 mkdir -p "${TMPDIR}/input_a"
 mkdir -p "${TMPDIR}/input_b"
 mkdir -p "${TMPDIR}/diff"
@@ -71,6 +93,17 @@ mkdir -p "${TMPDIR}/merged"
 
 run split  "${INPUT_A}"  "${TMPDIR}/input_a/page_%03d.png"
 run split  "${INPUT_B}"  "${TMPDIR}/input_b/page_%03d.png"
+
+pages_a=$(count_pages "${TMPDIR}/input_a")
+pages_b=$(count_pages "${TMPDIR}/input_b")
+
+max_pages="$pages_a"
+if [ "$pages_b" -gt "$max_pages" ]; then
+    max_pages="$pages_b"
+fi
+
+pad_with_blank_pages "${TMPDIR}/input_a" "$max_pages"
+pad_with_blank_pages "${TMPDIR}/input_b" "$max_pages"
 
 for page in ${TMPDIR}/input_a/page_*.png; do
     $verbose && step "Comparing $(basename $page .png)..."

--- a/report_tester/scripts/pdfcmp.sh
+++ b/report_tester/scripts/pdfcmp.sh
@@ -63,7 +63,7 @@ rasterjoin() {
 }
 
 count_pages() {
-    ls "$1"/page_*.pdf 2>/dev/null | wc -l
+    ls "$1"/page_*.png 2>/dev/null | wc -l
 }
 
 create_blank_page() {


### PR DESCRIPTION
## Objectiu

Report tester mes robust

## Targeta on es demana o Incidència

Sorgida de les targetes:
https://somenergia.openproject.com/projects/som-energia/work_packages/1437/activity
https://somenergia.openproject.com/projects/som-energia/work_packages/1774/activity
https://somenergia.openproject.com/projects/som-energia/work_packages/1777/activity
https://somenergia.openproject.com/projects/som-energia/work_packages/1778/activity

## Comportament antic

Errors silenciosos, falta de detecció d'alguins errors

## Comportament nou

Detecció correta

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the PDF comparison script to handle documents with different page counts. The main changes are:

- Count generated PNG pages before comparing.
- Pad the shorter side with blank pages.
- Generate blank PNG and PDF files for padded pages.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This is close, but the PDF comparison can still miss a changed page.

- The shorter-document padding works for normal tail-page differences.
- A page dropped by rasterization on both inputs is not padded or compared.
- That can make different PDFs look identical.

report_tester/scripts/pdfcmp.sh
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| report_tester/scripts/pdfcmp.sh | Adds PNG-based page counting and blank-page padding for PDFs with different page counts. |

</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 count png not pdf&#39;s"](https://github.com/som-energia/openerp_som_addons/commit/cf0ccaef3029bf3f09afed439beeee5898321a1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43247525)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (19)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/som-energia/github/Som-Energia/openerp_som_addons/-/custom-context?memory=73910dc8-2bf7-4f16-a448-409dbfed562b))
- Context used - .agents/skill-registry.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=046da57a-a39f-4238-9b9a-7553fe2716e9))
- Context used - docs/guides/sentry-triage-workflow.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=cd3cd948-41ea-4a72-82a6-f7340721357b))
- Context used - docs/external_repos.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=ed414071-cc85-485a-bd45-d7cf0caa01a8))
- Context used - docs/patterns/demo-data.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=84a07b27-afea-479b-b101-7722cd859ec7))
- Context used - docs/README.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=12593d98-c55c-40c9-9747-2ea9580c5432))
- Context used - docs/patterns/inheritance-types.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=2e11246d-dc3d-4ebe-b815-9d63d8cdb7e6))
- Context used - docs/patterns/_index.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=382e9f52-d803-40f7-bdbb-8eff1439dc8e))
- Context used - docs/patterns/test-basic.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=e4d219c4-b316-4627-b039-956a82ce39a6))
- Context used - docs/tech.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=06dde590-4bd4-4d07-8a39-88b9ac3063e2))
- Context used - docs/guides/getting-started.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=510e3c8a-244b-486d-a008-d1c58cf470e8))
- Context used - docs/guides/testing.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=da12fb97-d47f-43c9-83c8-eea70a2a63e4))
- Context used - docs/patterns/field-add.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=c23b41f9-a347-4f58-ab80-1399f6a84bb7))
- Context used - docs/patterns/module-structure.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=a32eeddb-b412-4e1a-bc90-ea484569aeed))
- Context used - docs/crear_nou_modul.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=b10acc42-54df-4ab0-832f-2f2790add231))
- Context used - docs/patterns/view-extend.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=6f795fce-9b26-4233-b182-e53e9fa08cc4))
- Context used - docs/patterns/wizard.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=ae87450a-a68f-41fc-9e7d-b549425b6a95))
- Context used - docs/guides/_index.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=ee3f9f39-c06a-4113-8371-3102870cdffd))
- Context used - docs/adr/0001-define-code-style.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=afdcb98a-d8c4-4106-bf9b-b025fad58e6e))
</details>

<!-- /greptile_comment -->