### PR TITLE
✨ Script d'ajuda al canvi de posicions fiscals al ERP

### DIFF
--- a/scripts/change_fiscal_positions.py
+++ b/scripts/change_fiscal_positions.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import dbconfig
+from erppeek import Client
+from consolemsg import success
+from tqdm import tqdm
+
+O = Client(**dbconfig.erppeek)  # noqa: E741
+
+fp_change_map = [
+    (98, 88),
+    (97, 87),
+    (39, 90),
+    (99, 89),
+    (96, 82),
+    (102, 86),
+    (103, 85),
+]
+
+pol_obj = O.GiscedataPolissa
+mod_obj = O.GiscedataPolissaModcontractual
+
+for fp_old, fp_new in tqdm(fp_change_map):
+    pol_ids = pol_obj.search([
+        ('fiscal_position_id', '=', fp_old),
+        ('state', 'in', ['activa', 'esborrany', 'baixa'])
+    ])
+
+    """ slow version
+    for p_id in tqdm(pol_ids):
+        pol = pol_obj.browse(p_id)
+        pol.fiscal_position_id = fp_new
+        pol.modcontractual_activa.fiscal_position_id = fp_new
+    """
+
+    pol_data = pol_obj.read(pol_ids, ['modcontractual_activa'])
+    mod_ids = [p['modcontractual_activa'][0] for p in pol_data if p['modcontractual_activa']]
+
+    pol_obj.write(pol_ids, {'fiscal_position_id': fp_new})
+    mod_obj.write(mod_ids, {'fiscal_position_id': fp_new})
+    success("FP {} -> {}: {} polisses actualitzades {} modcons actialitzades".format(fp_old,
+            fp_new, len(pol_ids), len(mod_ids)))

--- a/scripts/change_fiscal_positions.py
+++ b/scripts/change_fiscal_positions.py
@@ -6,6 +6,8 @@ from tqdm import tqdm
 
 O = Client(**dbconfig.erppeek)  # noqa: E741
 
+write_vals = False
+
 fp_change_map = [
     (98, 88),
     (97, 87),
@@ -28,14 +30,17 @@ for fp_old, fp_new in tqdm(fp_change_map):
     """ slow version
     for p_id in tqdm(pol_ids):
         pol = pol_obj.browse(p_id)
-        pol.fiscal_position_id = fp_new
-        pol.modcontractual_activa.fiscal_position_id = fp_new
+        if write_vals:
+            pol.fiscal_position_id = fp_new
+            pol.modcontractual_activa.fiscal_position_id = fp_new
     """
 
     pol_data = pol_obj.read(pol_ids, ['modcontractual_activa'])
     mod_ids = [p['modcontractual_activa'][0] for p in pol_data if p['modcontractual_activa']]
 
-    pol_obj.write(pol_ids, {'fiscal_position_id': fp_new})
-    mod_obj.write(mod_ids, {'fiscal_position_id': fp_new})
-    success("FP {} -> {}: {} polisses actualitzades {} modcons actialitzades".format(fp_old,
-            fp_new, len(pol_ids), len(mod_ids)))
+    if write_vals:
+        pol_obj.write(pol_ids, {'fiscal_position_id': fp_new})
+        mod_obj.write(mod_ids, {'fiscal_position_id': fp_new})
+
+    success("FP {} -> {}: {} polisses actualitzades {} modcons actualitzades {}".format(
+            fp_old, fp_new, len(pol_ids), len(mod_ids), "Si" if write_vals else "No"))

--- a/scripts/change_fiscal_positions.py
+++ b/scripts/change_fiscal_positions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import dbconfig
 from erppeek import Client
 from consolemsg import success
@@ -8,6 +9,7 @@ O = Client(**dbconfig.erppeek)  # noqa: E741
 
 write_vals = False
 
+# Hardcoded IDs handle with extremely caution, do not use in production without validation.
 fp_change_map = [
     (98, 88),
     (97, 87),


### PR DESCRIPTION
## Objectiu

Fer els canvis de posició fiscal ràpidament (canàries + excepcions) 

## Targeta on es demana o Incidència

Tancament de ronda surt possibilitat de possible futur canvi d'iva a l'agost, script desenvolupat pel canvi anterior

## Comportament antic

Feina manual, errors manuals

## Comportament nou

Feina automàtica, errors automàtics

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new one-shot migration script that bulk-updates `fiscal_position_id` on `GiscedataPolissa` and `GiscedataPolissaModcontractual` records across a hardcoded map of seven old→new fiscal position ID pairs, intended to support a regulatory Canary Islands VAT change.

- Introduces `write_vals = False` as a dry-run gate; the script reports counts without writing until the flag is flipped.
- The search domain unexpectedly includes `'baixa'` (cancelled) policies alongside active and draft ones, which may cause unnecessary writes to already-ended contracts.
- When a matched policy has no `modcontractual_activa`, its polissa record is still updated while the modcontractual is silently skipped, leaving the two records with different fiscal positions.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The script has a dry-run guard so no writes happen until write_vals is flipped, but the search domain includes cancelled contracts and the modcontractual update silently skips policies with no active modcontractual — both should be confirmed before the flag is enabled in production.

Including baixa contracts in the write path is likely unintended for a fiscal position migration, and the silent mismatch between polissa and modcontractual updates when modcontractual_activa is absent means some records could end up with inconsistent fiscal positions after the script runs in write mode.

scripts/change_fiscal_positions.py — specifically the state filter in the search domain and the modcontractual extraction logic.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/change_fiscal_positions.py | New bulk fiscal-position migration script with a write_vals dry-run guard; includes cancelled (baixa) policies in the write domain and silently skips updating modcontractuals for policies whose modcontractual_activa is False. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Script
    participant ERP as OpenERP (erppeek)
    participant Polissa as GiscedataPolissa
    participant Mod as GiscedataPolissaModcontractual

    Script->>ERP: Connect (dbconfig.erppeek)
    loop for each (fp_old, fp_new) in fp_change_map
        Script->>Polissa: "search([fiscal_position_id=fp_old, state in activa/esborrany/baixa])"
        Polissa-->>Script: pol_ids[]
        Script->>Polissa: read(pol_ids, [modcontractual_activa])
        Polissa-->>Script: pol_data[]
        Script->>Script: extract mod_ids from pol_data (skips False)
        alt "write_vals = True"
            Script->>Polissa: "write(pol_ids, {fiscal_position_id: fp_new})"
            Script->>Mod: "write(mod_ids, {fiscal_position_id: fp_new})"
        end
        Script->>Script: log success message
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Script
    participant ERP as OpenERP (erppeek)
    participant Polissa as GiscedataPolissa
    participant Mod as GiscedataPolissaModcontractual

    Script->>ERP: Connect (dbconfig.erppeek)
    loop for each (fp_old, fp_new) in fp_change_map
        Script->>Polissa: "search([fiscal_position_id=fp_old, state in activa/esborrany/baixa])"
        Polissa-->>Script: pol_ids[]
        Script->>Polissa: read(pol_ids, [modcontractual_activa])
        Polissa-->>Script: pol_data[]
        Script->>Script: extract mod_ids from pol_data (skips False)
        alt "write_vals = True"
            Script->>Polissa: "write(pol_ids, {fiscal_position_id: fp_new})"
            Script->>Mod: "write(mod_ids, {fiscal_position_id: fp_new})"
        end
        Script->>Script: log success message
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["🐛 py3k + comments"](https://github.com/som-energia/openerp_som_addons/commit/04a10d4b4164d179441178a002af47492a7efe9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44417326)</sub>

<!-- /greptile_comment -->