### PR TITLE
🩹 (leads) Escriure el delivery_type al lead

### DIFF
--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -797,6 +797,8 @@ class SomLeadWww(osv.osv_memory):
         ctx['delivery_type'] = 'url'
         ctx['provider'] = 'signaturit'
 
+        lead_o.write(cr, uid, lead_id, {'delivery_type': 'url'})
+
         cr.commit()
 
         # `start_signature_process` creates signature artifacts with admin-only

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -456,15 +456,18 @@ class SomLeadWww(osv.osv_memory):
         attempts = 5
         wait_seconds = 10
 
+        db = pooler.get_db(cr.dbname)
+
         for _ in range(attempts):
+            tmp_cursor = db.cursor()
             lead_data = lead_o.read(
-                cr, uid, lead_id, ['signature_process', 'status_firma'], context=context
+                tmp_cursor, uid, lead_id, ['signature_process', 'status_firma'], context=context
             )
             signature_process = lead_data.get('signature_process')
             signature_status = lead_data.get('status_firma')
 
             if not signature_process:
-                return True
+                return False
 
             if signature_status == self._SIGNATURE_COMPLETED_STATUS:
                 return True
@@ -472,7 +475,10 @@ class SomLeadWww(osv.osv_memory):
             if signature_status in self._SIGNATURE_ERROR_STATUSES:
                 return False
 
-            sign_process_obj.update(cr, uid, [signature_process[0]], context=context)
+            sign_process_obj.update(tmp_cursor, uid, [signature_process[0]], context=context)
+
+            tmp_cursor.commit()
+            tmp_cursor.close()
             time.sleep(wait_seconds)
 
         logger.warning(


### PR DESCRIPTION
## Objectiu
Escriure el delivery_type al lead

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/1905/activity

## Comportament antic
S'envia un correu (que falla) perquè intenta enviar una plantilla que de moment a ningú li importa

## Comportament nou
No s'envia aquest correu

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the lead-signature flow:
- Persists URL delivery mode on the lead before starting its signature process.
- Polls signature status through independent database cursors and commits provider updates between attempts.
- Rejects activation when the lead has no signature process.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the follow-up review scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/www/som_lead_www.py | Updates delivery-mode persistence and signature-status polling; no finding eligible for a new follow-up comment was identified. |

</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 (lead) \_signature\_allows\_activation"](https://github.com/som-energia/openerp_som_addons/commit/00c69adb7beb5b24b0e523884a8e0a2daa54c805) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48677162)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->