### PR TITLE
🐛 Fix CCPP indexada + bad copy

### DIFF
--- a/som_polissa_condicions_generals/i18n/es_ES.po
+++ b/som_polissa_condicions_generals/i18n/es_ES.po
@@ -405,8 +405,8 @@ msgid "Vigència del contracte: "
 msgstr "Vigencia del contrato: "
 
 #: rml:som_polissa_condicions_generals/report/components/capcalera.mako:26
-msgid "Sense permanència"
-msgstr "Sin permanencia"
+msgid "Trimestre natural"
+msgstr "Trimestre natural"
 
 #: rml:som_polissa_condicions_generals/report/components/capcalera.mako:28
 msgid "Data de renovació: "

--- a/som_polissa_condicions_generals/i18n/som_polissa_condicions_generals.pot
+++ b/som_polissa_condicions_generals/i18n/som_polissa_condicions_generals.pot
@@ -442,7 +442,7 @@ msgid "Vigència del contracte: "
 msgstr ""
 
 #: rml:som_polissa_condicions_generals/report/components/capcalera.mako:26
-msgid "Sense permanència"
+msgid "Trimestre natural"
 msgstr ""
 
 #: rml:som_polissa_condicions_generals/report/components/capcalera.mako:28

--- a/som_polissa_condicions_generals/models/report_backend_ccpp.py
+++ b/som_polissa_condicions_generals/models/report_backend_ccpp.py
@@ -38,7 +38,7 @@ class ReportBackendCondicionsParticulars(ReportBackend):
         ).get(pricelist_id, False)
         if price is False or price is None:
             return False
-        return price / 1000
+        return price
 
     def _get_coeficient_k_for_pricelist(self, fs_data, dades_tarifa, default_coeficient_k_untaxed):
         if not fs_data:

--- a/som_polissa_condicions_generals/report/components/capcalera.mako
+++ b/som_polissa_condicions_generals/report/components/capcalera.mako
@@ -23,7 +23,7 @@
                 %endif
                 <br/>
                 <b>${_(u"Vigència del contracte: ")}</b>
-                ${_(u"Sense permanència")}
+                ${_(u"Trimestre natural")}
                 <br/>
                 <b>${_(u"Data de renovació: ")}</b>
                 ${polissa['data_renovacio']}


### PR DESCRIPTION
## Objectiu
Hi ha un copy que ha de canviar segons juridic, i també s'estava dividint entre 1000 la K de la pricelist quan aqusesta ja ve informada en kWh.

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8196194?folder_id=103

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [x] Actualitzar mòdul
- [ ] Script de migració
- [x] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the indexed-tariff K coefficient and updates contract-validity wording.
- Stops dividing the pricelist K coefficient by 1000.
- Replaces “Sense permanència” with “Trimestre natural” in the shared report header.
- Updates the Spanish translation catalog and extraction template.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the juridical-status-specific wording is restored and the coefficient regression test is aligned with the intended unit contract.

The shared header currently changes legal wording for every titular despite the report exposing a business-status discriminator, and the coefficient change conflicts with an existing executable assertion.

**Files Needing Attention:** som_polissa_condicions_generals/report/components/capcalera.mako; som_polissa_condicions_generals/models/report_backend_ccpp.py; som_polissa_condicions_generals/tests/tests_report_backend_ccpp.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa_condicions_generals/models/report_backend_ccpp.py | Returns the pricelist K coefficient without conversion, but leaves an existing regression test expecting the previous unit conversion. |
| som_polissa_condicions_generals/report/components/capcalera.mako | Changes legal wording for every generated contract instead of conditioning it on the titular's juridical status. |
| som_polissa_condicions_generals/i18n/es_ES.po | Keeps the Spanish catalog synchronized with the changed report msgid. |
| som_polissa_condicions_generals/i18n/som_polissa_condicions_generals.pot | Updates the translation template to match the new source string. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 Fix CCPP indexada + bad copy"](https://github.com/som-energia/openerp_som_addons/commit/ab68ebe6a6772f55431f9020e99ba33da546c3e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47918299)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->