### PR TITLE
🩹 Fix CCPP ignore modcon inheritance for lang

### DIFF
--- a/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from report_backend.report_backend import ReportBackend, report_browsify
+from report_backend.report_backend import report_browsify
 from report_puppeteer.report_puppeteer import PuppeteerParser
 
+from .report_backend_ccpp import ReportBackendCondicionsParticulars
 
-class ReportBackendCondicionsParticularsIgnoreModcon(ReportBackend):
+
+class ReportBackendCondicionsParticularsIgnoreModcon(ReportBackendCondicionsParticulars):
     """Is the same report, but ignores modcons"""
     _source_model = "giscedata.polissa"
     _name = "report.backend.condicions.particulars.ignore.modcon"


### PR DESCRIPTION
## Objectiu
Resulta que tal i com està muntat, si la classe no te "get_lang", no funciona la traducció... el que no entenc es perque a testing no va passar el mateix...

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enables language resolution for the ignore-modcon particular-conditions report.
- Makes the ignore-modcon backend inherit from the standard particular-conditions backend.
- Reuses the standard backend’s `get_lang` implementation while preserving the existing ignore-modcon data and pricing overrides.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the inheritance change supplying the missing language behavior while retaining the report’s existing modcon-ignore path.

The newly inherited language method is appropriate for this report, the ignore-modcon context continues to be passed to the ordinary backend, and the relevant pricing and policy-data methods continue to honor it.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa_condicions_generals/models/report_backend_ccpp_ignore_modcon.py | The backend now inherits the standard CCPP report behavior needed for language selection, with no actionable regression identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🩹 Fix CCPP ignore modcon inheritance fo..."](https://github.com/som-energia/openerp_som_addons/commit/bdc2ad4a90ace756832059c9cfb346df9ae52e1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47851123)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->