### PR TITLE
🐛 Arreglar tests que fallen del backend de la factura en pdf

### DIFF
--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -667,7 +667,7 @@ class Tests_FacturacioFacturaReport_contract_data_component(Tests_FacturacioFact
                 "pricelist": u"TARIFAS ELECTRICIDAD",
                 "autoconsum_cau": "",
                 "is_autoconsum_colectiu": False,
-                "cups_direction": u"carrer inventat, 1 ESC. 1 1 1 aclaridor 00001 (Poble de Prova)",  # noqa: E501
+                "cups_direction": u"carrer inventat, 1 1 1 1 aclaridor 00001 (Poble de Prova)",  # noqa: E501
                 "autoconsum_colectiu_repartiment": 100.0,
                 "cnae": u"0111",
                 "power_invoicing_type": True,
@@ -720,7 +720,7 @@ class Tests_FacturacioFacturaReport_contract_data_component(Tests_FacturacioFact
             "pricelist": u"TARIFAS ELECTRICIDAD",
             "autoconsum_cau": u"ES0318363477145938GEA000",
             "is_autoconsum_colectiu": False,
-            "cups_direction": u"carrer inventat, 1 ESC. 1 1 1 aclaridor 00001 (Poble de Prova)",  # noqa: E501
+            "cups_direction": u"carrer inventat, 1 1 1 1 aclaridor 00001 (Poble de Prova)",  # noqa: E501
             "autoconsum_colectiu_repartiment": 100.0,
             "cnae": u"0111",
             "power_invoicing_type": False,
@@ -2146,7 +2146,7 @@ class Tests_FacturacioFacturaReport_invoice_info(Tests_FacturacioFacturaReport_b
                 "start_date": "01/01/2016",
                 "end_date": "29/02/2016",
                 "contract_number": u"0001C",
-                "address": u"carrer inventat, 1 ESC. 1 1 1 aclaridor 00001 (Poble de Prova)",
+                "address": u"carrer inventat, 1 1 1 1 aclaridor 00001 (Poble de Prova)",
                 "due_date": "01/01/2016",
             },
         )

--- a/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
+++ b/giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import mock
 import unittest
 from destral import testing
@@ -49,7 +50,7 @@ class Tests_FacturacioFacturaReport_base(testing.OOTestCase):
         lang_obj.create(self.cursor, self.uid, {"name": "cat", "code": "ca_ES"})
 
     def assertYamlfy(self, result):
-        self.assertTrue(len(ns.loads(ns(result).dump()).keys()) >= 0)
+        self.assertTrue(len(list((ns.loads(ns(result).dump()).keys()))) >= 0)
 
 
 class Tests_FacturacioFacturaReport_fill_and_find(Tests_FacturacioFacturaReport_base):
@@ -184,22 +185,11 @@ class Tests_FacturacioFacturaReport_logo_component(Tests_FacturacioFacturaReport
         f_id = self.get_fixture("giscedata_facturacio", "factura_0001")
         self.get_fixture("giscedata_polissa", "polissa_0001")
 
-        print "+-" * 50  # noqa: E999
-        print f.polissa_id  # noqa: F821
-        print f.polissa_id.soci  # noqa: F821
-        print f.polissa_id.id  # noqa: F821
-
         p = self.partner_obj.browse(self.cursor, self.uid, 23)
         self.partner_obj.write(self.cursor, self.uid, p.id, {"ref": "S019753"})
-        print "*" * 50
-        print p
-        print p.ref
 
         with patch("soci") as polissa:
             polissa.return_value = "S019753"
-
-            print "*" * 50
-            print f.polissa_id.soci  # noqa: F821
 
             result = self.r_obj.get_component_logo_data(**self.bfp(f_id))
             self.assertYamlfy(result)

--- a/giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
+++ b/giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
@@ -118,6 +118,9 @@ class Tests_FacturacioFacturaReportV2_base(testing.OOTestCase):
         fact.partner_id.write({'lang': 'ca_ES'})
         fact.write({'date_due': '2024-12-31'})
         fact.polissa_id.titular.write({'vat': 'ES11111111H'})
+        fact.company_id.write({
+            'partner_address_id': 1,
+        })
 
 
 class Tests_FacturacioFacturaReportV2(Tests_FacturacioFacturaReportV2_base):

--- a/giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
+++ b/giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
@@ -119,7 +119,7 @@ class Tests_FacturacioFacturaReportV2_base(testing.OOTestCase):
         fact.write({'date_due': '2024-12-31'})
         fact.polissa_id.titular.write({'vat': 'ES11111111H'})
         fact.company_id.write({
-            'partner_address_id': 1,
+            'partner_address_id': fact.company_id.partner_id.address[0].id,
         })
 
 

--- a/giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
+++ b/giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 from destral import testing
 from destral.transaction import Transaction
 


### PR DESCRIPTION
## Objectiu

Arreglar tests que fallen del backend de la factura en pdf

## Targeta on es demana o Incidència

lliure

## Comportament antic

tests fallen

## Comportament nou

tests no fallen

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates PDF invoice backend tests to match the current fixture data. The main changes are:

- Removes `ESC.` from three expected CUPS address values.
- Sets a company address before running the v2 report tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The test changes look mergeable after replacing the hard-coded address ID.

- The three address expectations change consistently.
- The v2 setup depends on database load order, which can make the test fail or use an unrelated address.

giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| giscedata_facturacio_comer_som/tests/tests_FacturacioFacturaReport_some.py | Updates three expected report addresses sourced from the same CUPS fixture. |
| giscedata_facturacio_comer_som/tests/tests_facturacio_factura_report_v2.py | Adds company-address setup but references the address through an unstable database ID. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 fix backend failing tests"](https://github.com/som-energia/openerp_som_addons/commit/01610a380c9e46d8adc306a245be7eeead292ad9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43859995)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/som-energia/github/Som-Energia/openerp_som_addons/-/custom-context?memory=73910dc8-2bf7-4f16-a448-409dbfed562b))
- Context used - docs/patterns/demo-data.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=84a07b27-afea-479b-b101-7722cd859ec7))
- Context used - docs/patterns/test-basic.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=e4d219c4-b316-4627-b039-956a82ce39a6))
- Context used - docs/guides/testing.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=da12fb97-d47f-43c9-83c8-eea70a2a63e4))
</details>

<!-- /greptile_comment -->