### PR TITLE
🐛 (leads) Arreglar reintents

### DIFF
--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -72,6 +72,7 @@ class GiscedataCrmLead(osv.OsvInherits):
         signature_o.send_poweremail(
             cursor, uid, [sign_id], context=context
         )
+        cursor.commit()
         search_params = [
             ("reference", "=", "giscedata.signatura.process,{}".format(sign_id)),
             ("template_id", "=", template_id),

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -453,7 +453,7 @@ class SomLeadWww(osv.osv_memory):
         sign_process_obj = self.pool.get("giscedata.signatura.process")
         logger = logging.getLogger("openerp.{0}.activate_lead.signature_mail".format(__name__))
 
-        attempts = 5
+        attempts = context.get("attempts") or 5
         wait_seconds = 10
 
         db = pooler.get_db(cr.dbname)
@@ -519,7 +519,7 @@ class SomLeadWww(osv.osv_memory):
             query = """SELECT l.id from giscedata_crm_lead as l
                        LEFT JOIN crm_case as c on c.id = l.crm_id
                        where c.state in ('open', 'pending')
-                       and l.create_date >= now() - INTERVAL '3 days'
+                       and l.create_date >= now() - INTERVAL '5 days'
                        order by id desc
                        FOR UPDATE skip locked
                        """
@@ -530,6 +530,7 @@ class SomLeadWww(osv.osv_memory):
             return False
         finally:
             tmp_cursor.close()
+        context["attempts"] = 1
         for lead_id in all_ids:
             self.activate_lead_async(cr, uid, lead_id, context=context)
 


### PR DESCRIPTION
## Objectiu
 Arreglar reintents

## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adjusts lead activation retries and signature-email transaction visibility.
- Commits generated signature-email state before locating and sending the outbox message.
- Lets signature polling attempts be configured through context and limits cron-triggered jobs to one attempt.
- Expands the cron retry window from three to five days.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The retry changes preserve repeated cron-based recovery for pending leads while reducing each queued job's polling duration, and the wider selection window covers more leads than the previous behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/models/giscedata_crm_lead.py | Adds an explicit commit between generating a signature email and searching for its outbox mailbox record; no actionable regression was established. |
| som_leads_polissa/www/som_lead_www.py | Makes signature polling attempts context-configurable, uses one poll per cron job, and broadens the retry selection window to five days. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Retry cron selects open or pending leads<br/>created within five days] --> B[Queue activate_lead_async<br/>with attempts = 1]
  B --> C[Read signature status]
  C -->|Completed| D[Create contract entities<br/>and send activation email]
  C -->|Error or unsent| E[Keep lead pending for review]
  C -->|Pending| F[Refresh signature process]
  F --> G[Wait ten seconds]
  G --> H[Mark lead pending]
  H --> A
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 (leads) Fix retries"](https://github.com/som-energia/openerp_som_addons/commit/5e21a1b580f9aee441220f9088bd3940c8d2953d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51802660)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->