### PR TITLE
🐛 Subcomponents amb problemes de traduccions

### DIFF
--- a/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
+++ b/giscedata_facturacio_comer_som/giscedata_facturacio_report.py
@@ -4101,6 +4101,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_component_energy_consumption_detail_td_data(self, fact, pol):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
         if not is_TD(pol):
             return {}
 
@@ -4130,6 +4131,8 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_energy_consumption_detail_meter_td_data(self, fact, pol, meter):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
+
         def visibility(subs):
             return any([sub["is_visible"] for sub in subs])
 
@@ -4187,6 +4190,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return False
 
     def get_sub_component_energy_consumption_detail_td_active_data(self, fact, pol, meter):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
         (a, a, a, a, lectures_a, a, a, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(
             fact
         )
@@ -4219,6 +4223,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_energy_consumption_detail_td_surplus_data(self, fact, pol, meter):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
         (a, a, a, a, a, a, a, lectures_g, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(
             fact
         )
@@ -4257,6 +4262,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_energy_consumption_detail_td_inductive_data(self, fact, pol, meter):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
         (a, a, a, a, a, lectures_r, a, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(
             fact
         )
@@ -4288,6 +4294,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_energy_consumption_detail_td_capacitive_data(self, fact, pol, meter):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
         (a, a, a, a, a, a, lectures_c, a, a, a, a, a, a, a, a, a, a, a, a) = self.get_readings_data(
             fact
         )
@@ -4319,6 +4326,7 @@ class GiscedataFacturacioFacturaReport(osv.osv):
         return data
 
     def get_sub_component_energy_consumption_detail_td_maximeter_data(self, fact, pol, meter):
+        context = {"lang": get_lang_partner(fact)}  # noqa: F841
         excess_lines = [l for l in fact.linia_ids if l.tipus == "exces_potencia"]  # noqa: E741
 
         data = {

--- a/giscedata_facturacio_comer_som/i18n/es_ES.po
+++ b/giscedata_facturacio_comer_som/i18n/es_ES.po
@@ -1137,7 +1137,7 @@ msgstr "Lectura final (%s) (%s)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:38
-msgid "Total periode "
+msgid "Total període "
 msgstr "Total periodo "
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:9
@@ -1227,7 +1227,7 @@ msgid "Potència excedida"
 msgstr "Potencia excedida"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:57
-msgid "Maximetre (kW)"
+msgid "Maxímetre (kW)"
 msgstr "Maxímetro (kW)"
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:15

--- a/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
+++ b/giscedata_facturacio_comer_som/i18n/giscedata_facturacio_comer_som.pot
@@ -1123,7 +1123,7 @@ msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako:43
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako:38
-msgid "Total periode "
+msgid "Total període "
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_collective/energy_consumption_detail_td_collective.mako:9
@@ -1212,7 +1212,7 @@ msgid "Potència excedida"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako:57
-msgid "Maximetre (kW)"
+msgid "Maxímetre (kW)"
 msgstr ""
 
 #: rml:giscedata_facturacio_comer_som/report/components/energy_consumption_graphic/energy_consumption_graphic.mako:15

--- a/giscedata_facturacio_comer_som/migrations/5.0.25.6.1/post-0001_load_translations.py
+++ b/giscedata_facturacio_comer_som/migrations/5.0.25.6.1/post-0001_load_translations.py
@@ -1,0 +1,22 @@
+import logging
+from tools import config
+from tools.translate import trans_load
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    module_name = 'giscedata_facturacio_comer_som'
+
+    logger.info("Updating translations")
+    trans_load(cursor, '{}/{}/i18n/es_ES.po'.format(config['addons_path'], module_name), 'es_ES')
+    logger.info("Translations succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_base/energy_consumption_detail_td_base.mako
@@ -40,7 +40,7 @@
     % else:
         <tr class="tr_bold last_row">
     % endif
-        <td class="detall_td">${_(u"Total periode ")}
+        <td class="detall_td">${_(u"Total període ")}
         % if meter.is_active:
             <sup class="sup_bold">(1)</sup>
         % endif

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_maximetre/energy_consumption_detail_td_maximetre.mako
@@ -54,7 +54,7 @@
         % endif
     % else:
         <tr>
-            <td class="td_first concepte_td" rowspan="3">${_(u"Maximetre (kW)")}</td>
+            <td class="td_first concepte_td" rowspan="3">${_(u"Maxímetre (kW)")}</td>
 
             <td class="detall_td">${_(u"Potència contractada")}</td>
             % for p in meter.showing_periods:

--- a/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
+++ b/giscedata_facturacio_comer_som/report/components/energy_consumption_detail_td_surplus/energy_consumption_detail_td_surplus.mako
@@ -35,7 +35,7 @@
         % else:
             <tr class="tr_bold last_row">
         % endif
-            <td class="detall_td">${_(u"Total periode ")}
+            <td class="detall_td">${_(u"Total període ")}
             % if meter.is_active:
                 <sup class="sup_bold">(1)</sup>
             % endif


### PR DESCRIPTION
## Objectiu

Amb la introducció de la variable default_lang a la configuració el trencament de context als reports aflora i provoca que el sistema de traduccions de vegades falli a la hora de traduir o no un text.
Aquest ha estat difícil de trobar

## Targeta on es demana o Incidència

https://freescout.somenergia.coop/conversation/8197136?folder_id=259

## Comportament antic

De vegades parts del bloc de lectures de la factura apareixia en castellà

## Comportament nou

Es força la variable "context" pel sistema de traduccions

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes invoice-report translation context for energy-consumption subcomponents.
- Derives the translation language from the invoice partner.
- Exposes that language through the caller-local `context` expected by OpenERP's translation implementation.
- Applies the context before translating active, surplus, reactive, and maximeter labels.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed report path.

Each affected translation call executes after a caller-local context is populated with the invoice partner language, matching the legacy OpenERP translation contract.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| giscedata_facturacio_comer_som/giscedata_facturacio_report.py | Correctly supplies partner-language context to OpenERP translation calls in the affected report helpers; no actionable regression identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 add context variable so the translati..."](https://github.com/som-energia/openerp_som_addons/commit/bfb57f27491df97933c4fa3acbbec1e431a512cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48666612)</sub>

**Context used:**

- Knowledge Base — [Billing core (facturació comer)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/billing-core.md)

<!-- /greptile_comment -->