### PR TITLE
💄 improve simulation models ux

### DIFF
--- a/som_webforms_helpers/models/som_annual_coefficient.py
+++ b/som_webforms_helpers/models/som_annual_coefficient.py
@@ -7,6 +7,7 @@ from osv import osv, fields
 class SomAnnualCoefficient(osv.osv):
     _name = "som.annual.coefficient"
     _description = "Annual kWh coefficients for simulations"
+    _order = "year desc, id desc"
 
     _columns = {
         "p1_ratio": fields.float("P1 ratio", digits=(16, 3), required=True),
@@ -21,7 +22,7 @@ class SomAnnualCoefficient(osv.osv):
 
     def get_current_coefficient(self, cursor, uid, tariff, context=None):
         ids = self.search(cursor, uid, [("tariff", "=", tariff)],
-                          limit=1, order="year desc", context=context)
+                          limit=1, order="year desc, id desc", context=context)
         if not ids:
             return False
         return self.read(

--- a/som_webforms_helpers/models/som_last_month_average_price.py
+++ b/som_webforms_helpers/models/som_last_month_average_price.py
@@ -7,6 +7,7 @@ from osv import osv, fields
 class SomLastMonthAveragePrice(osv.osv):
     _name = "som.last.month.average.price"
     _description = "Previous month prices for simulations"
+    _order = "date desc, id desc"
 
     _columns = {
         "p1_price": fields.float("P1 average (€/kWh)", digits=(16, 6), required=True),


### PR DESCRIPTION
## Objectiu
Ordenar per data els models realcionats amb la simulació per facilitar la festió

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8199815?folder_id=87

## Comportament antic
Ordenació més id més antic

## Comportament nou
Ordenació per data

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes the default ordering of two simulation reference-data models so recent years and dates appear first, with IDs providing deterministic tie-breaking.
- Orders annual coefficients by descending year and ID.
- Orders average-price records by descending date and ID.
- Makes annual-coefficient selection deterministic when multiple records share a year.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The nullable-date ordering defect should be fixed before merging because valid undated records will appear ahead of the newest prices.

The new model-level descending date order applies to the tree view while the ordered field remains optional, causing PostgreSQL to place undated records first.

**Files Needing Attention:** som_webforms_helpers/models/som_last_month_average_price.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_webforms_helpers/models/som_annual_coefficient.py | Adds deterministic newest-year-first ordering to the model and its current-coefficient lookup. |
| som_webforms_helpers/models/som_last_month_average_price.py | Adds newest-date-first default ordering, but nullable dates sort ahead of dated records under descending PostgreSQL ordering. |

</details>

<sub>Reviews (1): Last reviewed commit: ["💄 improve simulation models ux"](https://github.com/som-energia/openerp_som_addons/commit/5a6bfd9f35d4a07986248cf164adc76dbc035e5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50073274)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Customer-Ops and Miscellaneous Modules](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/customer-ops-misc.md)

<!-- /greptile_comment -->