### PR TITLE
🩹 (leads) less failed for unsended signaturits

### DIFF
--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -28,7 +28,7 @@ class SomLeadWww(osv.osv_memory):
     _128_SIMPLIFIED_SURPLUSES = 'a0'
     _131_CONSUMPTION = '01'
     _SIGNATURE_COMPLETED_STATUS = 'completed'
-    _SIGNATURE_ERROR_STATUSES = ('error', 'canceled', 'declined', 'expired')
+    _SIGNATURE_ERROR_STATUSES = ('error', 'canceled', 'declined', 'expired', 'unsend')
 
     def create_lead(self, cr, uid, www_vals, context=None):
         if context is None:


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR recognizes the canonical Signaturit `unsend` status as an unsuccessful state in lead-signature workflows.
- Stops activation when the signature process remains unsent.
- Aborts signing URL generation immediately instead of repeatedly polling an unsent process.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The added literal matches the signature integration’s canonical initial unsent status, and both affected workflows require progress beyond that state before they can succeed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/www/som_lead_www.py | Adds the canonical unsent signature-process status to the existing failure-status tuple used by activation and signing URL generation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🩹 (leads) less failed for unsended sign..."](https://github.com/som-energia/openerp_som_addons/commit/76975e5b1e6b50f988a81e52b8916e8db413aab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50064419)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->