### PR TITLE
Millorar botó e-mail de signatura instantani lead

### DIFF
--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -81,6 +81,11 @@ class GiscedataCrmLead(osv.OsvInherits):
         ]
         mail_ids = mail_o.search(cursor, uid, search_params, context=context)
         mail_o.send_this_mail(cursor, uid, mail_ids, context=context)
+
+        msg = u"S'ha enviat e-mail de Signatura manualment (en cas de dubte, mirar HelpScout)"
+
+        self.historize_msg(cursor, uid, [lead_id], msg, context=context)
+
         return True
 
     def contract_pdf(self, cursor, uid, ids, context=None):

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -79,12 +79,7 @@ class GiscedataCrmLead(osv.OsvInherits):
             ("template_id", "=", template_id),
             ("folder", "=", "outbox")
         ]
-        mail_ids = mail_o.search(cursor, uid, search_params, context=context)
-        mail_o.send_this_mail(cursor, uid, mail_ids, context=context)
-
-        msg = u"S'ha enviat e-mail de Signatura manualment (en cas de dubte, mirar HelpScout)"
-
-        self.historize_msg(cursor, uid, [lead_id], msg, context=context)
+        msg = u"S'ha sol·licitat l'enviament de l'e-mail de Signatura manualment (en cas de dubte, mirar HelpScout)"
 
         return True
 

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -79,7 +79,13 @@ class GiscedataCrmLead(osv.OsvInherits):
             ("template_id", "=", template_id),
             ("folder", "=", "outbox")
         ]
-        msg = u"S'ha sol·licitat l'enviament de l'e-mail de Signatura manualment (en cas de dubte, mirar HelpScout)"
+        mail_ids = mail_o.search(cursor, uid, search_params, context=context)
+        mail_o.send_this_mail(cursor, uid, mail_ids, context=context)
+
+        msg = u"S'ha sol·licitat l'enviament de l'e-mail de Signatura manualment" \
+            u"(en cas de dubte, mirar HelpScout)"
+
+        self.historize_msg(cursor, uid, [lead_id], msg, context=context)
 
         return True
 

--- a/som_leads_polissa/models/giscedata_crm_lead.py
+++ b/som_leads_polissa/models/giscedata_crm_lead.py
@@ -73,6 +73,7 @@ class GiscedataCrmLead(osv.OsvInherits):
             cursor, uid, [sign_id], context=context
         )
         cursor.commit()
+        sleep(2)
         search_params = [
             ("reference", "=", "giscedata.signatura.process,{}".format(sign_id)),
             ("template_id", "=", template_id),

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -565,7 +565,7 @@ class SomLeadWww(osv.osv_memory):
                 cr, uid, "som_leads_polissa", "webform_stage_error"
             )[1]
 
-            stage_id = lead_o.read(cr, uid, lead_id, ['stage_id'], context=context)["stage_id"]
+            stage_id = lead_o.read(cr, uid, lead_id, ['stage_id'], context=context)["stage_id"][0]
 
             if stage_id != signature_pending_review_stage_id:
                 logger.warning("Webform stage error (lead_id=%s)", lead_id)

--- a/som_leads_polissa/www/som_lead_www.py
+++ b/som_leads_polissa/www/som_lead_www.py
@@ -449,9 +449,7 @@ class SomLeadWww(osv.osv_memory):
             context = {}
 
         lead_o = self.pool.get("giscedata.crm.lead")
-        ir_model_o = self.pool.get("ir.model.data")
         sign_process_obj = self.pool.get("giscedata.signatura.process")
-        logger = logging.getLogger("openerp.{0}.activate_lead.signature_mail".format(__name__))
 
         attempts = context.get("attempts") or 5
         wait_seconds = 10
@@ -481,23 +479,6 @@ class SomLeadWww(osv.osv_memory):
             tmp_cursor.close()
             time.sleep(wait_seconds)
 
-        logger.warning(
-            "Signature still pending, activation e-mail not sent yet (lead_id=%s)", lead_id
-        )
-        signature_pending_review_stage_id = ir_model_o.get_object_reference(
-            cr, uid, "som_leads_polissa", "webform_stage_signature_pending_review"
-        )[1]
-        lead_o.write(
-            cr, uid, lead_id,
-            {'stage_id': signature_pending_review_stage_id, 'state': 'pending'},
-            context=context
-        )
-        lead_o.historize_msg(
-            cr, uid, [lead_id],
-            u"SIGNATURE_PENDING: activation e-mail not sent yet",
-            context=context
-        )
-        cr.commit()
         return False
 
     def activate_lead(self, cr, uid, lead_id, context=None):
@@ -580,20 +561,24 @@ class SomLeadWww(osv.osv_memory):
 
             return True
         else:
-            logger.warning("Webform stage error (lead_id=%s)", lead_id)
-
             signature_pending_review_stage_id = ir_model_o.get_object_reference(
                 cr, uid, "som_leads_polissa", "webform_stage_error"
             )[1]
-            lead_o.write(
-                cr, uid, lead_id,
-                {'stage_id': signature_pending_review_stage_id, 'state': 'pending'},
-                context=context
-            )
-            msg = u"ERROR: No s'ha pogut activar aquest lead." \
-                u"És probable que la signatura o el pagament no estiguin completats."
 
-            lead_o.historize_msg(cr, uid, [lead_id], msg, context=context)
+            stage_id = lead_o.read(cr, uid, lead_id, ['stage_id'], context=context)["stage_id"]
+
+            if stage_id != signature_pending_review_stage_id:
+                logger.warning("Webform stage error (lead_id=%s)", lead_id)
+
+                lead_o.write(
+                    cr, uid, lead_id,
+                    {'stage_id': signature_pending_review_stage_id, 'state': 'pending'},
+                    context=context
+                )
+                msg = u"ERROR: No s'ha pogut activar aquest lead." \
+                    u"És probable que la signatura o el pagament no estiguin completats."
+
+                lead_o.historize_msg(cr, uid, [lead_id], msg, context=context)
             return False
 
     @job(queue="poweremail_sender")


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència
https://somenergia.openproject.com/projects/som-energia/work_packages/1755/activity

## Comportament antic
El botó no era instantani, els registres al lead no eren molt útils

## Comportament nou
Registres útils, queda marcat quan s'envia el correu, el botó és instantani

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes manual signature-email handling to rely on queued delivery and prevents duplicate activation-error history entries.
- Rewords the intended signature-email history marker as an email-send request.
- Compares the activation-error stage by ID before writing or historizing it again.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because manual signature-email requests are no longer recorded in the lead history.

The revised audit message is assigned but never passed to historize_msg, so every successful manual button action returns without leaving the requested operational marker.

**Files Needing Attention:** som_leads_polissa/models/giscedata_crm_lead.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/models/giscedata_crm_lead.py | The queued signature-email path no longer persists the revised request marker, leaving the intended audit behavior incomplete. |
| som_leads_polissa/www/som_lead_www.py | The many2one stage ID is extracted before comparison, preventing duplicate error history on retries. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Update som\_leads\_polissa/models/giscedat..."](https://github.com/som-energia/openerp_som_addons/commit/2f343eb5c244c8ff7b2b0cba0e5f810d0431c1cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52151029)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->