### PR TITLE
Fix qr comparador contract summary

### DIFF
--- a/som_polissa_condicions_generals/models/report_backend_contract_summary.py
+++ b/som_polissa_condicions_generals/models/report_backend_contract_summary.py
@@ -207,22 +207,6 @@ class ReportBackendContractSummary(ReportBackendCondicionsParticulars):
             "show_legal_text": has_autoconsum,
         }
 
-    def get_cnmc_data(self, cursor, uid, pol, context=None):
-        report_v2_obj = self.pool.get("giscedata.facturacio.factura.report.v2")
-        link_qr = "https://comparador.cnmc.gob.es/"
-        qr_image = False
-        if report_v2_obj and hasattr(report_v2_obj, "_get_qr_comparador_cnmc"):
-            try:
-                link_qr, qr_image = report_v2_obj._get_qr_comparador_cnmc({})
-            except Exception:
-                qr_image = False
-
-        return {
-            "is_visible": True,
-            "link_qr": link_qr,
-            "qr_image": qr_image,
-        }
-
     @report_browsify
     def get_data(self, cursor, uid, pol, context=None):
         context = self._get_summary_context(context)
@@ -240,7 +224,6 @@ class ReportBackendContractSummary(ReportBackendCondicionsParticulars):
             "discounts": self.get_discount_data(cursor, uid, pol, context=context),
             "features": features,
             "self_consumption": self_consumption,
-            "cnmc": self.get_cnmc_data(cursor, uid, pol, context=context),
             "bono_social_estimate": "",
             "gurb": features["gurb"],
         }

--- a/som_polissa_condicions_generals/report/components/summary_claims_cnmc.mako
+++ b/som_polissa_condicions_generals/report/components/summary_claims_cnmc.mako
@@ -1,4 +1,4 @@
-<%def name="summary_claims_cnmc(cnmc, is_indexed)">
+<%def name="summary_claims_cnmc(is_indexed)">
 <%
     first_number = 10 if is_indexed else 9
     second_number = 11 if is_indexed else 10
@@ -16,22 +16,16 @@
 <div class="summary-box">
     <h3>${_(u"{}. Accés al comparador d'ofertes de la CNMC").format(second_number)}</h3>
     <div class="summary-content">
-        % if cnmc.get('is_visible'):
-            <table class="summary-cnmc-table">
-                <tr>
-                    <td class="summary-cnmc-text">
-                        <p class="section-text">${_(u"Amb aquest enllaç")} <a href="${cnmc.get('link_qr')}">comparador.cnmc.gob.es</a> ${_(u"pots consultar i comparar les diferents ofertes vigents de les comercialitzadores d'electricitat del mercat lliure.")}</p>
-                    </td>
-                    <td class="summary-cnmc-qr">
-                        % if cnmc.get('qr_image'):
-                            <img class="summary-cnmc-qr-image" src="${'data:image/png;base64, {}'.format(cnmc.get('qr_image'))}">
-                        % else:
-                            <img class="summary-cnmc-qr-image" src="${addons_path}/giscedata_facturacio_comer_som/report/components/cnmc_comparator_qr_link/generic_qr_comparator.png">
-                        % endif
-                    </td>
-                </tr>
-            </table>
-        % endif
+        <table class="summary-cnmc-table">
+            <tr>
+                <td class="summary-cnmc-text">
+                    <p class="section-text">${_(u"Amb aquest enllaç")} <a href="https://comparador.cnmc.gob.es/">comparador.cnmc.gob.es</a> ${_(u"pots consultar i comparar les diferents ofertes vigents de les comercialitzadores d'electricitat del mercat lliure.")}</p>
+                </td>
+                <td class="summary-cnmc-qr">
+                    <img class="summary-cnmc-qr-image" src="${addons_path}/som_polissa_condicions_generals/report/assets/generic_qr_comparator.png">
+                </td>
+            </tr>
+        </table>
     </div>
 </div>
 </%def>

--- a/som_polissa_condicions_generals/report/contract_summary_puppeteer.mako
+++ b/som_polissa_condicions_generals/report/contract_summary_puppeteer.mako
@@ -37,7 +37,7 @@
                 ${summary_payment(informe['payment'])}
                 ${summary_discounts(informe['discounts'])}
                 ${summary_legal(informe['features'], informe['bono_social_estimate'], is_indexed, informe['holder']['lang'])}
-                ${summary_claims_cnmc(informe['cnmc'], is_indexed)}
+                ${summary_claims_cnmc(is_indexed)}
             </div>
         %endfor
     </body>

--- a/som_polissa_condicions_generals/tests/tests_report_backend_contract_summary.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_contract_summary.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals, division
 
 from datetime import datetime
 import os
-import mock
 import unittest
 
 from destral import testing
@@ -143,37 +142,6 @@ class TestReportBackendContractSummary(testing.OOTestCase):
         })
 
         self.assertNotEqual(result["tarifa_mostrar"], "Tarifa Períodes Empresa")
-
-    def test_get_cnmc_data_returns_generic_contract_summary_data(self):
-        pol = self.pol_obj.browse(self.cursor, self.uid, self.contract_20td_id)
-        report_v2_obj = self.openerp.pool.get("giscedata.facturacio.factura.report.v2")
-
-        with mock.patch.object(
-            report_v2_obj,
-            "_get_qr_comparador_cnmc",
-            side_effect=AssertionError("invoice report helper must not be used"),
-        ) as qr_helper:
-            result = self.backend_obj.get_cnmc_data(self.cursor, self.uid, pol, context={})
-
-        self.assertFalse(qr_helper.called)
-        self.assertEqual(result, {
-            "is_visible": True,
-            "lang": "es_es",
-            "link_qr": "https://comparador.cnmc.gob.es/",
-            "has_gkwh": False,
-        })
-
-    def test_get_cnmc_data_keeps_language_and_generation_flags(self):
-        pol = self.pol_obj.browse(self.cursor, self.uid, self.contract_20td_id)
-        self.pol_obj.write(self.cursor, self.uid, [pol.id], {"te_assignacio_gkwh": True})
-
-        pol = self.pol_obj.browse(self.cursor, self.uid, self.contract_20td_id)
-        result = self.backend_obj.get_cnmc_data(
-            self.cursor, self.uid, pol, context={"lang": "ca_ES"}
-        )
-
-        self.assertEqual(result["lang"], "ca_es")
-        self.assertTrue(result["has_gkwh"])
 
 
 class TestSummaryClaimsCnmcTemplate(unittest.TestCase):

--- a/som_polissa_condicions_generals/tests/tests_report_backend_contract_summary.py
+++ b/som_polissa_condicions_generals/tests/tests_report_backend_contract_summary.py
@@ -2,8 +2,6 @@
 from __future__ import absolute_import, unicode_literals, division
 
 from datetime import datetime
-import os
-import unittest
 
 from destral import testing
 from destral.transaction import Transaction
@@ -142,21 +140,3 @@ class TestReportBackendContractSummary(testing.OOTestCase):
         })
 
         self.assertNotEqual(result["tarifa_mostrar"], "Tarifa Períodes Empresa")
-
-
-class TestSummaryClaimsCnmcTemplate(unittest.TestCase):
-    def test_summary_claims_cnmc_does_not_include_invoice_component(self):
-        template_path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "report",
-            "components",
-            "summary_claims_cnmc.mako",
-        )
-        with open(template_path, "r") as template_file:
-            template = template_file.read()
-
-        self.assertFalse(
-            "/giscedata_facturacio_comer_som/report/components/"
-            "cnmc_comparator_qr_link/cnmc_comparator_qr_link.mako" in template
-        )


### PR DESCRIPTION
## Objectiu
Arreglar el QR del contract summary, aprofitant per netejar tota una serie de codi i testos que crec que son totalment innecessaris...

Com a TODO futur, podriem fins i tot integrar-ho amb el mako "openerp_som_addons/som_polissa_condicions_generals/report/components/cnmc_comparator_qr_link.mako" i no repetir codi

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8203262?folder_id=87

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes the contract-summary CNMC QR by replacing the removed backend data path with a fixed official comparator link and a module-local static image.
- Removes the unused CNMC data method and result key from the report backend.
- Inlines the CNMC comparator markup in the contract-summary component.
- Updates the parent template call and removes obsolete CNMC tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking formatting violation in the inlined CNMC markup is corrected.

The backend, template signature, and static asset reference remain internally consistent; the only accepted concern is that two newly added Mako lines violate the repository's line-length requirement.

**Files Needing Attention:** som_polissa_condicions_generals/report/components/summary_claims_cnmc.mako
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa_condicions_generals/models/report_backend_contract_summary.py | Removes the CNMC helper and data key after the sole report-template consumer is updated. |
| som_polissa_condicions_generals/report/components/summary_claims_cnmc.mako | Inlines the fixed CNMC link and local QR asset correctly, but adds two lines exceeding the repository's 100-character limit. |
| som_polissa_condicions_generals/report/contract_summary_puppeteer.mako | Updates the component invocation to match its simplified signature. |
| som_polissa_condicions_generals/tests/tests_report_backend_contract_summary.py | Removes tests for deleted CNMC backend behavior and an obsolete structural import assertion. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Contract summary backend] --> B[Contract summary Mako template]
  B --> C[CNMC claims component]
  C --> D[Official comparator hyperlink]
  C --> E[Module-local generic QR image]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove more useless tests"](https://github.com/som-energia/openerp_som_addons/commit/b9a914ac0a07a923c8cc21dcdf9be8921cec530b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52876174)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - docs/adr/0001-define-code-style.md ([source](https://github.com/som-energia/openerp_som_addons/blob/main/docs/adr/0001-define-code-style.md))
- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->