### PR TITLE
🩹 (mandate) Agafar idioma correcte si el mandat ve del lead

### DIFF
--- a/som_polissa/report/report_sepa.py
+++ b/som_polissa/report/report_sepa.py
@@ -90,6 +90,10 @@ class ReportBackendMandatSepa(ReportBackend):
     _source_model = "payment.mandate"
 
     def get_lang(self, cursor, uid, record_id, context=None):
+        if context is None:
+            context = {}
+        if context.get("lang"):
+            return context["lang"]
         mandate_backend = self.pool.get("report.backend.mandat")
         return mandate_backend.get_lang(
             cursor, uid, record_id, context=context


### PR DESCRIPTION
## Objectiu
Agafar idioma correcte si el mandat ve del lead

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8198372?folder_id=307

## Comportament antic
Sempre era Espanyol...

## Comportament nou
Ara surt Català si s'escau

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes SEPA mandate language resolution to prefer a language explicitly supplied in the report context before falling back to the mandate backend.
- Initializes an absent report context.
- Uses a truthy `context["lang"]` as the language override.
- Preserves the existing mandate-derived fallback.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete blocking or independently actionable issue was established.

The changed code preserves the existing mandate-language lookup as a fallback and no reachable caller was found that demonstrates the new explicit context override selecting an incorrect language.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_polissa/report/report_sepa.py | Adds context-based language precedence for SEPA mandate rendering; no publishable defect was established from reachable callers. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🩹 (mandate) Get correct lang if mandate..."](https://github.com/som-energia/openerp_som_addons/commit/77d41436ea9dc12aa5b38eb597e4d63a146e36f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53359348)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->