### PR TITLE
🩹 (leads) Crear Lead Manual crea ATR en Esborrany

### DIFF
--- a/som_leads_polissa/wizard/wizard_crm_lead_create_entities_view.xml
+++ b/som_leads_polissa/wizard/wizard_crm_lead_create_entities_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="giscedata_crm_leads.view_crm_lead_create_entities_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_activation_lead_entity']" position="attributes">
-                    <attribute name="context">{'som_from_activation_lead' : True}</attribute>
+                    <attribute name="context">{'som_from_activation_lead' : True, 'create_draft_atr': True}</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
## Objectiu
Crear Lead Manual crea ATR en Esborrany

## Targeta on es demana o Incidència
https://freescout.somenergia.coop/conversation/8197195?folder_id=307

## Comportament antic
Es crea un ATR com actiu i pot tenir problemes per a contractes que no pot revisar que envia a la distri, no passa gaire.

## Comportament nou
Ara es creen amb draft i fan el fluxe normal!

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/openerp_som_addons/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns manual lead conversion with the existing automatic lead flow by creating the resulting ATR switching case in draft rather than open.

- Adds `create_draft_atr` to the manual entity-creation button context.
- Preserves the existing `som_from_activation_lead` context flag.
- The shared wizard propagates this context to the contract’s ATR creation method, where the new flag sets the case state to `draft`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the manual wizard propagates the new flag to the existing draft-ATR handling and no broken workflow was identified.

The base button defines no context that could be overwritten, the wizard preserves the added context throughout entity creation, and the resulting draft state matches the behavior already used and tested by automatic lead activation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_leads_polissa/wizard/wizard_crm_lead_create_entities_view.xml | Adds the established draft-ATR context flag to manual lead conversion without removing any base-button context or exposing a concrete workflow regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🩹 (leads) Manual CreateEntities --&gt; Dra..."](https://github.com/som-energia/openerp_som_addons/commit/3565fa41ab4ce98b82e6ba8a0cf7fb11d7d31b0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53361937)</sub>

**Context used:**

- Knowledge Base — [Polissa Contracts (giscedata.polissa extensions)](https://app.greptile.com/som-energia/-/custom-context/knowledge-base/som-energia/openerp_som_addons/-/docs/polissa-contracts.md)

<!-- /greptile_comment -->