### PR TITLE
Petites millores i correccions del nou formulari rdl

### DIFF
--- a/som_leads_polissa/__terp__.py
+++ b/som_leads_polissa/__terp__.py
@@ -21,6 +21,7 @@
         "account_account_som",
         "som_partner_account",
         "giscedata_crm_leads_signatura",
+        "giscedata_crm_leads_switching_signaturit",
         "som_card_payment",
     ],
     "init_xml": [],

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -453,7 +453,7 @@ class SomLeadWww(osv.osv_memory):
         sign_process_obj = self.pool.get("giscedata.signatura.process")
         logger = logging.getLogger("openerp.{0}.activate_lead.signature_mail".format(__name__))
 
-        attempts = 30
+        attempts = 5
         wait_seconds = 10
 
         for _ in range(attempts):
@@ -527,7 +527,7 @@ class SomLeadWww(osv.osv_memory):
         for lead_id in all_ids:
             self.activate_lead_async(cr, uid, lead_id, context=context)
 
-    @job(queue="leads")
+    @job(queue="leads", timeout=300)
     def activate_lead_async(self, cr, uid, lead_id, context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts the new RDL lead activation and Signaturit integration.
- Adds the switching/Signaturit module dependency and a default attachment category.
- Loads the new category during module upgrades through a migration.
- Reduces signature-status polling from approximately five minutes to fifty seconds.
- Sets a five-minute timeout on asynchronous lead activation jobs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The new data is declared for both installation and upgrade, while signature polling exhaustion moves leads into the existing pending retry flow rather than discarding activation work.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/__terp__.py | Adds the Signaturit switching dependency and registers the new attachment-category data file. |
| som_leads_polissa/data/giscedata_signatura_documents_data.xml | Defines the default Signaturit attachment category used by the lead-signing flow. |
| som_leads_polissa/migrations/5.0.25.5.0/post-0006_minor_fixes_new_RDL_changes_migrate_fields_data.py | Loads the new category data when upgrading an already-installed module. |
| som_leads_polissa/www/som_lead_www.py | Shortens signature polling and bounds asynchronous lead activation to five minutes; existing pending-state retry handling provides recovery when polling expires. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Queued lead activation] --> B[Poll signature status]
  B -->|Completed or absent| C[Check payment]
  B -->|Pending after 5 attempts| D[Mark pending for review]
  C -->|Allowed| E[Create lead entities]
  E --> F[Advance lead stage]
  F --> G[Send activation email]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🩹 (leads) Categories documents"](https://github.com/som-energia/openerp_som_addons/commit/3db35b870f5c2f4dd2fab8fa1098725811bd347b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47931050)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->