### PR TITLE
🐛 Remove english from SEPA report

### DIFF
--- a/som_polissa/report/sepa.css
+++ b/som_polissa/report/sepa.css
@@ -52,10 +52,10 @@ p {
     font-family: Arial, Helvetica, sans-serif;
     padding: 3px;
 }
-.spanish {
+.normal-text {
     font-size: 11px;
 }
-.english {
+.small-text {
     font-size: 10px;
     font-style: italic;
 }

--- a/som_polissa/report/sepa.css
+++ b/som_polissa/report/sepa.css
@@ -5,6 +5,7 @@ html, body {
 
 h1 {
     font-size: 15px;
+    margin-bottom: 30px;
 }
 h2 {
     font-size: 13px;

--- a/som_polissa/report/sepa_ca.mako
+++ b/som_polissa/report/sepa_ca.mako
@@ -6,100 +6,85 @@
         <div class="centered title">
             %if data['is_business']:
                 <h1>Ordre de domiciliació de dèbit directe SEPA B2B</h1>
-                <h2>SEPA Business-to-Business Direct Debit Mandate</h2>
             %else:
                 <h1>Ordre de domiciliació de dèbit directe SEPA</h1>
-                <h2>SEPA Direct Debit Mandate</h2>
             %endif
         </div>
     </div>
     <div>
-        <div class="centered blau">A emplenar pel creditor /
-            <span class="english">To be completed by the creditor</span>
-        </div>
+        <div class="centered blau">A emplenar pel creditor</div>
         <div class="intern margin50 full-width">
-            <div class="parella"><p class="label">Referència de l'ordre de domiciliació / <span class="english">Mandate reference</span></p>
+            <div class="parella"><p class="label">Referència de l'ordre de domiciliació</p>
             <p class="entrada">${data['order_reference']}</p></div>
-            <div class="parella"><p class="label">Identificador del creditor / <span class="english">Creditor identifier</span></p>
+            <div class="parella"><p class="label">Identificador del creditor</p>
             <p class="entrada">${data['creditor_code']}</p></div>
-            <div class="parella"><p class="label">Nom del creditor / <span class="english">Creditor´s name</span></p>
+            <div class="parella"><p class="label">Nom del creditor</p>
             <p class="entrada">${data['creditor_name']}</p></div>
-            <div class="parella"><p class="label">Adreça / <span class="english">Address</span></p>
+            <div class="parella"><p class="label">Adreça</p>
             <p class="entrada">${data['creditor_address']}</p></div>
-            <div class="parella"><p class="label">Província / <span class="english">Province </span></p>
+            <div class="parella"><p class="label">Província</p>
             <p class="entrada">${data['creditor_province']}</p></div>
-            <div class="parella"><p class="label">País / <span class="english">Country</span></p>
+            <div class="parella"><p class="label">País</p>
             <p class="entrada">${data['creditor_country']}</p></div>
         </div>
     </div>
     <div>
         %if data['is_business']:
-            <p class="margin20 spanish">
+            <p class="margin20 normal-text">
             Mitjançant la signatura d'aquesta ordre de domiciliació, el deutor autoritza (A) el creditor a enviar instruccions a l'entitat del deutor perquè carregui imports al seu compte i (B) l'entitat a efectuar els càrrecs al seu compte seguint les instruccions del creditor. Aquesta ordre de domiciliació està prevista exclusivament per a operacions entre empreses i/o autònoms. El deutor no té dret que la seva entitat li reemborsi l'import un cop s'hagi efectuat el càrrec en compte, però pot sol·licitar a la seva entitat que no efectuï el càrrec al compte fins a la data de venciment. Pot obtenir informació detallada sobre el procediment a la seva entitat financera.
-            </p>
-            <p class="margin20 english">
-            By signing this mandate form, you authorize (A) the Creditor to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with the instructions from the Creditor. This mandate is only intended for business-to-business transactions. You are not entitled to a refund from your bank after your account has been debited, but you are entitled to request your bank not to debit your account up until the day on which the payment is due. Please contact your bank for detailed procedures in such a case.
             </p>
         %else:
             <p class="margin20">
             Mitjançant la signatura d'aquesta ordre de domiciliació, el deutor autoritza (A) el creditor a enviar instruccions a l'entitat del deutor perquè carregui imports al seu compte i (B) l'entitat a efectuar els càrrecs al seu compte seguint les instruccions del creditor. Com a part dels seus drets, el deutor té dret al reemborsament per part de la seva entitat en els termes i les condicions del contracte subscrit amb aquesta. La sol·licitud de reemborsament s'haurà d'efectuar dins de les vuit setmanes següents a la data del càrrec en compte. Pot obtenir informació addicional sobre els seus drets a la seva entitat financera.
             </p>
-            <p class="margin20 english">
-            By signing this mandate form, you authorise (A) the Creditor to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with the instructions from the Creditor. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within eigth weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank.
-            </p>
         %endif
     </div>
     <div>
-        <div class="centered blau">A emplenar pel deutor /
-            <span class="english">To be completed by the debtor</span>
-        </div>
+        <div class="centered blau">A emplenar pel deutor</div>
         <div class="intern margin50 full-width">
-            <div class="parella"><p class="label">Nom del deutor/s / <span class="english">Debtor’s name</span></p>
+            <div class="parella"><p class="label">Nom del deutor/s</p>
             <p class="entrada">${data['debtor_name']}</p></div>
-            <div class="parella"><p class="label">Adreça del deutor / <span class="english">Address of the debtor</span></p>
+            <div class="parella"><p class="label">Adreça del deutor</p>
             <p class="entrada">${data['debtor_address']}</p></div>
-            <div class="parella"><p class="label">Província / <span class="english">Province</span></p>
+            <div class="parella"><p class="label">Província</p>
             <p class="entrada">${data['debtor_province']}</p></div>
-            <div class="parella"><p class="label">País del deutor / <span class="english">Country of the debtor</span></p>
+            <div class="parella"><p class="label">País del deutor</p>
             <p class="entrada">${data['debtor_country']}</p></div>
-            <div class="parella"><p class="label">Swift BIC / <span class="english">Swift BIC (pot contenir 8 o 11 posicions) / Swift BIC (up to 8 or 11 characters)</span></p>
+            <div class="parella"><p class="label">Swift BIC / <span class="small-text">Swift BIC (pot contenir 8 o 11 posicions)</span></p>
             <p class="entrada entrada-alta">${data['swift']}</p></div>
-            <div class="parella"><p class="label">Número de compte - IBAN / <span class="english">Account number - IBAN</span></p>
+            <div class="parella"><p class="label">Número de compte - IBAN</p>
             <p class="entrada entrada-alta">${data['debtor_iban_print']}</p></div>
-            <p class="english">A Espanya l'IBAN consta de 24 posicions i comença sempre per ES / Spanish IBAN of 24 positions always starting ES</p>
+            <p class="small-text">A Espanya l'IBAN consta de 24 posicions i comença sempre per ES</p>
             <div class="parella">
-                <p class="label">Tipus de pagament / <span class="english">Type of payment</span>:</p>
+                <p class="label">Tipus de pagament:</p>
                 <label class="entrada-label">
-                    <input type="checkbox" name="optradio" ${data['recurring']}>Pagament recurrent / <span class="english">Recurrent payment</span>
+                    <input type="checkbox" name="optradio" ${data['recurring']}>Pagament recurrent</span>
                 </label>
                 <label class="entrada-label">
-                    <input type="checkbox" name="optradio" ${data['single_payment']}>Pagament únic / <span class="english">One-off payment</span>
+                    <input type="checkbox" name="optradio" ${data['single_payment']}>Pagament únic</span>
                 </label>
             </div>
-            <div class="parella"><p class="label">Data - Localitat / <span class="english">Date - location in which you are signing</span>:</p>
+            <div class="parella"><p class="label">Data - Localitat:</p>
             <p class="entrada">${data['sign_date']} - ${data['creditor_city']}</p></div>
-            <div class="parella"><p class="label">Signatura del deutor / <span class="english">Signature of the debtor</span>:</p>
+            <div class="parella"><p class="label">Signatura del deutor:</p>
             <p class="entrada entrada-molt-alta"></p></div>
         </div>
     </div>
     <div class="last">
         %if data['is_business']:
-            <p class="spanish centered">
+            <p class="normal-text centered">
                 TOTS ELS CAMPS S'HAN D'EMPLENAR OBLIGATÒRIAMENT.
                 UN COP SIGNADA, AQUESTA ORDRE DE DOMICILIACIÓ S'HA D'ENVIAR AL CREDITOR PERQUÈ LA CUSTODIÏ.
                 L'ENTITAT DEL DEUTOR REQUEREIX L'AUTORITZACIÓ PRÈVIA D'AQUEST ABANS DE CARREGAR ELS DÈBITS DIRECTES B2B AL COMPTE.
                 EL DEUTOR PODRÀ GESTIONAR AQUESTA AUTORITZACIÓ MITJANÇANT ELS CANALS QUE LA SEVA ENTITAT POSI A LA SEVA DISPOSICIÓ.
                 <br>
             </p>
-            <p class="english centered">ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE. NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION
-                BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT. THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.</p>
         %else:
-            <p class="spanish centered">
+            <p class="normal-text centered">
                 TOTS ELS CAMPS S'HAN D'EMPLENAR OBLIGATÒRIAMENT.
                 UN COP SIGNADA, AQUESTA ORDRE DE DOMICILIACIÓ S'HA D'ENVIAR AL CREDITOR PERQUÈ LA CUSTODIÏ.
                 <br>
             </p>
-            <p class="english centered">ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.</p>
         %endif
     </div>
 </div>

--- a/som_polissa/report/sepa_ca.mako
+++ b/som_polissa/report/sepa_ca.mako
@@ -58,10 +58,10 @@
             <div class="parella">
                 <p class="label">Tipus de pagament:</p>
                 <label class="entrada-label">
-                    <input type="checkbox" name="optradio" ${data['recurring']}>Pagament recurrent</span>
+                    <input type="checkbox" name="optradio" ${data['recurring']}>Pagament recurrent
                 </label>
                 <label class="entrada-label">
-                    <input type="checkbox" name="optradio" ${data['single_payment']}>Pagament únic</span>
+                    <input type="checkbox" name="optradio" ${data['single_payment']}>Pagament únic
                 </label>
             </div>
             <div class="parella"><p class="label">Data - Localitat:</p>

--- a/som_polissa/report/sepa_es.mako
+++ b/som_polissa/report/sepa_es.mako
@@ -6,100 +6,85 @@
         <div class="centered title">
             %if data['is_business']:
                 <h1>Orden de domiciliación de adeudo directo SEPA B2B</h1>
-                <h2>SEPA Business-to-Business Direct Debit Mandate</h2>
             %else:
                 <h1>Orden de domiciliación de adeudo directo SEPA</h1>
-                <h2>SEPA Direct Debit Mandate</h2>
             %endif
         </div>
     </div>
     <div>
-        <div class="centered blau">A cumplimentar por el acreedor /
-            <span class="english">To be completed by the creditor</span>
-        </div>
+        <div class="centered blau">A cumplimentar por el acreedor</div>
         <div class="intern margin50 full-width">
-            <div class="parella"><p class="label">Referencia de la orden de domiciliación / <span class="english">Mandate reference</span></p>
+            <div class="parella"><p class="label">Referencia de la orden de domiciliación</p>
             <p class="entrada">${data['order_reference']}</p></div>
-            <div class="parella"><p class="label">Identificador del acreedor / <span class="english">Creditor identifier</span></p>
+            <div class="parella"><p class="label">Identificador del acreedor</p>
             <p class="entrada">${data['creditor_code']}</p></div>
-            <div class="parella"><p class="label">Nombre del acreedor / <span class="english">Creditor´s name</span></p>
+            <div class="parella"><p class="label">Nombre del acreedor</p>
             <p class="entrada">${data['creditor_name']}</p></div>
-            <div class="parella"><p class="label">Dirección / <span class="english">Address</span></p>
+            <div class="parella"><p class="label">Dirección</p>
             <p class="entrada">${data['creditor_address']}</p></div>
-            <div class="parella"><p class="label">Provincia / <span class="english">Province </span></p>
+            <div class="parella"><p class="label">Provincia</p>
             <p class="entrada">${data['creditor_province']}</p></div>
-            <div class="parella"><p class="label">País / <span class="english">Country</span></p>
+            <div class="parella"><p class="label">País</p>
             <p class="entrada">${data['creditor_country']}</p></div>
         </div>
     </div>
     <div>
         %if data['is_business']:
-            <p class="margin20 spanish">
+            <p class="margin20 normal-text">
             Mediante la firma de esta orden de domiciliación, el deudor autoriza (A) al acreedor a enviar instrucciones a la entidad del deudor para adeudar su cuenta y (B) a la entidad para efectuar los adeudos en su cuenta siguiendo las instrucciones del acreedor. Esta orden de domiciliación está prevista para operaciones exclusivamente entre empresas y/o autónomos. El deudor no tiene derecho a que su entidad le reembolse una vez que se haya realizado el cargo en cuenta, pero puede solicitar a su entidad que no efectúe el adeudo en la cuenta hasta la fecha debida. Podrá obtener información detallada del procedimiento en su entidad financiera.
-            </p>
-            <p class="margin20 english">
-            By signing this mandate form, you authorize (A) the Creditor to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with the instructions from the Creditor. This mandate is only intended for business-to-business transactions. You are not entitled to a refund from your bank after your account has been debited, but you are entitled to request your bank not to debit your account up until the day on which the payment is due. Please contact your bank for detailed procedures in such a case.
             </p>
         %else:
             <p class="margin20">
             Mediante la firma de esta orden de domiciliación, el deudor autoriza (A) al acreedor a enviar instrucciones a la entidad del deudor para adeudar su cuenta y (B) a la entidad para efectuar los adeudos en su cuenta siguiendo las instrucciones del acreedor. Como parte de sus derechos, el deudor está legitimado al reembolso por su entidad en los términos y condiciones del contrato suscrito con la misma. La solicitud de reembolso deberá efectuarse dentro de las ocho semanas que siguen a la fecha de adeudo en cuenta. Puede obtener información adicional sobre sus derechos en su entidad financiera.
             </p>
-            <p class="margin20 english">
-            By signing this mandate form, you authorise (A) the Creditor to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with the instructions from the Creditor. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within eigth weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank.
-            </p>
         %endif
     </div>
     <div>
-        <div class="centered blau">A cumplimentar por el deudor /
-            <span class="english">To be completed by the debtor</span>
-        </div>
+        <div class="centered blau">A cumplimentar por el deudor</div>
         <div class="intern margin50 full-width">
-            <div class="parella"><p class="label">Nombre del deudor/es / <span class="english">Debtor’s name</span></p>
+            <div class="parella"><p class="label">Nombre del deudor/es</p>
             <p class="entrada">${data['debtor_name']}</p></div>
-            <div class="parella"><p class="label">Dirección del deudor / <span class="english">Address of the debtor</span></p>
+            <div class="parella"><p class="label">Dirección del deudor</p>
             <p class="entrada">${data['debtor_address']}</p></div>
-            <div class="parella"><p class="label">Provincia / <span class="english">Province</span></p>
+            <div class="parella"><p class="label">Provincia</p>
             <p class="entrada">${data['debtor_province']}</p></div>
-            <div class="parella"><p class="label">País del deudor / <span class="english">Country of the debtor</span></p>
+            <div class="parella"><p class="label">País del deudor</p>
             <p class="entrada">${data['debtor_country']}</p></div>
-            <div class="parella"><p class="label">Swift BIC / <span class="english">Swift BIC (puede contener 8 u 11 posiciones) / Swift BIC (up to 8 or 11 characters)</span></p>
+            <div class="parella"><p class="label">Swift BIC / <span class="small-text">Swift BIC (puede contener 8 u 11 posiciones)</span></p>
             <p class="entrada entrada-alta">${data['swift']}</p></div>
-            <div class="parella"><p class="label">Número de cuenta - IBAN / <span class="english">Account number - IBAN</span></p>
+            <div class="parella"><p class="label">Número de cuenta - IBAN</p>
             <p class="entrada entrada-alta">${data['debtor_iban_print']}</p></div>
-            <p class="english">En España el IBAN consta de 24 posiciones comenzando siempre por ES / Spanish IBAN of 24 positions always starting ES</p>
+            <p class="small-text">En España el IBAN consta de 24 posiciones comenzando siempre por ES</p>
             <div class="parella">
-                <p class="label">Tipo de pago / <span class="english">Type of payment</span>:</p>
+                <p class="label">Tipo de pago:</p>
                 <label class="entrada-label">
-                    <input type="checkbox" name="optradio" ${data['recurring']}>Pago recurrente / <span class="english">Recurrent payment</span>
+                    <input type="checkbox" name="optradio" ${data['recurring']}>Pago recurrente
                 </label>
                 <label class="entrada-label">
-                    <input type="checkbox" name="optradio" ${data['single_payment']}>Pago único / <span class="english">One-off payment</span>
+                    <input type="checkbox" name="optradio" ${data['single_payment']}>Pago único
                 </label>
             </div>
-            <div class="parella"><p class="label">Fecha - Localidad / <span class="english">Date - location in which you are signing</span>:</p>
+            <div class="parella"><p class="label">Fecha - Localidad:</p>
             <p class="entrada">${data['sign_date']} - ${data['creditor_city']}</p></div>
-            <div class="parella"><p class="label">Firma del deudor / <span class="english">Signature of the debtor</span>:</p>
+            <div class="parella"><p class="label">Firma del deudor:</p>
             <p class="entrada entrada-molt-alta"></p></div>
         </div>
     </div>
     <div class="last">
         %if data['is_business']:
-            <p class="spanish centered">
+            <p class="normal-text centered">
                 TODOS LOS CAMPOS HAN DE SER CUMPLIMENTADOS OBLIGATORIAMENTE.
                 UNA VEZ FIRMADA ESTA ORDEN DE DOMICILIACIÓN DEBE SER ENVIADA AL ACREEDOR PARA SU CUSTODIA.
                 LA ENTIDAD DE DEUDOR REQUIERE AUTORIZACIÓN DE ÉSTE PREVIA AL CARGO EN CUENTA DE LOS ADEUDOS DIRECTOS B2B.
                 EL DEUDOR PODRÁ GESTIONAR DICHA AUTORIZACIÓN CON LOS MEDIOS QUE SU ENTIDAD PONGA A SU DISPOSICIÓN.
                 <br>
             </p>
-            <p class="english centered">ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE. NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION
-                BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT. THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.</p>
         %else:
-            <p class="spanish centered">
+            <p class="normal-text centered">
                 TODOS LOS CAMPOS HAN DE SER CUMPLIMENTADOS OBLIGATORIAMENTE.
                 UNA VEZ FIRMADA ESTA ORDEN DE DOMICILIACIÓN DEBE SER ENVIADA AL ACREEDOR PARA SU CUSTODIA.
                 <br>
             </p>
-            <p class="english centered">ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.</p>
         %endif
     </div>
 </div>

--- a/som_polissa/tests/test_report_sepa.py
+++ b/som_polissa/tests/test_report_sepa.py
@@ -126,5 +126,4 @@ class TestSepaTemplate(unittest.TestCase):
         self.assertIn(u"operacions entre empreses i/o autònoms", result)
         self.assertIn(u"Orden de domiciliación de adeudo directo SEPA", result)
         self.assertIn(u"operaciones exclusivamente entre empresas", result)
-        self.assertIn(u"SEPA Direct Debit Mandate", result)
         self.assertEqual(result.count(u"mandate-page"), 3)


### PR DESCRIPTION
## Objectiu
Arreglar cosetes del informe de SEPA. Treure l'angles, i potser arreglar algun copy més (per confirmar)

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8201554?folder_id=87

## Comprovacions

- [ ] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR removes English copy from the Catalan and Spanish SEPA mandate reports and adjusts styling for the remaining localized text.
- Removes bilingual headings, labels, explanatory paragraphs, and payment text.
- Renames language-oriented CSS classes to typography-oriented names and adds title spacing.
- Updates the report test to stop expecting the removed English heading.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; both previously reported issues are fixed in the current code.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa/report/sepa.css | Renames language-specific typography classes and adds spacing beneath the localized report heading. |
| som_polissa/report/sepa_ca.mako | Removes English copy from the Catalan SEPA template and fixes the previously malformed payment-label spans. |
| som_polissa/report/sepa_es.mako | Removes English copy from the Spanish SEPA template while retaining localized BIC and IBAN guidance. |
| som_polissa/tests/test_report_sepa.py | Removes the obsolete English-heading assertion while preserving localized content and page-count checks. |

</details>

<sub>Reviews (2): Last reviewed commit: ["🩹 Fix CSS"](https://github.com/som-energia/openerp_som_addons/commit/1c7364631d825cc5d0cc166b35f070c174359fa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51772325)</sub>

<!-- /greptile_comment -->