### PR TITLE
🐛 fix duplicate advocats

### DIFF
--- a/som_account_invoice_pending/models/update_pending_states.py
+++ b/som_account_invoice_pending/models/update_pending_states.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from osv import osv
 from datetime import datetime, timedelta, date
 from addons.som_account_invoice_pending.models.som_account_invoice_pending_exceptions import (
@@ -115,7 +117,7 @@ class UpdatePendingStates(osv.osv_memory):
         except Exception as e:
             logger.info(
                 "ERROR sending email to invoice {factura_id}: {exc}".format(
-                    factura_id=factura_id, exc=e.message
+                    factura_id=factura_id, exc=str(e)
                 )
             )
             return -1
@@ -147,7 +149,7 @@ class UpdatePendingStates(osv.osv_memory):
         except Exception as e:
             logger.info(
                 "ERROR sending sms to invoice {factura_id}: {exc}".format(
-                    factura_id=factura_id, exc=e.message
+                    factura_id=factura_id, exc=str(e)
                 )
             )
             raise e
@@ -213,19 +215,19 @@ class UpdatePendingStates(osv.osv_memory):
             except UpdateWaitingFor48hException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_48h: {exc}".format(
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except UpdateWaitingCancelledContractsException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_48h: {exc}".format(
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except Exception as e:
                 logger.info(
                     "UNHANDLED ERROR updating invoice {factura_id} in update_waiting_for_48h: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
 
@@ -298,19 +300,19 @@ class UpdatePendingStates(osv.osv_memory):
             except UpdateWaitingFor48hException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_48h: {exc}".format(
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except UpdateWaitingCancelledContractsException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_48h: {exc}".format(
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except Exception as e:
                 logger.info(
                     "UNHANDLED ERROR updating invoice {factura_id} in update_waiting_for_48h: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
 
@@ -445,19 +447,19 @@ class UpdatePendingStates(osv.osv_memory):
             except UpdateWaitingForAnnexIVException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_annexIV: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except UpdateWaitingCancelledContractsException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_annexIV: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except Exception as e:
                 logger.info(
                     "UNHANDLED ERROR updating invoice {factura_id} in update_waiting_for_annexIV: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
 
@@ -508,19 +510,19 @@ class UpdatePendingStates(osv.osv_memory):
             except UpdateWaitingForAnnexIVException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_annexIV: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except UpdateWaitingCancelledContractsException as e:
                 logger.info(
                     "ERROR updating invoice {factura_id} in update_waiting_for_annexIV: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
             except Exception as e:
                 logger.info(
                     "UNHANDLED ERROR updating invoice {factura_id} in update_waiting_for_annexIV: {exc}".format(  # noqa: E501
-                        factura_id=factura_id, exc=e.message
+                        factura_id=factura_id, exc=str(e)
                     )
                 )
 

--- a/som_account_invoice_pending/models/update_pending_states.py
+++ b/som_account_invoice_pending/models/update_pending_states.py
@@ -951,9 +951,10 @@ class UpdatePendingStates(osv.osv_memory):
                             self.update_waiting_for_annex_cancelled_contracts(
                                 cursor, uid, fact_id[0], traspas_advocats_bs, context
                             )
-                        self.update_waiting_for_annex_cancelled_contracts(
-                            cursor, uid, fact_id[0], traspas_advocats_dp, context
-                        )
+                        else:
+                            self.update_waiting_for_annex_cancelled_contracts(
+                                cursor, uid, fact_id[0], traspas_advocats_dp, context
+                            )
                     fact_obj.set_pending(cursor, uid, fact_id, waiting_notif_id)
 
     def poverty_eligible(self, cursor, uid, polissa_id):

--- a/som_account_invoice_pending/tests/update_pending_states_tests.py
+++ b/som_account_invoice_pending/tests/update_pending_states_tests.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from destral import testing
 import mock
 from mock import ANY

--- a/som_account_invoice_pending/tests/update_pending_states_tests.py
+++ b/som_account_invoice_pending/tests/update_pending_states_tests.py
@@ -173,6 +173,13 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
             "default_pendent_traspas_advocats_pending_state",
         )[1]
 
+        self.traspas_advocats_bs = imd_obj.get_object_reference(
+            cursor,
+            uid,
+            "som_account_invoice_pending",
+            "pendent_traspas_advocats_pending_state",
+        )[1]
+
         self.consulta_pobresa = imd_obj.get_object_reference(
             cursor,
             uid,
@@ -232,6 +239,43 @@ class TestUpdatePendingStates(testing.OOTestCaseWithCursor):
         self.assertEqual(inv_data.pending_state.id, self.waiting_48h_bs)
         inv_data = fact_obj.browse(cursor, uid, self.invoice_2_id)
         self.assertEqual(inv_data.pending_state.id, self.waiting_48h_bs)
+
+    @mock.patch("som_account_invoice_pending.models.update_pending_states.UpdatePendingStates.send_email")  # noqa: E501
+    @mock.patch("som_account_invoice_pending.models.update_pending_states.UpdatePendingStates.send_sms")  # noqa: E501
+    def test__update_second_unpaid_invoice__bo_social_baixa_uses_bo_social_lawyer_state(
+        self, mock_sms, mock_mail
+    ):
+        cursor = self.txn.cursor
+        uid = self.txn.user
+        imd_obj = self.pool.get("ir.model.data")
+        pol_obj = self.pool.get("giscedata.polissa")
+        fact_obj = self.pool.get("giscedata.facturacio.factura")
+        history_obj = self.pool.get("account.invoice.pending.history")
+        pol_id = imd_obj.get_object_reference(
+            cursor, uid, "giscedata_polissa", "polissa_0001"
+        )[1]
+        pol_obj.write(cursor, uid, [pol_id], {"state": "baixa"})
+        self._load_data_unpaid_invoices(
+            cursor, uid, [self.waiting_unpaid_id, self.waiting_unpaid_id]
+        )
+
+        pending_obj = self.pool.get("update.pending.states")
+        pending_obj.update_second_unpaid_invoice(cursor, uid)
+
+        self.assertEqual(mock_mail.call_count, 2)
+        self.assertEqual(mock_sms.call_count, 2)
+        for factura_id in (self.invoice_1_id, self.invoice_2_id):
+            factura = fact_obj.browse(cursor, uid, factura_id)
+            self.assertEqual(factura.pending_state.id, self.waiting_48h_bs)
+            history_states = history_obj.search(
+                cursor,
+                uid,
+                [("invoice_id", "=", factura.invoice_id.id)],
+            )
+            history_states = history_obj.read(cursor, uid, history_states, ["pending_state_id"])
+            history_state_ids = [state["pending_state_id"][0] for state in history_states]
+            self.assertIn(self.traspas_advocats_bs, history_state_ids)
+            self.assertNotIn(self.traspas_advocats_dp, history_state_ids)
 
     def test__update_second_unpaid_invoice__two_invoices_not_moving(self):
         cursor = self.txn.cursor


### PR DESCRIPTION
## Objectiu

Arreglar l'assignació de traspàs advocats en el procés d'estats pendents

## Targeta on es demana o Incidència

Diari bugbuster

## Comportament antic

Estat duplicat

## Comportament nou

Estat correcte

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevents cancelled-contract invoices from receiving duplicate lawyer-transfer states.
- Routes Bo Social invoices exclusively to the Bo Social lawyer-transfer state.
- Retains the default lawyer-transfer state for the Default Process branch.
- Adds regression coverage confirming that Bo Social invoice histories exclude the default lawyer state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the corrected branch preserving the default path while preventing duplicate lawyer-state history for Bo Social invoices.

The new else branch cleanly partitions the two existing hardcoded process calls, and the regression test exercises the previously duplicated Bo Social cancelled-contract path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_account_invoice_pending/models/update_pending_states.py | Makes the default lawyer-transfer update mutually exclusive with the Bo Social update, eliminating the duplicate transition while preserving both process paths. |
| som_account_invoice_pending/tests/update_pending_states_tests.py | Adds a focused cancelled-contract regression test that verifies Bo Social invoices record the correct lawyer state and exclude the default state. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Second unpaid invoice] --> B{Contract cancelled?}
  B -->|No| C[Continue normal pending-state flow]
  B -->|Yes| D{Bo Social process?}
  D -->|Yes| E[Apply Bo Social lawyer-transfer state]
  D -->|No| F[Apply default lawyer-transfer state]
  E --> G[Set waiting notification state]
  F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 fix duplicate advocats"](https://github.com/som-energia/openerp_som_addons/commit/8387c28434d391622a426fc1f6bdc9f2cdb8ba5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47935340)</sub>

<!-- /greptile_comment -->