### PR TITLE
Nova entrada de menú per a F1s tipus A amb expedients

### DIFF
--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from osv import osv, fields
 import re
 from tools.translate import _

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -65,6 +65,10 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
         if tarifaATR:
             vals["tarifa_atr"] = tarifaATR[0]
 
+        motiu_facturacio = re.findall("<MotivoFacturacion>(.*)</MotivoFacturacion>", xml_data)
+        if motiu_facturacio:
+            vals["motiu_facturacio"] = motiu_facturacio[0]
+
         if vals["type_factura"] in ("C", "A"):
             expedient = re.findall("<NumeroExpediente>(.*)</NumeroExpediente>", xml_data)
             if expedient:

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia.py
@@ -65,7 +65,7 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
         if tarifaATR:
             vals["tarifa_atr"] = tarifaATR[0]
 
-        if vals["type_factura"] == "C":
+        if vals["type_factura"] in ("C", "A"):
             expedient = re.findall("<NumeroExpediente>(.*)</NumeroExpediente>", xml_data)
             if expedient:
                 vals["num_expedient"] = expedient[0]
@@ -248,6 +248,7 @@ class GiscedataFacturacioImportacioLinia(osv.osv):
             help=u"Tipus de autoconsum informat a l'F1",
         ),
         "tarifa_atr": fields.selection(TABLA_17, u"Tarifa", readonly=True),
+        "motiu_facturacio": fields.char(_(u"Motiu facturació"), size=4, readonly=True),
         "num_expedient": fields.char(_(u"Núm. Expedient"), size=16, readonly=True),
         "comentari": fields.text(_(u"Comentari de l'F1"), readonly=True),
         "polissa_id": fields.function(

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml
@@ -13,8 +13,8 @@
                 </xpath>
                 <xpath expr="//field[@name='type_factura']" position="after">
                     <group attrs="{'invisible': [('type_factura', 'not in', ['C', 'A'])]}" colspan="4" col="4">
-                        <field name="motiu_facturacio"/>
-                        <field name="num_expedient"/>
+                        <field name="motiu_facturacio" select="2"/>
+                        <field name="num_expedient" select="2"/>
                         <field name="comentari"/>
                     </group>
                 </xpath>
@@ -45,7 +45,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="giscedata_facturacio_switching.view_importacio_linia_general_tree"/>
-            <field name="domain">[('moitu_facturacio', 'in', ['06', '11]), ('type_factura', '=', 'A')]</field>
+            <field name="domain">[('motiu_facturacio', 'in', ['06', '11']), ('type_factura', '=', 'A')]</field>
         </record>
         <menuitem id="menu_importacio_linia_abonament_expedients_som" action="action_importacio_linia_expedients_inspeccio_frau_som" parent="giscedata_facturacio_switching.menu_importacio_linia"/>
     </data>

--- a/som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml
+++ b/som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml
@@ -12,7 +12,8 @@
                     <field name="tarifa_atr" select="2" />
                 </xpath>
                 <xpath expr="//field[@name='type_factura']" position="after">
-                    <group attrs="{'invisible': [('type_factura', 'not in', ['C'])]}" colspan="4" col="4">
+                    <group attrs="{'invisible': [('type_factura', 'not in', ['C', 'A'])]}" colspan="4" col="4">
+                        <field name="motiu_facturacio"/>
                         <field name="num_expedient"/>
                         <field name="comentari"/>
                     </group>
@@ -37,5 +38,15 @@
                 </field>
             </field>
         </record>
+        <record model="ir.actions.act_window" id="action_importacio_linia_expedients_inspeccio_frau_som">
+            <field name="name">Fitxers F1 abonament expedients</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">giscedata.facturacio.importacio.linia</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="giscedata_facturacio_switching.view_importacio_linia_general_tree"/>
+            <field name="domain">[('moitu_facturacio', 'in', ['06', '11]), ('type_factura', '=', 'A')]</field>
+        </record>
+        <menuitem id="menu_importacio_linia_abonament_expedients_som" action="action_importacio_linia_expedients_inspeccio_frau_som" parent="giscedata_facturacio_switching.menu_importacio_linia"/>
     </data>
 </openerp>

--- a/som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py
+++ b/som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py
@@ -29,6 +29,7 @@ def up(cursor, installed_version):
     module = 'som_facturacio_switching'
     mh = MigrationHelper(cursor, module)
 
+    mh.init_model('giscedata.facturacio.importacio.linia')
     file = 'giscedata_facturacio_importacio_linia_view.xml'
     views = [
         'view_importacio_linia_auto_tarifa_codi_rect_anul_form',
@@ -43,11 +44,3 @@ def down(cursor, installed_version):
 
 
 migrate = up
-
-
-
-
-
-sql = """
-
-"""

--- a/som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py
+++ b/som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+import logging
+
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info('Updating motiu_facturacio on giscedata_facturacio_importacio_linia table')
+
+    query = '''
+        UPDATE giscedata_facturacio_importacio_linia AS f1
+        SET motiu_facturacio = foo.tipo_factura
+        FROM (
+            SELECT f1.id AS f1_id, COALESCE(fact.tipo_factura, '01') AS tipo_factura 
+            FROM giscedata_facturacio_importacio_linia f1 
+            LEFT JOIN account_invoice ai on ai.origin = f1.invoice_number_text 
+            LEFT JOIN giscedata_facturacio_factura fact on fact.invoice_id = ai.id
+        ) AS foo
+        WHERE f1.id = foo.f1_id
+    '''
+    cursor.execute(query)
+
+    module = 'som_facturacio_switching'
+    mh = MigrationHelper(cursor, module)
+
+    file = 'giscedata_facturacio_importacio_linia_view.xml'
+    views = [
+        'view_importacio_linia_auto_tarifa_codi_rect_anul_form',
+        'action_importacio_linia_expedients_inspeccio_frau_som',
+        'menu_importacio_linia_abonament_expedients_som',
+    ]
+    mh.update_xml_records(xml_path=file, init_record_ids=views)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up
+
+
+
+
+
+sql = """
+
+"""

--- a/som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py
+++ b/som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import
+
 import logging
 
 from oopgrade.oopgrade import MigrationHelper
@@ -17,9 +19,9 @@ def up(cursor, installed_version):
         UPDATE giscedata_facturacio_importacio_linia AS f1
         SET motiu_facturacio = foo.tipo_factura
         FROM (
-            SELECT f1.id AS f1_id, COALESCE(fact.tipo_factura, '01') AS tipo_factura 
-            FROM giscedata_facturacio_importacio_linia f1 
-            LEFT JOIN account_invoice ai on ai.origin = f1.invoice_number_text 
+            SELECT f1.id AS f1_id, COALESCE(fact.tipo_factura, '01') AS tipo_factura
+            FROM giscedata_facturacio_importacio_linia f1
+            LEFT JOIN account_invoice ai on ai.origin = f1.invoice_number_text
             LEFT JOIN giscedata_facturacio_factura fact on fact.invoice_id = ai.id
         ) AS foo
         WHERE f1.id = foo.f1_id

--- a/som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py
+++ b/som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import column_exists, add_columns
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    # Nova Instancia de Logger.
+    logger = logging.getLogger('openerp.migration')
+
+    # CREAR a la base de dades
+    logger.info('Create new field motiu_facturacio in giscedata_facturacio_importacio_linia ...')
+    if not column_exists(cursor, 'giscedata_facturacio_importacio_linia', 'motiu_facturacio'):
+        add_columns(cursor, {
+            'giscedata_facturacio_importacio_linia': [('motiu_facturacio', 'VARCHAR(4)')]
+        })
+        logger.info('Cap afegit a la taula giscedata_facturacio_importacio_linia.')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py
+++ b/som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import logging
-from oopgrade.oopgrade import column_exists, add_columns
+from oopgrade.oopgrade import column_exists
 
 
 def up(cursor, installed_version):

--- a/som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py
+++ b/som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py
@@ -7,15 +7,14 @@ def up(cursor, installed_version):
     if not installed_version:
         return
 
-    # Nova Instancia de Logger.
     logger = logging.getLogger('openerp.migration')
-
-    # CREAR a la base de dades
     logger.info('Create new field motiu_facturacio in giscedata_facturacio_importacio_linia ...')
     if not column_exists(cursor, 'giscedata_facturacio_importacio_linia', 'motiu_facturacio'):
-        add_columns(cursor, {
-            'giscedata_facturacio_importacio_linia': [('motiu_facturacio', 'VARCHAR(4)')]
-        })
+        query = """
+            ALTER TABLE giscedata_facturacio_importacio_linia
+                ADD COLUMN motiu_facturacio varchar(4) DEFAULT '01'
+        """
+        cursor.execute(query)
         logger.info('Cap afegit a la taula giscedata_facturacio_importacio_linia.')
 
 


### PR DESCRIPTION
## Objectiu

Nova entrada de menú per a F1s tipus A amb expedients

## Targeta on es demana o Incidència

https://somenergia.openproject.com/projects/cim-erp/work_packages/1874

## Comportament nou

Nova entrada de menú per a F1s tipus A amb expedients

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
    - [ ] som_facturacio_switching
- [x] Script de migració
    - [ ] pre-0001_add_column_motiu_facturacio
    - [ ] post-0001_update_motiu_facturacio

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a dedicated menu for type-A F1 files associated with fraud or inspection cases.
- Stores the billing reason and expediente number when importing new F1 records.
- Displays the new metadata and filters the menu to billing reasons `06` and `11`.
- Adds upgrade migrations to create and backfill the billing-reason column and load the new UI records.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the action now references the defined field, and the import path now stores the billing reason needed to include newly imported qualifying records.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_facturacio_switching/giscedata_facturacio_importacio_linia.py | Adds persisted billing-reason extraction and extends expediente extraction to type-A F1 imports, resolving the previously reported omission for newly imported records. |
| som_facturacio_switching/giscedata_facturacio_importacio_linia_view.xml | Exposes the new metadata and defines the filtered menu action using the corrected `motiu_facturacio` field. |
| som_facturacio_switching/migrations/5.0.26.12.0/pre-0001_add_column_motiu_facturacio.py | Adds the stored billing-reason column during upgrades when it does not already exist. |
| som_facturacio_switching/migrations/5.0.26.12.0/post-0001_update_motiu_facturacio.py | Backfills historical billing reasons and initializes the updated model, view, action, and menu records. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[F1 XML import] --> B[Extract invoice type]
  B --> C[Extract billing reason]
  B --> D[Extract expediente for type A or C]
  C --> E[Persist import line]
  D --> E
  E --> F{Type A and reason 06 or 11?}
  F -->|Yes| G[Show in expedientes menu]
  F -->|No| H[Exclude from menu]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["🦺 Fix linter and py3 compatibility"](https://github.com/som-energia/openerp_som_addons/commit/59400e4bb2e500d3d4e4ecc885088eb6583ef867) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47505561)</sub>

**Context used:**

- Knowledge Base — [Billing Extensions](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/billing-extensions.md)

<!-- /greptile_comment -->