### PR TITLE
🐛 (gurb) Activate instead of deactivation

### DIFF
--- a/som_gurb/models/giscedata_switching.py
+++ b/som_gurb/models/giscedata_switching.py
@@ -386,14 +386,6 @@ class GiscedataSwitchingM1_05(osv.osv):
                     gurb_obj.activate_gurb_from_m1_05(
                         cursor, uid, sw_id, data_activacio, context=context
                     )
-                    gurb_cups_id = sgc_obj.search(
-                        cursor, uid, [('cups_id', '=', sw.cups_polissa_id.cups.id)], context=context
-                    )
-                    if gurb_cups_id:
-                        gurb_cups = sgc_obj.browse(cursor, uid, gurb_cups_id[0], context=context)
-                        gurb_cups.send_signal(['button_activate_modification'])
-                        gurb_cups.send_signal(['button_activate_cups'])
-
         return step_id
 
 

--- a/som_gurb/models/som_gurb_cups.py
+++ b/som_gurb/models/som_gurb_cups.py
@@ -419,7 +419,7 @@ class SomGurbCups(osv.osv):
             )
         gurb_cups = self.browse(cursor, uid, gurb_cups_id, context=context)
         if gurb_cups.state == "atr_pending":
-            gurb_cups.send_signal(["button_confirm_atr"])
+            gurb_cups.send_signal(["button_reject_atr"])
         elif gurb_cups.state == "comming_registration":
             gurb_cups.send_signal(["button_activate_cups"])
 


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes how GURB CUPS records are activated after an M1-05 response. The main changes are:

- Return an `atr_pending` CUPS to `active` through `button_reject_atr`.
- Remove duplicate activation signals from M1-05 processing.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The M1-05 modification path can leave a GURB CUPS in an intermediate state.

- Registration and ATR-pending activation remain handled by the callee.
- The removed signal was the completion transition for `comming_modification`.
- No replacement branch handles that state.

som_gurb/models/giscedata_switching.py and som_gurb/models/som_gurb_cups.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_gurb/models/giscedata_switching.py | Removes caller-side activation signals, including the transition that completes `comming_modification`. |
| som_gurb/models/som_gurb_cups.py | Changes the `atr_pending` path to return the GURB CUPS to `active`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 (gurb) Activate instead of deactivati..."](https://github.com/som-energia/openerp_som_addons/commit/7c6fe752a5c38dbe9bf192174137a3f603e6f522) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44146798)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/som-energia/github/Som-Energia/openerp_som_addons/-/custom-context?memory=73910dc8-2bf7-4f16-a448-409dbfed562b))
- Context used - .agents/skills/erp-test/SKILL.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=541c3dd3-6556-4435-8605-564ca2cb6346))
- Context used - docs/patterns/test-basic.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=e4d219c4-b316-4627-b039-956a82ce39a6))
- Context used - docs/guides/testing.md ([source](https://app.greptile.com/som-energia/-/custom-context?memory=da12fb97-d47f-43c9-83c8-eea70a2a63e4))
</details>

<!-- /greptile_comment -->