### PR TITLE
✨ Add compatibility to new canaries subsistema TG

### DIFF
--- a/som_dashboard/migrations/5.0.25.5.0/post-0002_fix_subsistema_tg_migrate_data.py
+++ b/som_dashboard/migrations/5.0.25.5.0/post-0002_fix_subsistema_tg_migrate_data.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'som_dashboard_custom_search.xml',
+    ]
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_dashboard', data_file,
+            idref=None, mode='update'
+        )
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_dashboard/som_dashboard_custom_search.xml
+++ b/som_dashboard/som_dashboard_custom_search.xml
@@ -106,7 +106,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: ATR % Indexada%' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+        observacions LIKE '%Mode facturaci%: ATR % Indexada%' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY
         CAST(gpm.create_date AS DATE)
 ) aaa ON g.fecha = aaa.dates
@@ -120,7 +120,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: Indexada % ATR%' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+        observacions LIKE '%Mode facturaci%: Indexada % ATR%' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY
         CAST(gpm.create_date AS DATE)
 ) bbb ON g.fecha = bbb.dates
@@ -244,7 +244,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'index' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') and gpm.name = '1'
+        mode_facturacio = 'index' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') and gpm.name = '1'
     GROUP BY
         CAST(gpm.data_inici AS DATE)
 ) aac ON g.fecha = aac.dates
@@ -258,7 +258,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'atr' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') and gpm.name = '1'
+        mode_facturacio = 'atr' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') and gpm.name = '1'
     GROUP BY
         CAST(gpm.data_inici AS DATE)
 ) aad ON g.fecha = aad.dates
@@ -620,7 +620,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'index' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+        mode_facturacio = 'index' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY
         CAST(gp.data_baixa AS DATE)
 ) aac ON g.fecha = aac.dates
@@ -634,7 +634,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'atr' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+        mode_facturacio = 'atr' and rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY
         CAST(gp.data_baixa AS DATE)
 ) aad ON g.fecha = aad.dates
@@ -870,7 +870,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: ATR % Indexada%' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+        observacions LIKE '%Mode facturaci%: ATR % Indexada%' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY
         DATE_TRUNC('month', gpm.create_date)
 ) aaa ON g.fecha = aaa.dates
@@ -884,7 +884,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: Indexada % ATR%' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+        observacions LIKE '%Mode facturaci%: Indexada % ATR%' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY
         DATE_TRUNC('month', gpm.create_date)
 ) bbb ON g.fecha = bbb.dates
@@ -1001,7 +1001,7 @@ LEFT JOIN (
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        gpm.mode_facturacio = 'index' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') AND gpm.name = '1'
+        gpm.mode_facturacio = 'index' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') AND gpm.name = '1'
     GROUP BY 1
 ) aac ON g.fecha = aac.dates
 LEFT JOIN (
@@ -1014,7 +1014,7 @@ LEFT JOIN (
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        gpm.mode_facturacio = 'atr' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') AND gpm.name = '1'
+        gpm.mode_facturacio = 'atr' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') AND gpm.name = '1'
     GROUP BY 1
 ) aad ON g.fecha = aad.dates
 ORDER BY g.fecha
@@ -1316,7 +1316,7 @@ LEFT JOIN (
     LEFT JOIN giscedata_cups_ps gcps ON gp.cups = gcps.id
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
-    WHERE mode_facturacio = 'index' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+    WHERE mode_facturacio = 'index' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY DATE_TRUNC('month', gp.data_baixa)
 ) aac ON g.fecha = aac.dates
 LEFT JOIN (
@@ -1327,7 +1327,7 @@ LEFT JOIN (
     LEFT JOIN giscedata_cups_ps gcps ON gp.cups = gcps.id
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
-    WHERE mode_facturacio = 'atr' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL')
+    WHERE mode_facturacio = 'atr' AND rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG')
     GROUP BY DATE_TRUNC('month', gp.data_baixa)
 ) aad ON g.fecha = aad.dates
 ORDER BY g.fecha

--- a/som_dashboard/som_dashboard_custom_search.xml
+++ b/som_dashboard/som_dashboard_custom_search.xml
@@ -78,7 +78,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: ATR % Indexada%' and rse.code IN ('IF', 'MM')
+        observacions LIKE '%Mode facturaci%: ATR % Indexada%' and rse.code IN ('IF', 'MM', 'SB')
     GROUP BY
         CAST(gpm.create_date AS DATE)
 ) aa ON g.fecha = aa.dates
@@ -92,7 +92,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: Indexada % ATR%' and rse.code IN ('IF', 'MM')
+        observacions LIKE '%Mode facturaci%: Indexada % ATR%' and rse.code IN ('IF', 'MM', 'SB')
     GROUP BY
         CAST(gpm.create_date AS DATE)
 ) bb ON g.fecha = bb.dates
@@ -216,7 +216,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'index' and rse.code IN ('IF', 'MM') and gpm.name = '1'
+        mode_facturacio = 'index' and rse.code IN ('IF', 'MM', 'SB') and gpm.name = '1'
     GROUP BY
         CAST(gpm.data_inici AS DATE)
 ) aaa ON g.fecha = aaa.dates
@@ -230,7 +230,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'atr' and rse.code IN ('IF', 'MM') and gpm.name = '1'
+        mode_facturacio = 'atr' and rse.code IN ('IF', 'MM', 'SB') and gpm.name = '1'
     GROUP BY
         CAST(gpm.data_inici AS DATE)
 ) aab ON g.fecha = aab.dates
@@ -592,7 +592,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'index' and rse.code IN ('IF', 'MM')
+        mode_facturacio = 'index' and rse.code IN ('IF', 'MM', 'SB')
     GROUP BY
         CAST(gp.data_baixa AS DATE)
 ) aaa ON g.fecha = aaa.dates
@@ -606,7 +606,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        mode_facturacio = 'atr' and rse.code IN ('IF', 'MM')
+        mode_facturacio = 'atr' and rse.code IN ('IF', 'MM', 'SB')
     GROUP BY
         CAST(gp.data_baixa AS DATE)
 ) aab ON g.fecha = aab.dates
@@ -842,7 +842,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: ATR % Indexada%' AND rse.code IN ('IF', 'MM')
+        observacions LIKE '%Mode facturaci%: ATR % Indexada%' AND rse.code IN ('IF', 'MM', 'SB')
     GROUP BY
         DATE_TRUNC('month', gpm.create_date)
 ) aa ON g.fecha = aa.dates
@@ -856,7 +856,7 @@ LEFT JOIN (
         LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
         LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        observacions LIKE '%Mode facturaci%: Indexada % ATR%' AND rse.code IN ('IF', 'MM')
+        observacions LIKE '%Mode facturaci%: Indexada % ATR%' AND rse.code IN ('IF', 'MM', 'SB')
     GROUP BY
         DATE_TRUNC('month', gpm.create_date)
 ) bb ON g.fecha = bb.dates
@@ -975,7 +975,7 @@ LEFT JOIN (
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        gpm.mode_facturacio = 'index' AND rse.code IN ('IF', 'MM') AND gpm.name = '1'
+        gpm.mode_facturacio = 'index' AND rse.code IN ('IF', 'MM', 'SB') AND gpm.name = '1'
     GROUP BY 1
 ) aaa ON g.fecha = aaa.dates
 LEFT JOIN (
@@ -988,7 +988,7 @@ LEFT JOIN (
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
     WHERE
-        gpm.mode_facturacio = 'atr' AND rse.code IN ('IF', 'MM') AND gpm.name = '1'
+        gpm.mode_facturacio = 'atr' AND rse.code IN ('IF', 'MM', 'SB') AND gpm.name = '1'
     GROUP BY 1
 ) aab ON g.fecha = aab.dates
 LEFT JOIN (
@@ -1294,7 +1294,7 @@ LEFT JOIN (
     LEFT JOIN giscedata_cups_ps gcps ON gp.cups = gcps.id
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
-    WHERE mode_facturacio = 'index' AND rse.code IN ('IF', 'MM')
+    WHERE mode_facturacio = 'index' AND rse.code IN ('IF', 'MM', 'SB')
     GROUP BY DATE_TRUNC('month', gp.data_baixa)
 ) aaa ON g.fecha = aaa.dates
 LEFT JOIN (
@@ -1305,7 +1305,7 @@ LEFT JOIN (
     LEFT JOIN giscedata_cups_ps gcps ON gp.cups = gcps.id
     LEFT JOIN res_municipi rm ON gcps.id_municipi = rm.id
     LEFT JOIN res_subsistemas_electricos rse ON rm.subsistema_id = rse.id
-    WHERE mode_facturacio = 'atr' AND rse.code IN ('IF', 'MM')
+    WHERE mode_facturacio = 'atr' AND rse.code IN ('IF', 'MM', 'SB')
     GROUP BY DATE_TRUNC('month', gp.data_baixa)
 ) aab ON g.fecha = aab.dates
 LEFT JOIN (

--- a/som_indexada/data/custom_search_data.xml
+++ b/som_indexada/data/custom_search_data.xml
@@ -12,7 +12,7 @@ tarifes_sistemes AS (
     SELECT DISTINCT
         gpt.name AS tarifa_name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -44,7 +44,7 @@ LEFT JOIN (
         COUNT(*) AS altes,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -62,7 +62,7 @@ LEFT JOIN (
         COUNT(*) AS altes_indexada,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -80,7 +80,7 @@ LEFT JOIN (
         COUNT(*) AS canvis_index,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -98,7 +98,7 @@ LEFT JOIN (
         COUNT(*) AS baixes,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -116,7 +116,7 @@ LEFT JOIN (
         COUNT(*) AS baixes_indexada,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -134,7 +134,7 @@ LEFT JOIN (
         COUNT(*) AS canvis_periodes,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -160,7 +160,7 @@ tarifes_sistemes AS (
     SELECT DISTINCT
         gpt.name AS tarifa_name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -191,7 +191,7 @@ LEFT JOIN (
         COUNT(*) AS altes,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -209,7 +209,7 @@ LEFT JOIN (
         COUNT(*) AS altes_indexada,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -227,7 +227,7 @@ LEFT JOIN (
         COUNT(*) AS canvis_index,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -245,7 +245,7 @@ LEFT JOIN (
         COUNT(*) AS baixes,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -263,7 +263,7 @@ LEFT JOIN (
         COUNT(*) AS baixes_indexada,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
@@ -281,7 +281,7 @@ LEFT JOIN (
         COUNT(*) AS canvis_periodes,
         gpt.name,
         CASE
-            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL') THEN 'Canàries'
+            WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
             WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema

--- a/som_indexada/data/custom_search_data.xml
+++ b/som_indexada/data/custom_search_data.xml
@@ -13,7 +13,7 @@ tarifes_sistemes AS (
         gpt.name AS tarifa_name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa gp
@@ -45,7 +45,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -63,7 +63,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -81,7 +81,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -99,7 +99,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa gp
@@ -117,7 +117,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa gp
@@ -135,7 +135,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -161,7 +161,7 @@ tarifes_sistemes AS (
         gpt.name AS tarifa_name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa gp
@@ -192,7 +192,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -210,7 +210,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -228,7 +228,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm
@@ -246,7 +246,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa gp
@@ -264,7 +264,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa gp
@@ -282,7 +282,7 @@ LEFT JOIN (
         gpt.name,
         CASE
             WHEN rse.code IN ('TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG') THEN 'Canàries'
-            WHEN rse.code IN ('IF', 'MM') THEN 'Balears'
+            WHEN rse.code IN ('IF', 'MM', 'SB') THEN 'Balears'
             WHEN rse.code = 'PE' THEN 'Península'
         END AS sistema
     FROM giscedata_polissa_modcontractual gpm

--- a/som_indexada/giscedata_polissa.py
+++ b/som_indexada/giscedata_polissa.py
@@ -80,7 +80,7 @@ class GiscedataPolissa(osv.osv):
         res_municipi_o = self.pool.get("res.municipi")
         municipi = res_municipi_o.browse(cursor, uid, id_municipi)
         subsistema_code = municipi.subsistema_id.code
-        if subsistema_code in ['TF', 'PA', 'LG', 'HI', 'GC', 'FL']:
+        if subsistema_code in ['TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG']:
             return "canaries"
         elif subsistema_code in ['IF', 'MM']:
             return "balears"

--- a/som_indexada/giscedata_polissa.py
+++ b/som_indexada/giscedata_polissa.py
@@ -82,7 +82,7 @@ class GiscedataPolissa(osv.osv):
         subsistema_code = municipi.subsistema_id.code
         if subsistema_code in ['TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG']:
             return "canaries"
-        elif subsistema_code in ['IF', 'MM']:
+        elif subsistema_code in ['IF', 'MM', 'SB']:
             return "balears"
         else:
             return "peninsula"

--- a/som_indexada/migrations/5.0.25.5.0/post-0001_fix_subsistema_tg_migrate_fields_data.py
+++ b/som_indexada/migrations/5.0.25.5.0/post-0001_fix_subsistema_tg_migrate_fields_data.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'data/custom_search_data.xml',
+    ]
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_indexada', data_file,
+            idref=None, mode='update'
+        )
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_indexada/wizard/wizard_massive_k_change.py
+++ b/som_indexada/wizard/wizard_massive_k_change.py
@@ -101,7 +101,7 @@ class WizardMassiveKChange(osv.osv_memory):
                                 cursor, uid, "som_indexada",
                                 "pricelist_indexada_empresa_canaries_non_standard_2024"
                             )[1]
-                        elif polissa.cups.id_municipi.subsistema_id.code in ['IF', 'MM']:
+                        elif polissa.cups.id_municipi.subsistema_id.code in ['IF', 'MM', 'SB']:
                             pricelist_id = ir_model_data.get_object_reference(
                                 cursor, uid, "som_indexada",
                                 "pricelist_indexada_empresa_balears_non_standard_2024"

--- a/som_indexada/wizard/wizard_massive_k_change.py
+++ b/som_indexada/wizard/wizard_massive_k_change.py
@@ -95,7 +95,7 @@ class WizardMassiveKChange(osv.osv_memory):
                     if wiz_og.update_pricelist:
                         if (
                             polissa.cups.id_municipi.subsistema_id.code in
-                            ['TF', 'PA', 'LG', 'HI', 'GC', 'FL']
+                            ['TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG']
                         ):
                             pricelist_id = ir_model_data.get_object_reference(
                                 cursor, uid, "som_indexada",

--- a/som_polissa/models/giscedata_polissa.py
+++ b/som_polissa/models/giscedata_polissa.py
@@ -979,7 +979,7 @@ class GiscedataPolissa(osv.osv):
         municipi = municipi_obj.browse(cursor, uid, cups.id_municipi.id, context=context)
         posicio_id = None
         is_canarias = municipi and municipi.subsistema_id and municipi.subsistema_id.code in [
-            'TF', 'PA', 'LG', 'HI', 'GC', 'FL']
+            'TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG']
         is_pdlc = cups.distribuidora_id.ref == '0401'
         is_vivienda = cnae and cnae == "9820"
         power = max(powers or [0])

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -596,7 +596,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
         ]
 
     def esBalears(self, cursor, uid, env, context=False):
-        return env.polissa_id.cups.id_municipi.subsistema_id.code in ['MM', 'IF']
+        return env.polissa_id.cups.id_municipi.subsistema_id.code in ['MM', 'IF', 'SB']
 
     def getTarifaCorreu(self, cursor, uid, env, context=False):
         key_prefixes = ["Indexada", "Periodes"]

--- a/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
+++ b/som_polissa_condicions_generals/report_backend_mailcanvipreus.py
@@ -592,7 +592,7 @@ class ReportBackendMailcanvipreus(ReportBackend):
 
     def esCanaries(self, cursor, uid, env, context=False):
         return env.polissa_id.cups.id_municipi.subsistema_id.code in [
-            'TF', 'PA', 'LG', 'HI', 'GC', 'FL'
+            'TF', 'PA', 'LG', 'HI', 'GC', 'FL', 'TG'
         ]
 
     def esBalears(self, cursor, uid, env, context=False):

--- a/www_som/giscedata_polissa.py
+++ b/www_som/giscedata_polissa.py
@@ -180,7 +180,7 @@ class GiscedataPolissa(osv.osv):
         elif mode_facturacio == 'atr':
             if location == 'peninsula':
                 new_pricelist_id = pp_periodes_peninsula_id
-            elif location == 'insular':
+            else:
                 new_pricelist_id = pp_periodes_insular_id
 
         return new_pricelist_id


### PR DESCRIPTION
## Objectiu
Que no deixi de funcionar tot lo que mira si es canàries

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8199172?folder_id=90


## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates Canary and Balearic subsystem classification to recognize TG and SB throughout pricing, reporting, dashboards, and contract workflows.
- Adds TG and SB to subsystem classification lists and dashboard queries.
- Adds migrations to reload the affected custom-search records.
- Updates the OV ATR resolver so non-peninsular locations receive the insular pricelist.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| www_som/giscedata_polissa.py | The ATR resolver now maps the helper's Canary and Balearic results to the existing insular pricelist, resolving the previously reported invalid zero ID. |
| som_indexada/giscedata_polissa.py | TG and SB are added consistently to the helper's established Canary and Balearic return categories. |
| som_dashboard/som_dashboard_custom_search.xml | Dashboard queries now include TG and SB in their respective regional aggregates. |
| som_dashboard/migrations/5.0.25.5.0/post-0002_fix_subsistema_tg_migrate_data.py | The migration reloads the modified dashboard XML using the module's established migration pattern. |
| som_indexada/migrations/5.0.25.5.0/post-0001_fix_subsistema_tg_migrate_fields_data.py | The migration reloads indexed-pricing custom searches using the same pattern as an earlier migration for this data file. |

</details>

<sub>Reviews (2): Last reviewed commit: ["✨ Add new balears subsistema + migration..."](https://github.com/som-energia/openerp_som_addons/commit/9c84ccb59ef50acfbb97facf4a2327ee55c55b80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50737294)</sub>

**Context used:**

- Knowledge Base — [Base Platform: Shared Extensions, Views, Assets, and Templates](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/base-platform.md)
- Knowledge Base — [Customer-Ops and Miscellaneous Modules](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/customer-ops-misc.md)

<!-- /greptile_comment -->