### PR TITLE
✨ add Flux Solar contract listing

### DIFF
--- a/som_facturacio_flux_solar/giscedata_bateria_virtual.xml
+++ b/som_facturacio_flux_solar/giscedata_bateria_virtual.xml
@@ -30,6 +30,22 @@
                 </field>
             </field>
         </record>
+
+        <record model="ir.actions.act_window" id="action_som_bateries_polissa_tree">
+            <field name="name">Contractes Flux Solar</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">giscedata.bateria.virtual.polissa</field>
+            <field name="domain">[]</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="giscedata_facturacio_bateria_virtual.view_bateries_polissa_tree_listat"/>
+        </record>
+
+        <menuitem id="menu_som_bateries_polissa_tree"
+                  name="Contractes Flux Solar"
+                  parent="giscedata_facturacio_bateria_virtual.menu_bateries_virtuals"
+                  action="action_som_bateries_polissa_tree"/>
+
         <record id="view_giscedata_import_bateria_virtual_tree_inherit" model="ir.ui.view">
             <field name="name">view_giscedata_import_bateria_virtual_tree_inherit</field>
             <field name="model">giscedata.bateria.virtual.resum.facturacio</field>

--- a/som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0002_add_flux_solar_contract_listing.py
+++ b/som_facturacio_flux_solar/migrations/5.0.26.12.0/post-0002_add_flux_solar_contract_listing.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+from __future__ import absolute_import
+
+from tools import config
+from oopgrade.oopgrade import MigrationHelper
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return None
+
+    mh = MigrationHelper(cursor, module_name='som_facturacio_flux_solar')
+    mh.update_xml(xml_path='giscedata_bateria_virtual.xml')
+    return True
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
## Objectiu
Nou llistat de bateria virtual pòlissa

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8140834?mark_as_read=f0bb2173-76c6-416d-915a-76f69d0ddde0&folder_id=87#thread-11620455

## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a standalone “Contractes Flux Solar” menu entry that opens the existing virtual-battery contract-association tree and form views.

- Defines a new window action for `giscedata.bateria.virtual.polissa`.
- Adds the action beneath the existing virtual-battery menu.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking XML line-length issue.

The new action references an existing compatible tree view and its parent module is declared as a dependency; the only accepted concern is formatting of one declaration.

**Files Needing Attention:** som_facturacio_flux_solar/giscedata_bateria_virtual.xml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_facturacio_flux_solar/giscedata_bateria_virtual.xml | Adds the Flux Solar contract-list action and menu using valid upstream model and view references; one new declaration violates the line-length rule. |

</details>

<sub>Reviews (1): Last reviewed commit: ["✨ add Flux Solar contract listing"](https://github.com/som-energia/openerp_som_addons/commit/892d962892ff2a9acb7f6f7d1a257ddf8005b407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51113407)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - docs/adr/0001-define-code-style.md ([source](https://github.com/som-energia/openerp_som_addons/blob/main/docs/adr/0001-define-code-style.md))
- Knowledge Base — [Billing Extensions](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/billing-extensions.md)

<!-- /greptile_comment -->