### PR TITLE
🐛 Fix ccpp ignore modcon to respect inheritance

### DIFF
--- a/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
@@ -1,24 +1,33 @@
+from report_backend.report_backend import ReportBackend, report_browsify
 from report_puppeteer.report_puppeteer import PuppeteerParser
-from .report_backend_ccpp import ReportBackendCondicionsParticulars
 
 
-class ReportBackendCondicionsParticularsIgnoreModcon(ReportBackendCondicionsParticulars):
+class ReportBackendCondicionsParticularsIgnoreModcon(ReportBackend):
     """Is the same report, but ignores modcons"""
     _name = "report.backend.condicions.particulars.ignore.modcon"
+
+    @report_browsify
+    def get_data(self, cursor, uid, pol, context=None):
+        context = context or {}
+        context.update({'ignore_modcon_pricelist': True})
+
+        return self.pool.get(
+            'report.backend.condicions.particulars'
+        ).get_data(cursor, uid, pol, context=context)
 
     def get_polissa_data(self, cursor, uid, pol, context=None):
         context = context or {}
         context.update({'ignore_modcon_pricelist': True})
-        res = super(ReportBackendCondicionsParticularsIgnoreModcon, self).get_polissa_data(
-            cursor, uid, pol, context=context)
-        return res
+        return self.pool.get(
+            'report.backend.condicions.particulars'
+        ).get_polissa_data(cursor, uid, pol, context=context)
 
     def get_prices_data(self, cursor, uid, pol, context=None):
         context = context or {}
         context.update({'ignore_modcon_pricelist': True})
-        res = super(ReportBackendCondicionsParticularsIgnoreModcon, self).get_prices_data(
-            cursor, uid, pol, context=context)
-        return res
+        return self.pool.get(
+            'report.backend.condicions.particulars'
+        ).get_prices_data(cursor, uid, pol, context=context)
 
 
 ReportBackendCondicionsParticularsIgnoreModcon()

--- a/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from report_backend.report_backend import ReportBackend, report_browsify
 from report_puppeteer.report_puppeteer import PuppeteerParser
 

--- a/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
@@ -4,6 +4,7 @@ from report_puppeteer.report_puppeteer import PuppeteerParser
 
 class ReportBackendCondicionsParticularsIgnoreModcon(ReportBackend):
     """Is the same report, but ignores modcons"""
+    _source_model = "giscedata.polissa"
     _name = "report.backend.condicions.particulars.ignore.modcon"
 
     @report_browsify


### PR DESCRIPTION
## Objectiu
Que el report "Contracte (ignora modcon)" respecti l'herència, com per exemple la que fa GURB.


## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the ignore-modcon particular-conditions backend to preserve extensions of the primary backend.
- Replaces direct Python inheritance with delegation through the Odoo model pool.
- Adds a browsified `get_data` entry point that sets the ignore-modcon pricing flag.
- Delegates the existing policy and pricing helpers through the dynamically resolved backend.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge, with non-blocking improvements needed around regression coverage and context isolation.

The delegation reaches dynamically inherited backend behavior and propagates the ignore-modcon flag to its consumers, while the new public path remains untested and adds the backend-specific flag directly to the caller's context.

som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py | The pool-based delegation preserves inherited backend behavior, but its public entry point lacks regression coverage and mutates the caller-owned context. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 Fix ccpp ignore modcon to respect inh..."](https://github.com/som-energia/openerp_som_addons/commit/0c8510e7dd6c4cea84a3dc7b63720b892347fcd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46611156)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->