### PR TITLE
Botó per enviar la signatura del e-mail

### DIFF
--- a/som_leads_polissa/migrations/5.0.25.5.0/post-0007_send_sign_email_migrate_fields_data.py
+++ b/som_leads_polissa/migrations/5.0.25.5.0/post-0007_send_sign_email_migrate_fields_data.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import logging
 from oopgrade.oopgrade import load_data
 

--- a/som_leads_polissa/migrations/5.0.25.5.0/post-0007_send_sign_email_migrate_fields_data.py
+++ b/som_leads_polissa/migrations/5.0.25.5.0/post-0007_send_sign_email_migrate_fields_data.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML files")
+    data_files = [
+        'views/giscedata_crm_lead_view.xml',
+    ]
+    for data_file in data_files:
+        load_data(
+            cursor, 'som_leads_polissa', data_file,
+            idref=None, mode='update'
+        )
+    logger.info("Migration completed successfully.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -51,6 +51,27 @@ class GiscedataCrmLead(osv.OsvInherits):
             if constraint[0].__name__ != "check_num_tel_mob_longitude"
         ]
 
+    def send_sign_email(self, cursor, uid, lead_id, context=None):
+        if context is None:
+            context = {}
+
+        mail_o = self.pool.get("poweremail.mailbox")
+
+        lead = self.browse(cursor, uid, lead_id, context=context)
+        if not lead.signature_process:
+            raise osv.except_osv(
+                "Error",
+                "No hi ha cap procés de signatura associat a aquest lead."
+            )
+
+        lead.signature_process.send_poweremail(cursor, uid, [lead_id], context=context)
+        search_params = [
+            ("reference", "=", "poweremail.mailbox,{}".format(lead_id))
+        ]
+        mail_ids = mail_o.search(cursor, uid, search_params, context=context)
+        mail_o.send_this_mail(cursor, uid, mail_ids, context=context)
+        return True
+
     def contract_pdf(self, cursor, uid, ids, context=None):
         if context is None:
             context = {}

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -58,6 +58,8 @@ class GiscedataCrmLead(osv.OsvInherits):
         mail_o = self.pool.get("poweremail.mailbox")
         signature_o = self.pool.get("giscedata.signatura.process")
 
+        if not isinstance(lead_id, (list, tuple)):
+            lead_id = [lead_id]
         lead = self.browse(cursor, uid, lead_id[0], context=context)
         if not lead.signature_process:
             raise osv.except_osv(

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -64,9 +64,15 @@ class GiscedataCrmLead(osv.OsvInherits):
                 "No hi ha cap procés de signatura associat a aquest lead."
             )
 
-        lead.signature_process.send_poweremail(cursor, uid, [lead_id], context=context)
+        sign_id = lead.signature_process.id
+        template_id = lead.signature_process.template_id.id
+        lead.signature_process.send_poweremail(
+            cursor, uid, [sign_id], context=context
+        )
         search_params = [
-            ("reference", "=", "poweremail.mailbox,{}".format(lead_id))
+            ("reference", "=", "giscedata.signatura.process,{}".format(sign_id)),
+            ("template_id", "=", template_id),
+            ("folder", "=", "outbox")
         ]
         mail_ids = mail_o.search(cursor, uid, search_params, context=context)
         mail_o.send_this_mail(cursor, uid, mail_ids, context=context)

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -56,6 +56,7 @@ class GiscedataCrmLead(osv.OsvInherits):
             context = {}
 
         mail_o = self.pool.get("poweremail.mailbox")
+        signature_o = self.pool.get("giscedata.signatura.process")
 
         lead = self.browse(cursor, uid, lead_id[0], context=context)
         if not lead.signature_process:
@@ -66,8 +67,8 @@ class GiscedataCrmLead(osv.OsvInherits):
 
         sign_id = lead.signature_process.id
         template_id = lead.signature_process.template_id.id
-        lead.signature_process.send_poweremail(
-            [sign_id], context=context
+        signature_o.send_poweremail(
+            cursor, uid, [sign_id], context=context
         )
         search_params = [
             ("reference", "=", "giscedata.signatura.process,{}".format(sign_id)),

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -67,7 +67,7 @@ class GiscedataCrmLead(osv.OsvInherits):
         sign_id = lead.signature_process.id
         template_id = lead.signature_process.template_id.id
         lead.signature_process.send_poweremail(
-            cursor, uid, [sign_id], context=context
+            [sign_id], context=context
         )
         search_params = [
             ("reference", "=", "giscedata.signatura.process,{}".format(sign_id)),

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -57,7 +57,7 @@ class GiscedataCrmLead(osv.OsvInherits):
 
         mail_o = self.pool.get("poweremail.mailbox")
 
-        lead = self.browse(cursor, uid, lead_id, context=context)
+        lead = self.browse(cursor, uid, lead_id[0], context=context)
         if not lead.signature_process:
             raise osv.except_osv(
                 "Error",

--- a/som_leads_polissa/tests/tests_sign_lead.py
+++ b/som_leads_polissa/tests/tests_sign_lead.py
@@ -7,6 +7,8 @@ from destral.transaction import Transaction
 from osv import osv
 import mock
 
+from poweremail_oorq import poweremail_mailbox
+
 
 class TestSignLead(testing.OOTestCase):
 
@@ -125,6 +127,51 @@ class TestSignLead(testing.OOTestCase):
                         self.cursor, self.uid, lead_id, self._cups,
                         context={'skip_validations': True}
                     )
+
+    def test_send_sign_email_raises_when_signature_process_not_found(self):
+        lead_id = self._create_lead()
+        with self.assertRaises(osv.except_osv):
+            self.lead_o.send_sign_email(self.cursor, self.uid, lead_id, context={})
+
+    @mock.patch.object(poweremail_mailbox.PoweremailMailbox, 'send_this_mail')
+    def test_send_sign_email(self, mock_send_this_mail):
+        mailbox_o = self.get_model('poweremail.mailbox')
+        lead_id = self._create_lead()
+        template_id = self.ir_model_o.get_object_reference(
+            self.cursor, self.uid,
+            'giscedata_crm_leads_signatura', 'alta_lead_signatura'
+        )[1]
+        process_id = self.process_o.create(
+            self.cursor, self.uid,
+            {
+                'subject': 'Test process',
+                'status': 'wait',
+                'signature_url': 'http://sign.url',
+                'template_id': template_id,
+                'template_res_id': lead_id,
+                'lang': 'en_US',
+                'recipients': [(0, 0, {
+                    'name': 'Test titular',
+                    'email': 'test@example.org',
+                })],
+            },
+            context={}
+        )
+        lead = self.lead_o.browse(self.cursor, self.uid, lead_id)
+        lead.write({'signature_process': process_id}, context={})
+        self.lead_o.send_sign_email(self.cursor, self.uid, lead_id, context={})
+        search_params = [
+            ('reference', '=', 'giscedata.signatura.process,{}'.format(process_id)),
+            ('template_id', '=', template_id),
+            ('folder', '=', 'outbox'),
+        ]
+        mail_ids = mailbox_o.search(
+            self.cursor, self.uid, search_params, context={}
+        )
+        self.assertEqual(len(mail_ids), 1)
+        mock_send_this_mail.assert_called_once_with(
+            self.cursor, self.uid, mail_ids, context=mock.ANY
+        )
 
 
 class TestActivationMailAfterSignature(testing.OOTestCase):

--- a/som_leads_polissa/views/giscedata_crm_lead_view.xml
+++ b/som_leads_polissa/views/giscedata_crm_lead_view.xml
@@ -9,12 +9,12 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='polissa_id']" position="after">
                     <group colspan="2" attrs="{'invisible': [('polissa_id', '=', False)]}">
-                        <button name="button_send_mail" type="object" string="Enviar correu conforme ha contractat" icon="send" colspan="2" confirm="Aquesta acció enviarà un correu electrònic, vols procedir?"/>
+                        <button name="button_send_mail" type="object" string="Enviar correu conforme ha contractat" icon="mail" colspan="2" confirm="Aquesta acció enviarà un correu electrònic, vols procedir?"/>
                     </group>
                     <group colspan="2" attrs="{'invisible': [('signature_process', '=', False)]}">
                         <button name="send_sign_email" type="object"
-                            string="Enviar correu per Signar (correu instantàni)"
-                            icon="send" colspan="2"/>
+                            string="Enviar correu per Signar (correu instantani)" confirm="Aquesta acció enviarà un correu electrònic INSTANTANI, vols procedir?"
+                            icon="mail-fast" colspan="2"/>
                     </group>
                 </xpath>
                 <xpath expr="//field[@name='llista_preu']" position="replace">

--- a/som_leads_polissa/views/giscedata_crm_lead_view.xml
+++ b/som_leads_polissa/views/giscedata_crm_lead_view.xml
@@ -11,6 +11,9 @@
                     <group colspan="2" attrs="{'invisible': [('polissa_id', '=', False)]}">
                         <button name="button_send_mail" type="object" string="Enviar correu conforme ha contractat" icon="send" colspan="2" confirm="Aquesta acció enviarà un correu electrònic, vols procedir?"/>
                     </group>
+                    <group colspan="2" attrs="{'invisible': [('signature_process', '=', False)]}">
+                        <button name="send_sign_email" type="object" string="Enviar correu per Signar (correu instantàni)" icon="send" colspan="2"/>
+                    </group>
                 </xpath>
                 <xpath expr="//field[@name='llista_preu']" position="replace">
                 </xpath>

--- a/som_leads_polissa/views/giscedata_crm_lead_view.xml
+++ b/som_leads_polissa/views/giscedata_crm_lead_view.xml
@@ -12,7 +12,9 @@
                         <button name="button_send_mail" type="object" string="Enviar correu conforme ha contractat" icon="send" colspan="2" confirm="Aquesta acció enviarà un correu electrònic, vols procedir?"/>
                     </group>
                     <group colspan="2" attrs="{'invisible': [('signature_process', '=', False)]}">
-                        <button name="send_sign_email" type="object" string="Enviar correu per Signar (correu instantàni)" icon="send" colspan="2"/>
+                        <button name="send_sign_email" type="object"
+                            string="Enviar correu per Signar (correu instantàni)"
+                            icon="send" colspan="2"/>
                     </group>
                 </xpath>
                 <xpath expr="//field[@name='llista_preu']" position="replace">

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -28,7 +28,7 @@ class SomLeadWww(osv.osv_memory):
     _128_SIMPLIFIED_SURPLUSES = 'a0'
     _131_CONSUMPTION = '01'
     _SIGNATURE_COMPLETED_STATUS = 'completed'
-    _SIGNATURE_ERROR_STATUSES = ('error', 'canceled', 'declined', 'expired', 'unsend')
+    _SIGNATURE_ERROR_STATUSES = ('error', 'canceled', 'declined', 'expired')
 
     def create_lead(self, cr, uid, www_vals, context=None):
         if context is None:
@@ -472,7 +472,7 @@ class SomLeadWww(osv.osv_memory):
             if signature_status == self._SIGNATURE_COMPLETED_STATUS:
                 return True
 
-            if signature_status in self._SIGNATURE_ERROR_STATUSES:
+            if signature_status in self._SIGNATURE_ERROR_STATUSES or signature_status == 'unsend':
                 return False
 
             sign_process_obj.update(tmp_cursor, uid, [signature_process[0]], context=context)
@@ -519,7 +519,7 @@ class SomLeadWww(osv.osv_memory):
             query = """SELECT l.id from giscedata_crm_lead as l
                        LEFT JOIN crm_case as c on c.id = l.crm_id
                        where c.state in ('open', 'pending')
-                       and l.create_date >= now() - INTERVAL '7 days'
+                       and l.create_date >= now() - INTERVAL '3 days'
                        order by id desc
                        FOR UPDATE skip locked
                        """


### PR DESCRIPTION
## Objectiu
Posar un botó per enviar automàticament el correu per recordar la signatura

## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/1755/activity

## Comportament antic
No existia

## Comportament nou
Existeix

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a lead-form action that immediately generates and sends a signature reminder email, including migration and test coverage. It also adjusts signature activation polling and narrows the retry window from seven days to three.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/models/giscedata_crm_lead.py | Adds the signature-reminder action and correctly extracts the singleton record ID supplied by the form button. |
| som_leads_polissa/tests/tests_sign_lead.py | Covers successful reminder generation and the missing-signature-process error path. |
| som_leads_polissa/www/som_lead_www.py | Handles the unsent signature state explicitly and changes retry eligibility to leads created within three days. |
| som_leads_polissa/migrations/5.0.25.5.0/post-0007_send_sign_email_migrate_fields_data.py | Reloads the CRM lead view during module migration. |
| som_leads_polissa/views/giscedata_crm_lead_view.xml | Adds the signature-reminder button to leads with an associated signature process. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/sen..."](https://github.com/som-energia/openerp_som_addons/commit/8c6612a6cbc13a96806142079a21faeb85d41193) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50782767)</sub>

**Context used:**

- Context used - docs/adr/0001-define-code-style.md ([source](https://github.com/som-energia/openerp_som_addons/blob/main/docs/adr/0001-define-code-style.md))
- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->