### PR TITLE
Adapt openerp_som_addons to the gisce formula_indexada refactor

### DIFF
--- a/som_auvidi/giscedata_serveis_generacio.py
+++ b/som_auvidi/giscedata_serveis_generacio.py
@@ -130,7 +130,7 @@ class GiscedataServeiGeneracioPolissa(osv.osv):
         # La llista de preus és Empresa
         llista_preus = polissa.llista_preu
         te_llista_preus_empresa = (llista_preus
-                                   and (llista_preus.indexed_formula == 'Indexada ESMASA'
+                                   and (llista_preus.indexed_formula.name == 'Indexada ESMASA'
                                         or 'Empresa' in llista_preus.name))
 
         # Condicions especifiques

--- a/som_facturacio_comer/giscedata_polissa.py
+++ b/som_facturacio_comer/giscedata_polissa.py
@@ -56,7 +56,7 @@ class GiscedataPolissa(osv.osv):
             cursor, uid, polissa_id, data_inici, data_final, with_power=with_power, context=ctx)
 
         llista_preu_dades = []
-        indexed_formula_old = ""
+        indexed_formula_old = None
 
         for mod_data in sorted(dates_de_tall.keys()):
             values = ['llista_preu', 'data_inici', 'data_final']
@@ -77,7 +77,7 @@ class GiscedataPolissa(osv.osv):
                 indexed_formula = price_o.read(cursor, uid, llista_preu_id, ['indexed_formula'],
                                                context=context)['indexed_formula']
 
-                if indexed_formula != indexed_formula_old and indexed_formula_old != "":
+                if indexed_formula != indexed_formula_old and indexed_formula_old is not None:
                     # updatar registre
                     dates_de_tall[mod_data]['changes'] = ['potencia']
 


### PR DESCRIPTION
## Objectiu
Adaptar openerp_som_addons per https://github.com/gisce/erp/pull/27913 .

Els testos probablement fallaran mentre no estigui aplicat lo altre, però és prou trivial de revisar :)


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adapts indexed-formula handling to the upstream `formula_indexada` refactor.
- Reads the indexed formula name when evaluating AUVIDI enterprise-price-list eligibility.
- Uses `None` as the initial sentinel when detecting indexed-formula changes across contractual intervals.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified under the intended coupled upstream deployment.

The two focused changes consistently adapt formula access and initialization semantics to the referenced upstream field refactor without establishing a broken billing or AUVIDI path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_auvidi/giscedata_serveis_generacio.py | Updates AUVIDI eligibility logic to compare the refactored indexed-formula object's name. |
| som_facturacio_comer/giscedata_polissa.py | Updates formula-change tracking to use a sentinel compatible with the refactored field representation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Adapt openerp\_som\_addons to the gisce fo..."](https://github.com/som-energia/openerp_som_addons/commit/dcd5d4b018a4bf19f457597227309d4cdba06b93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48629280)</sub>

**Context used:**

- Knowledge Base — [Billing core (facturació comer)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/billing-core.md)
- Knowledge Base — [Payment Collection: Remittances, Devolucions, and Card Payments](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/payments-collections.md)

<!-- /greptile_comment -->