### PR TITLE
✅ fix tests som_sortida

### DIFF
--- a/som_sortida/tests/tests_giscedata_polissa.py
+++ b/som_sortida/tests/tests_giscedata_polissa.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from osv import osv
 from destral import testing
 from datetime import datetime

--- a/som_sortida/tests/tests_res_partner_address.py
+++ b/som_sortida/tests/tests_res_partner_address.py
@@ -26,7 +26,7 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
         cursor = self.cursor
         uid = self.uid
         rpa_obj = self.openerp.pool.get("res.partner.address")
-        self.openerp.pool.get("giscedata.polissa")
+        pol_obj = self.openerp.pool.get("giscedata.polissa")
         imd_obj = self.openerp.pool.get('ir.model.data')
         polissa_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', 'polissa_0001'
@@ -37,7 +37,9 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
         self.assertEqual(res, {
             'num_socia': 'S202129',
             'situacio_socia': 'Apadrinada',
-            'category_id': [],
+            'category_id': [cat.id for cat in pol_obj.browse(
+                cursor, uid, polissa_id
+            ).category_id],
         })
 
     def test__fill_merge_fields_titular_polissa_ctss__ok(self):
@@ -57,7 +59,7 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
             'email_address': u'test@test.test',
             'merge_fields': {
                 'EMAIL': u'test@test.test',
-                'FNAME': u'Pere',
+                'FNAME': '',
                 'MMERGE11': u'08600',
                 'MMERGE3': '',
                 'MMERGE4': 'Origen vinculat al CT sense socia',
@@ -94,5 +96,5 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
         rpa_obj.unsubscribe_titular_in_ctss_lists(cursor, uid, partner_id)
 
         mocked_archive.assert_called_once_with(
-            cursor, uid, address_id, 77, mailchimp_client
+            mock.ANY, uid, address_id, 77, mailchimp_client
         )

--- a/som_sortida/tests/tests_res_partner_address.py
+++ b/som_sortida/tests/tests_res_partner_address.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import mock
 from destral import testing
 
@@ -11,7 +12,6 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
         cursor = self.cursor
         uid = self.uid
         rpa_obj = self.openerp.pool.get("res.partner.address")
-        self.openerp.pool.get("giscedata.polissa")
         imd_obj = self.openerp.pool.get('ir.model.data')
         polissa_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', 'polissa_0001'
@@ -46,7 +46,6 @@ class TestsPartnerAddress(testing.OOTestCaseWithCursor):
         cursor = self.cursor
         uid = self.uid
         rpa_obj = self.openerp.pool.get("res.partner.address")
-        self.openerp.pool.get("giscedata.polissa")
         imd_obj = self.openerp.pool.get('ir.model.data')
         polissa_id = imd_obj.get_object_reference(
             cursor, uid, 'giscedata_polissa', 'polissa_0001'

--- a/som_sortida/tests/tests_switching.py
+++ b/som_sortida/tests/tests_switching.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from destral.transaction import Transaction
 import mock
 from giscedata_switching.tests.common_tests import TestSwitchingImport

--- a/som_sortida/tests/tests_update_pending_states.py
+++ b/som_sortida/tests/tests_update_pending_states.py
@@ -207,7 +207,13 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
         partner_soci_id = imd_obj.get_object_reference(
             cursor, uid, 'som_polissa_soci', 'res_partner_soci_ct'
         )[1]
-        pol_obj.write(cursor, uid, [polissa_id], {'soci': partner_soci_id}, context={
+        pricelist_id = imd_obj.get_object_reference(
+            cursor, uid, 'giscedata_facturacio', 'pricelist_tarifas_electricidad'
+        )[1]
+        pol_obj.write(cursor, uid, [polissa_id], {
+            'soci': partner_soci_id,
+            'llista_preu': pricelist_id,
+        }, context={
             'custom_change_dates': {polissa_id: '2023-09-01'},
         })
         pol_obj.send_signal(cursor, uid, [polissa_id], [

--- a/som_sortida/tests/tests_update_pending_states.py
+++ b/som_sortida/tests/tests_update_pending_states.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from destral import testing
 from base_extended_som.tests.utils import avoid_creating_subcursors
 


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates `som_sortida` tests to reflect current contract categories and merge-field behavior, accept the queued job's cursor, and provide the pricelist required by the pending-state workflow fixture.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only corrects test setup and expectations without changing production behavior.

The updated assertions follow the existing merge-field implementation, and the added pricelist supplies fixture data needed by the exercised contract workflow; no concrete regression or weakened production contract was identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sortida/tests/tests_res_partner_address.py | Aligns expected merge data with the policy fixture and avoids asserting cursor identity across a queued job boundary. |
| som_sortida/tests/tests_update_pending_states.py | Completes the contract fixture with an electricity pricelist before exercising workflow transitions and B1 case creation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["✅ fix tests som\_sortida"](https://github.com/som-energia/openerp_som_addons/commit/56111aa28e69d19900b8e7085e8dae7d84f3070d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47886600)</sub>

**Context used:**

- Knowledge Base — [Customer-Ops and Miscellaneous Modules](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/customer-ops-misc.md)

<!-- /greptile_comment -->